### PR TITLE
clarify that gbd point prevalence represents year midpoint

### DIFF
--- a/docs/source/models/cause.rst
+++ b/docs/source/models/cause.rst
@@ -289,20 +289,11 @@ scenarios:
 	simulant is *born* into a simulation. See the below section on birth 
 	prevalence for how cause model states are initialized in this scenario.
 
-While GBD results are estimates of *point* prevalence at the year midpoint, 
-cause model initialization occurs continuously throughtout a full simulation 
-year. The following are two possible assumptions on how the GBD point 
-prevalence estimate might apply across the full simulation year that it 
-represents.
-
-- Point prevalence estimate is constant across the full year. This is likely 
-  appropriate in cases where prevalence is relatively constant over time. 
-
-- Prevalence estimates across several years follow a smooth line between 
-  annual midpoint point prevalence estimates. This approach would require 
-  fitting a curve across existing point prevalence estimates and may be 
-  appropriate when prevalence of a given condition is steeply increasing or 
-  decreasing over time.
+GBD results of cause prevalence are estimates of *point* prevalence at the year 
+midpoint. Notably, Vivarium assumes that the prevalence of a given cause is 
+*constant* across the entire year that it represents. This is likely an
+appropriate assumption in cases where prevalence is relatively constant over
+time and over age groups, although it may be limited in cases where it is not. 
 
 Birth Prevalence
 ^^^^^^^^^^^^^^^^

--- a/docs/source/models/cause.rst
+++ b/docs/source/models/cause.rst
@@ -152,16 +152,6 @@ generalization thereof]]
 Data Sources for Cause Models
 -----------------------------
 
-.. todo::
-
-   #. Update mortality-related data sources within existing format (yaqi).
-   #. Describe the relationship that duration and transition rates can play
-      when there are multiple ways out of a state (LTBI)
-   #. Update transition rate section to reflect feedback
-   #. Include formulas discussed in office hours for incidence/hazards and
-      then link out to survey. analysis page
-   #. Change remission example to diarrheal disease
-
 Once a cause model structure is specified, data is needed to inform its states
 and transitions. For our purposes, cause models generally have the following
 data needs:
@@ -270,17 +260,14 @@ Prevalence
 ^^^^^^^^^^
 
 Prevalence is defined as the **proportion of a given population that possesses
-a given condition or trait** at a given time-point.
+a specific condition or trait** at a given time-point.
 
   For example, the prevalence of diabetes mellitus in the United States was
   approximately 6.5% in 2017.
 
-When a *time-frame* (such as 2016, i.e. 1/1/16 to 12/31/16) instead of a
-*time-point* (such as 1/1/16) is reported, it is commonly assumed that the
-reported prevalence represents the prevalence of the *midpoint* of
-that time-frame (7/1/16 is the midpoint for the time frame of all of 2016).
-However, this may not always be the case and it should be considered when
-relevant.
+	Notably, GBD prevalence estimates for a given year (e.g. 2017) are meant 
+	to represent the point prevalence at the *midpoint* of that year (e.g. 
+	7/1/17).
 
 Prevalence data can be used to **initialize cause model states** and
 represents the **probability that a simulant will begin the simulation in a
@@ -298,9 +285,24 @@ scenarios:
   location
 - A simulant enters the simulation by *aging* into the simulation
 
-Prevalence is **not** used to initialize cause model states when a simulant 
-is *born* into a simulation. See the below section on birth prevalence for 
-how cause model states are initialized in this scenario.
+	Prevalence is **not** used to initialize cause model states when a 
+	simulant is *born* into a simulation. See the below section on birth 
+	prevalence for how cause model states are initialized in this scenario.
+
+While GBD results are estimates of *point* prevalence at the year midpoint, 
+cause model initialization occurs continuously throughtout a full simulation 
+year. The following are two possible assumptions on how the GBD point 
+prevalence estimate might apply across the full simulation year that it 
+represents.
+
+- Point prevalence estimate is constant across the full year. This is likely 
+  appropriate in cases where prevalence is relatively constant over time. 
+
+- Prevalence estimates across several years follow a smooth line between 
+  annual midpoint point prevalence estimates. This approach would require 
+  fitting a curve across existing point prevalence estimates and may be 
+  appropriate when prevalence of a given condition is steeply increasing or 
+  decreasing over time.
 
 Birth Prevalence
 ^^^^^^^^^^^^^^^^
@@ -317,7 +319,6 @@ the simulation will be born into a given neonatal cause model state.**
 
   For example, the probability that a simulant born during a simulation of
   cleft lip in the United States in 2006 is 0.00106, or 0.106%.
-
 
 Cause Model Transitions
 +++++++++++++++++++++++


### PR DESCRIPTION
This PR is to update the existing description of prevalence as a data source for cause model initialization to clarify that GBD prevalence estimates are estimates of point prevalence at the midpoint of a given year and to discuss assumptions about how we use this point prevalence estimate across full simulation year(s). 

Let me know if you have any feedback! Thanks