### PR TITLE
Add stubs for causes in LSFF model

### DIFF
--- a/docs/source/models/gbd2017/causes/index.rst
+++ b/docs/source/models/gbd2017/causes/index.rst
@@ -9,3 +9,4 @@ Cause Models
    :glob:
 
    *
+   */index

--- a/docs/source/models/gbd2017/causes/neonatal_encephalopathy/index.rst
+++ b/docs/source/models/gbd2017/causes/neonatal_encephalopathy/index.rst
@@ -1,0 +1,8 @@
+.. _2017_cause_neonatal_encephalopathy:
+
+==============================================================
+Neonatal encephalopathy due to birth asphyxia and birth trauma
+==============================================================
+
+.. todo::
+   Describe cause model

--- a/docs/source/models/gbd2017/causes/neonatal_jaundice/index.rst
+++ b/docs/source/models/gbd2017/causes/neonatal_jaundice/index.rst
@@ -1,0 +1,8 @@
+.. _2017_cause_neonatal_jaundice:
+
+==============================================
+Haemolytic disease and other neonatal jaundice
+==============================================
+
+.. todo::
+   Describe cause model

--- a/docs/source/models/gbd2017/causes/neonatal_other/index.rst
+++ b/docs/source/models/gbd2017/causes/neonatal_other/index.rst
@@ -1,0 +1,38 @@
+.. _2017_cause_neonatal_other:
+
+========================
+Other neonatal disorders
+========================
+
+Modeling other neonatal disorders in GBD 2017
+---------------------------------------------
+
+Beginning of CoD Appendix
++++++++++++++++++++++++++
+
+Mortality for five causes are modeled within “neonatal disorders”: preterm birth
+complications, neonatal encephalopathy and birth trauma, neonatal sepsis and
+other infections, hemolytic disease and neonatal jaundice, and other neonatal
+disorders. An overall neonatal disorders “parent” envelope is also estimated, to
+which all neonatal causes are squeezed.
+
+Complete content of YLD Appendix
+++++++++++++++++++++++++++++++++
+
+In addition to the neonatal disorders described above, there are many diverse
+types of neonatal disorders with a range of severities and associated sequelae.
+Because these other neonatal disorders are diverse in their underlying causes
+and risk factors as well as in their associated health outcomes, modelling them
+together in a DisMod-MR model would not produce reliable estimates of prevalence
+or excess mortality. Instead, we calculated the YLDs caused by other neonatal
+disorders directly using a YLD/YLL ratio.
+
+We calculated the ratio of YLDs to YLLs across the specified neonatal disorders
+for which non-fatal outcomes were modelled, using YLL estimates from the GBD
+2017 cause of death (CoD) analysis. We then multiplied this YLD/YLL ratio by the
+YLL estimates for other chronic respiratory diseases from the GBD 2017 CoD
+analysis, providing us with an estimate of the YLDs associated with other
+neonatal disorders.
+
+.. todo::
+   Describe cause model

--- a/docs/source/models/gbd2017/causes/neonatal_other/index.rst
+++ b/docs/source/models/gbd2017/causes/neonatal_other/index.rst
@@ -1,14 +1,14 @@
 .. _2017_cause_neonatal_other:
 
 ========================
-Other neonatal disorders
+Other Neonatal Disorders
 ========================
 
-Modeling other neonatal disorders in GBD 2017
+Modeling Other Neonatal Disorders in GBD 2017
 ---------------------------------------------
 
-Beginning of CoD Appendix
-+++++++++++++++++++++++++
+Beginning of "Neonatal Disorders" in CoD Appendix
++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Mortality for five causes are modeled within “neonatal disorders”: preterm birth
 complications, neonatal encephalopathy and birth trauma, neonatal sepsis and
@@ -16,8 +16,8 @@ other infections, hemolytic disease and neonatal jaundice, and other neonatal
 disorders. An overall neonatal disorders “parent” envelope is also estimated, to
 which all neonatal causes are squeezed.
 
-Complete content of YLD Appendix
-++++++++++++++++++++++++++++++++
+Complete content of "Other neonatal disorders" in YLD Appendix
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 In addition to the neonatal disorders described above, there are many diverse
 types of neonatal disorders with a range of severities and associated sequelae.

--- a/docs/source/models/gbd2017/causes/neonatal_sepsis/index.rst
+++ b/docs/source/models/gbd2017/causes/neonatal_sepsis/index.rst
@@ -1,0 +1,8 @@
+.. _2017_cause_neonatal_sepsis:
+
+=============================================
+Neonatal sepsis and other neonatal infections
+=============================================
+
+.. todo::
+   Describe cause model

