### PR TITLE
Change TOC depth to 1 for GBD 2017 causes

### DIFF
--- a/docs/source/models/gbd2017/causes/index.rst
+++ b/docs/source/models/gbd2017/causes/index.rst
@@ -5,7 +5,7 @@ Cause Models
 ============
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :glob:
 
    *


### PR DESCRIPTION
The table of contents was looking very cluttered because it was showing all the section headings; this changes it to only show the title of each cause model document.