--- a/docs/source/models/gbd2017/concept_models/vivarium_conic_lsff/concept_model.rst
+++ b/docs/source/models/gbd2017/concept_models/vivarium_conic_lsff/concept_model.rst
@@ -43,20 +43,20 @@ GBD Causes
 :ref:`Neural Tube Defects <2017_cause_neural_tube_defects>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Lower Respiratory Infections
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Lower Respiratory Infections <2017_cause_lower_respiratory_infections>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Neonatal encephalopathy* due to birth asphyxia and birth trauma
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Neonatal Encephalopathy <2017_cause_neonatal_encephalopathy>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Neonatal sepsis* and other neonatal infections
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Neonatal Sepsis <2017_cause_neonatal_sepsis>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Haemolytic disease and other *neonatal jaundice*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Neonatal Jaundice <2017_cause_neonatal_jaundice>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Other neonatal* disorders
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Other neonatal disorders <2017_cause_neonatal_other>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PAF-of-1 Cause/Risk Pairs
 +++++++++++++++++++++++++
@@ -73,8 +73,8 @@ Additional GBD Risks
 Low Birth Weight and Short Gestation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Risk-Cause Relationships
-++++++++++++++++++++++++
+Risk-Outcome Relationships
+++++++++++++++++++++++++++
 
 Coverage Gap Framework
 ++++++++++++++++++++++

--- a/docs/source/models/gbd2017/concept_models/vivarium_conic_lsff/concept_model.rst
+++ b/docs/source/models/gbd2017/concept_models/vivarium_conic_lsff/concept_model.rst
@@ -55,17 +55,17 @@ GBD Causes
 :ref:`Neonatal Jaundice <2017_cause_neonatal_jaundice>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:ref:`Other neonatal disorders <2017_cause_neonatal_other>`
+:ref:`Other Neonatal Disorders <2017_cause_neonatal_other>`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PAF-of-1 Cause/Risk Pairs
 +++++++++++++++++++++++++
 
-Vitamin A Deficiency / Vitamin A Deficiency
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Vitamin A Deficiency / Vitamin A Deficiency <2017_cause_vitamin_a_deficiency>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Dietary Iron Deficiency / Iron Deficiency
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+:ref:`Dietary Iron Deficiency / Iron Deficiency <2017_cause_iron_deficiency>`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Additional GBD Risks
 ++++++++++++++++++++

--- a/docs/source/models/gbd2017/risk_attributable_causes/index.rst
+++ b/docs/source/models/gbd2017/risk_attributable_causes/index.rst
@@ -1,0 +1,12 @@
+.. _2017_risk_attributable_cause_models:
+
+==============================
+Risk-Attributable Cause Models
+==============================
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   *
+   */index

--- a/docs/source/models/gbd2017/risk_attributable_causes/iron_deficiency/index.rst
+++ b/docs/source/models/gbd2017/risk_attributable_causes/iron_deficiency/index.rst
@@ -1,0 +1,8 @@
+.. _2017_cause_iron_deficiency:
+
+================================================
+Dietary Iron Deficiency (Iron Deficiency Anemia)
+================================================
+
+.. todo::
+   Describe PAF-of-1 cause model

--- a/docs/source/models/gbd2017/risk_attributable_causes/vitamin_a_deficiency/index.rst
+++ b/docs/source/models/gbd2017/risk_attributable_causes/vitamin_a_deficiency/index.rst
@@ -1,0 +1,8 @@
+.. _2017_cause_vitamin_a_deficiency:
+
+====================
+Vitamin A Deficiency
+====================
+
+.. todo::
+   Describe PAF-of-1 cause model

--- a/docs/source/models/gbd2017/risk_effects/index.rst
+++ b/docs/source/models/gbd2017/risk_effects/index.rst
@@ -6,7 +6,7 @@ Risk Outcome Relationship Models
 
 .. todo::
 
-   Describe how to model interventions here.
+   Describe how to model risk outcome relationships here.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
I added stubs for the neonatal causes and the PAF-of-1 vitamin A and iron deficiency causes, and I fixed a copy/paste typo in the "Risk Outcome Relationship Models" stub. I started a new directory structure where each cause goes in its own subfolder to keep the related files together, and I modified the appropriate index files accordingly.