### PR TITLE
Fix syntax in "Modeling Causes" and "Cause Models in GBD"

### DIFF
--- a/docs/source/models/cause.rst
+++ b/docs/source/models/cause.rst
@@ -151,16 +151,16 @@ generalization thereof]]
 Basic Cause Model Structures
 ----------------------------
 
-.. todo:: 
+.. todo::
 
 	Link to examples of cause model documents
 
-Common basic cause model structures are described in the following table and 
-dicussed in further detail below. Notably, cause models are almost always more 
-complicated than the basic structures discussed in this section. The following 
-basic structures should be considered as basic guiding concepts, and not as 
-templates that are appropriate for all (or even most) cause models. Examples 
-of more complicated cause model structures are discussed in the `Other Cause 
+Common basic cause model structures are described in the following table and
+dicussed in further detail below. Notably, cause models are almost always more
+complicated than the basic structures discussed in this section. The following
+basic structures should be considered as basic guiding concepts, and not as
+templates that are appropriate for all (or even most) cause models. Examples
+of more complicated cause model structures are discussed in the `Other Cause
 Model Structures`_ section afterward.
 
 .. list-table:: Basic Cause Model Structures
@@ -185,14 +185,14 @@ SI
 
 .. image:: SI.png
 
-In this cause model structure, simulants in the susceptible state can 
-transition to the infected state, where they will remain for the remainder of 
-the simulation. 
+In this cause model structure, simulants in the susceptible state can
+transition to the infected state, where they will remain for the remainder of
+the simulation.
 
-This cause model structure is appropriate for chronic conditions from which 
+This cause model structure is appropriate for chronic conditions from which
 individuals can never recover.
 
-Examples of conditions potentially appropriate for an SI cause model structure 
+Examples of conditions potentially appropriate for an SI cause model structure
 include Alzheimer’s disease and other dementias.
 
 SIS
@@ -200,15 +200,15 @@ SIS
 
 .. image:: SIS.png
 
-In this cause model structure, simulants in the susceptible state can 
-transition to the infected state and simulants in the infected state can 
+In this cause model structure, simulants in the susceptible state can
+transition to the infected state and simulants in the infected state can
 transition to the susceptible state. Notably, this cause model allows for
-simulants to enter the infected state more than once in a simulation. 
+simulants to enter the infected state more than once in a simulation.
 
-This cause model structure is appropriate for conditions for which individuals 
+This cause model structure is appropriate for conditions for which individuals
 can have multiple cases over their lifetimes.
 
-Examples of conditions potentially appropriate for an SIS cause model 
+Examples of conditions potentially appropriate for an SIS cause model
 structure include :ref:`diarrheal diseases <2017_cause_diarrhea>`.
 
 SIR
@@ -216,17 +216,17 @@ SIR
 
 .. image:: SIR.png
 
-In this cause model structure, simulants in the susceptible state can 
-transition to the infected state and simulants in the infected state can 
+In this cause model structure, simulants in the susceptible state can
+transition to the infected state and simulants in the infected state can
 transition to a recovered state where they will remain for the remainder
-of the simulation. Notably, the cause model allows individuals to become 
+of the simulation. Notably, the cause model allows individuals to become
 infected only once in a simulation.
 
-This cause model structure is appropriate for conditions for which individuals 
-can only have a single case, but do not stay in the with condition state 
+This cause model structure is appropriate for conditions for which individuals
+can only have a single case, but do not stay in the with condition state
 forever.
 
-An example of a condition potentially appropriate for an SIR cause model 
+An example of a condition potentially appropriate for an SIR cause model
 structure is :ref:`measles <2017_cause_measles>`.
 
 .. _`Other Cause Model Structures`:
@@ -234,8 +234,8 @@ structure is :ref:`measles <2017_cause_measles>`.
 Other Cause Model Structures
 ++++++++++++++++++++++++++++
 
-It is common that a particular cause may not fit well into one of the common 
-basic cause model structures discussed above. Examples of situations that may 
+It is common that a particular cause may not fit well into one of the common
+basic cause model structures discussed above. Examples of situations that may
 require custom cause model structures are listed below:
 
 - Cause models with severity splits
@@ -323,11 +323,11 @@ and discussed in more detail afterward.
      - Transition rates
      - Once scaled to simulation time-step, represents the probability a
        simulant will recover from the with-condition state.
-   * - `Duration`_
+   * - `Duration <Duration-Based Transitions_>`_
      - Length of time a condition lasts.
      - Transition rates
      - Amount of time a simulant remains in a given state
-   * - `Progression`_
+   * - `Progression <Progression Transitions_>`_
      -
      - Transition rates
      -
@@ -367,35 +367,35 @@ a specific condition or trait** at a given time-point.
   For example, the prevalence of diabetes mellitus in the United States was
   approximately 6.5% in 2017.
 
-	Notably, GBD prevalence estimates for a given year (e.g. 2017) are meant 
-	to represent the point prevalence at the *midpoint* of that year (e.g. 
+	Notably, GBD prevalence estimates for a given year (e.g. 2017) are meant
+	to represent the point prevalence at the *midpoint* of that year (e.g.
 	7/1/17).
 
 Prevalence data can be used to **initialize cause model states** and
 represents the **probability that a simulant will begin the simulation in a
 given state.**
 
-  For example, the probability that a simulant in a model of diabetes 
-  mellitus in the United States beginning in 2017 will begin the simulation 
-  with diabetes is 0.065, or 6.5%. 
+  For example, the probability that a simulant in a model of diabetes
+  mellitus in the United States beginning in 2017 will begin the simulation
+  with diabetes is 0.065, or 6.5%.
 
-Notably, prevalence is used to initialize cause model states in the following 
+Notably, prevalence is used to initialize cause model states in the following
 scenarios:
 
 - A simulant enters the simulation at the start of the simulation
-- A simulant enters the simulation due to immigration to the simulated 
+- A simulant enters the simulation due to immigration to the simulated
   location
 - A simulant enters the simulation by *aging* into the simulation
 
-	Prevalence is **not** used to initialize cause model states when a 
-	simulant is *born* into a simulation. See the below section on birth 
+	Prevalence is **not** used to initialize cause model states when a
+	simulant is *born* into a simulation. See the below section on birth
 	prevalence for how cause model states are initialized in this scenario.
 
-GBD results of cause prevalence are estimates of *point* prevalence at the year 
-midpoint. Notably, Vivarium assumes that the prevalence of a given cause is 
+GBD results of cause prevalence are estimates of *point* prevalence at the year
+midpoint. Notably, Vivarium assumes that the prevalence of a given cause is
 *constant* across the entire year that it represents. This is likely an
 appropriate assumption in cases where prevalence is relatively constant over
-time and over age groups, although it may be limited in cases where it is not. 
+time and over age groups, although it may be limited in cases where it is not.
 
 Birth Prevalence
 ^^^^^^^^^^^^^^^^
@@ -419,141 +419,141 @@ Cause Model Transitions
 .. todo::
 
 	Enhance blurb to beginning of cause model transition section about how we use probabilies to inform cause model transitions (to come in next commits)
-  
+
   Limitations/assumptions of incidence rates section
-	
+
   Detail remaining transition rate data sources (remission, duration, severity splits, deterministic)
 
-Vivarium uses probabilities to make decisions about how and when simulants 
-move between cause model states. 
+Vivarium uses probabilities to make decisions about how and when simulants
+move between cause model states.
 
 Incidence Rates
 ^^^^^^^^^^^^^^^
 
-Generally, incidence is a measure of new cases of a given condition that occur 
-in a specified timeframe and population. The count value of new cases of the 
-condition of interest will always be the numerator of incidence measures. The 
-denominator of incidence measures is somewhat more complex and is critical to 
-ensuring an accurate data source to inform cause model transition rates. 
+Generally, incidence is a measure of new cases of a given condition that occur
+in a specified timeframe and population. The count value of new cases of the
+condition of interest will always be the numerator of incidence measures. The
+denominator of incidence measures is somewhat more complex and is critical to
+ensuring an accurate data source to inform cause model transition rates.
 
-Two incidence measures relevant to cause model transition rate data sources 
-using GBD results are discussed in this section, including measures we refer 
-to as **incidence in the total population** (as estimated by the GBD study) 
-and **incidence in the susceptible** (or *at-risk*) **population.** These 
+Two incidence measures relevant to cause model transition rate data sources
+using GBD results are discussed in this section, including measures we refer
+to as **incidence in the total population** (as estimated by the GBD study)
+and **incidence in the susceptible** (or *at-risk*) **population.** These
 measures are defined using the following key concepts:
 
-  **Person-time:** person-time is a measure of the number of individuals 
-  multiplied by the amount of time they individually occupy the population 
-  of interest. Notably, the population of interest varies depending on context 
+  **Person-time:** person-time is a measure of the number of individuals
+  multiplied by the amount of time they individually occupy the population
+  of interest. Notably, the population of interest varies depending on context
   and can be defined by age group, sex, location, time, disease status, etc.
 
-    For example, if one individual is occupies the population of interest for 
-    two years, they contribute two person-years. If another individual is in 
+    For example, if one individual is occupies the population of interest for
+    two years, they contribute two person-years. If another individual is in
     our population of interest for 6 months, they contribute 0.5 person-years.
     Together, these two individuals contribute a total of 2.5 person-years.
 
-  **Susceptible or At-Risk Population:** the susceptible population, also 
+  **Susceptible or At-Risk Population:** the susceptible population, also
   referred to as the at-risk population, is defined as the population that *
-  does not* have the condition of interest; in other words, the susceptible 
-  population that is at risk of developing the condition. Notably, the number 
-  of individuals in this population will change over time as the following 
+  does not* have the condition of interest; in other words, the susceptible
+  population that is at risk of developing the condition. Notably, the number
+  of individuals in this population will change over time as the following
   events occur:
 
-     - Members of the at-risk population develop the condition and are no 
+     - Members of the at-risk population develop the condition and are no
        longer susceptible
-     - Members of the at-risk population die and are no longer susceptible 
-     - Individuals are born or age into the at-risk population and become 
+     - Members of the at-risk population die and are no longer susceptible
+     - Individuals are born or age into the at-risk population and become
        susceptible
      - Individuals age out of the at-risk population and are no longer susceptible
-     - Individuals with the condition recover from the condition and re-enter 
-       the at-risk population as susceptible (in the case of conditions with 
+     - Individuals with the condition recover from the condition and re-enter
+       the at-risk population as susceptible (in the case of conditions with
        remission)
 
-**Total Population Incidence Rate** is estimated by the Global Burden of 
-Disease Study by estimating the number of incident cases that occur in one 
+**Total Population Incidence Rate** is estimated by the Global Burden of
+Disease Study by estimating the number of incident cases that occur in one
 year and scaling this value per 100,000 individuals of a specified population.
 
 .. math::
 
   \frac{n_\text{incident cases}}{\text{person-time}_\text{total population}}
 
-Because the denominator of this measure is not specific to a particular cause 
-model state, it is **not** an appropriate data source for cause model 
-transition rates between states. 
+Because the denominator of this measure is not specific to a particular cause
+model state, it is **not** an appropriate data source for cause model
+transition rates between states.
 
-.. note:: 
+.. note::
 
-  GBD estimates of total population incidence rate require transformation 
-  prior to use as a cause model transition probability data source (see below 
+  GBD estimates of total population incidence rate require transformation
+  prior to use as a cause model transition probability data source (see below
   for more detail).
 
-**Susceptible/At-Risk Population Incidence Rate** as discussed here is also 
-referred to as incidence density rate, person-time incidence rate, and in some 
+**Susceptible/At-Risk Population Incidence Rate** as discussed here is also
+referred to as incidence density rate, person-time incidence rate, and in some
 cases may simply be referred to as the incidence rate. It is defined as:
 
 .. math::
 
   \frac{n_\text{incident cases}}{\text{person-time}_\text{susceptible population}}
 
-Because the denominator for the susceptible population incidence rate is 
-person-time in the at-risk population, this incidence rate can be used to 
-compute the probability of a new case of the condition occuring in an individual 
-without the condition in a given time frame. Therefore, it can be used to compute 
-the probability that a simulant will transition from a susceptible to infected 
+Because the denominator for the susceptible population incidence rate is
+person-time in the at-risk population, this incidence rate can be used to
+compute the probability of a new case of the condition occuring in an individual
+without the condition in a given time frame. Therefore, it can be used to compute
+the probability that a simulant will transition from a susceptible to infected
 cause model state in a given timestep.
 
-  For instance, consider an example in which the global susceptible population 
-  incidence rate of injuries in 2017 was 6,800 cases per 100,000 person-years, 
-  or 0.068 cases per person-year. In this example, 6,800 new injuries occurred 
+  For instance, consider an example in which the global susceptible population
+  incidence rate of injuries in 2017 was 6,800 cases per 100,000 person-years,
+  or 0.068 cases per person-year. In this example, 6,800 new injuries occurred
   among 100,000 person-years of observation among the non-injured population.
 
-  Now, consider a cause model with a susceptible (not injured) state and an 
-  infected (injured) state with a simulation timestep of 1 year. In this case, 
-  the probability that a simulant will transition from the susceptible to 
-  infected state within a single timestep (i.e. the transition probability) 
+  Now, consider a cause model with a susceptible (not injured) state and an
+  infected (injured) state with a simulation timestep of 1 year. In this case,
+  the probability that a simulant will transition from the susceptible to
+  infected state within a single timestep (i.e. the transition probability)
   would be represented as 0.068.
 
-  Notably, in order to represent the transition probability for a single 
-  simulant within a single timestep, the cumulative incidence value needs to 
-  be scaled so that the person-time denominator is equal to the simulation 
-  timestep. Therefore, if the timestep of the cause model considered above 
-  were six months instead of one year, the transition probability would be 
-  0.034 (0.034 cases per 0.5 person-years). 
+  Notably, in order to represent the transition probability for a single
+  simulant within a single timestep, the cumulative incidence value needs to
+  be scaled so that the person-time denominator is equal to the simulation
+  timestep. Therefore, if the timestep of the cause model considered above
+  were six months instead of one year, the transition probability would be
+  0.034 (0.034 cases per 0.5 person-years).
 
 .. note::
 
-  Because GBD estimates total population incidence rates, Vivarium 
-  automatically transforms GBD results into susceptible population incidence 
-  rates that can be used as an appropriate data source for cause model 
-  transition probabilities. 
+  Because GBD estimates total population incidence rates, Vivarium
+  automatically transforms GBD results into susceptible population incidence
+  rates that can be used as an appropriate data source for cause model
+  transition probabilities.
 
-  This transformation from total population incidence rate to an approximation 
-  of the susceptible population incidence rate is performed with the following 
+  This transformation from total population incidence rate to an approximation
+  of the susceptible population incidence rate is performed with the following
   calculation:
 
   .. math::
 
     \frac{\text{Total Population Incidence Rate}}{(1-\text{Condition Prevalence})}
 
-There are several key assumptions and limitations to the approach of using GBD 
-incidence rates as data sources for cause model transition rates, disscussed 
+There are several key assumptions and limitations to the approach of using GBD
+incidence rates as data sources for cause model transition rates, disscussed
 below.
 
 .. todo::
 
-    Add discussion of transformation of GBD estimates of total population to 
+    Add discussion of transformation of GBD estimates of total population to
     susceptible population incidence rates
 
-    Add discuission about assumption that transition probability is constant 
-    over time frame and link to hazard rates page for when this might be an 
-    issue. Include formulas about how we are approximating hazard rate. 
+    Add discuission about assumption that transition probability is constant
+    over time frame and link to hazard rates page for when this might be an
+    issue. Include formulas about how we are approximating hazard rate.
 
-    Add discussion about how cause model transition probabilities are 
-    state-specific and not necessarily cause-specific. Cannot use cumulative 
-    incidence of disease to represent the transition probability from 
-    susceptible to moderate disease directly, for example. (maybe use LTBI as 
+    Add discussion about how cause model transition probabilities are
+    state-specific and not necessarily cause-specific. Cannot use cumulative
+    incidence of disease to represent the transition probability from
+    susceptible to moderate disease directly, for example. (maybe use LTBI as
     an example here)
-    
+
 
 Remission Rates
 ^^^^^^^^^^^^^^^

--- a/docs/source/models/gbd2017/causes/causes.rst
+++ b/docs/source/models/gbd2017/causes/causes.rst
@@ -1,21 +1,22 @@
-.. _2017_cause_models:
+.. _2017_cause_models_gbd:
 
-============
+===================
 Cause Models in GBD
-============
+===================
 
 What is a cause?
 ----------------
-A cause in the GBD is something that is responsible for death, disease, injury or disability. 
-Some examples could be infectious diseases like malaria or diarrhea. 
-They could also be chronic diseases like diabetes or cancer. The could be things
+A cause in the GBD is something that is responsible for death or disability,
+such as a disease or injury.
+Some examples could be infectious diseases like malaria or diarrhea.
+They could also be chronic diseases like diabetes or cancer. They could be things
 that people are born with like congenital disorders or happen during childbirth like maternal hemorrhage.
 Some causes are only associated with non-fatal outcomes, such as lower back pain.
-Many different things cause health loss and 
-this variation is reflected in the many ways that GBD models them. 
+Many different things cause health loss and
+this variation is reflected in the many ways that GBD models them.
 
 Causes in the GBD are organized in a hierarchy where at every level of that hierarchy
-causes of death or disease are mutually exclusive and collectively exhaustive. 
+causes of death or disease are mutually exclusive and collectively exhaustive.
 
 - All causes
 
@@ -23,10 +24,10 @@ causes of death or disease are mutually exclusive and collectively exhaustive.
 
     - ... down to the most detailed level
 
-*Measures* are a quantity of disease burden. Measures for causes include:  
+*Measures* are a quantity of disease burden. Measures for causes include:
 deaths, incidence, prevalence, remission, excess mortality, YLDs, YLLs, and DALYs
 
-*Metrics* are units that describe disease burden. Metrics for causes include:  
+*Metrics* are units that describe disease burden. Metrics for causes include:
 counts, rates, and percentages
 
 Modeling causes of death
@@ -35,7 +36,7 @@ Modeling causes of death
 .. image:: fatal_flowchart.png
    :width: 600
 
-**Modeling approach** 
+**Modeling approach**
 
 Most causes are estimated using a centrally-maintained Bayesian ensemble modeling tool (CODEm)
 
@@ -51,7 +52,7 @@ Some causes are modeled in custom approaches. Important examples include HIV, ca
 **Input data**
 
 Input data into CODEm are managed by a single team (`Cause of death team
-<https://hub.ihme.washington.edu/display/COD/Causes+of+Death>`_) 
+<https://hub.ihme.washington.edu/display/COD/Causes+of+Death>`_)
 and undergo a series of data adjustments before modeling.
 These adjustments can be somewhat complicated but in general they are to account for causes of death that are not sufficiently specific.
 GBD calls these "garbage codes", meaning deaths coded to things that are not detailed enough. An example might be "dehydration".
@@ -73,24 +74,24 @@ on CoDCorrect can be found `here
 <https://hub.ihme.washington.edu/display/CCMD/CoDCorrect>`_.
 
 GBD does this by scaling cause-specific mortality estimates to cumulatively sum to the all-cause mortality estimate. This occurs
-by age/sex/year/location. The central tool that performs this scaling is called CodCorrect. CoDCorrect runs at the draw level and so 
+by age/sex/year/location. The central tool that performs this scaling is called CodCorrect. CoDCorrect runs at the draw level and so
 it maintains the uncertainty from each model. Importantly, it also adds back in HIV deaths as well as *fatal discontinuity* deaths.
 A fatal discontinuity is jargon for a death that occurred as part of a cluster of deaths that were irregular, like wars,
-epidemics, or famines. 
+epidemics, or famines.
 
 **Getting results**
 
 The central function `get_draws()
-<https://scicomp-docs.ihme.washington.edu/get_draws/current/>`_ 
-can be used to get estimates of cause of deaths models at the draw level for two outputs. Unless there is a good and 
+<https://scicomp-docs.ihme.washington.edu/get_draws/current/>`_
+can be used to get estimates of cause of deaths models at the draw level for two outputs. Unless there is a good and
 specific reason, draws from CoDCorrect should be used to estimate cause-specific mortality or YLLs.
 
 - Output from CoDCorrect are age/sex/year/location specific deaths and years of life lost (YLLs). The function get_draws() returns both deaths and YLLs in *count* space.
-	
+
 	- The source for CoDCorrect should be "codcorrect"
-	
+
 - Output from CODEm are age/sex/year/location specific cause specific mortality rates and cause fractions (percent of all deaths)
-	
+
 	- get_draws() can return CODEm and custom COD model results (source = "codem")
 	- This might not be the best place to pull results because they haven't gone through CoDCorrect yet.
 
@@ -100,43 +101,43 @@ The documentation for GBD causes (write-ups) are typically separate Word documen
 for the study publication. If you have access to the shared drives at IHME, you can find the documentation on the
 I Drive: I:/RTs_and_Projects/GBD/Publications/Capstone Lancet Papers 2018/Cause Write-Ups/COD/Resubmission/4_final/
 
-The Appendix for the GBD 2017 Cause of Death manuscript is also available and Open Access at the Lancet website 
+The Appendix for the GBD 2017 Cause of Death manuscript is also available and Open Access at the Lancet website
 `GBD COD Capstone
 <https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(18)32203-7/fulltext#seccestitle540>`_
 
 
 Modeling non-fatal outcomes (Outline)
----------------------------
+-------------------------------------
 
 .. image:: gbd_nonfatal_flowchart_sim_team.jpg
    :width: 600
 
-**DisMod** 
+**DisMod**
 
 Disease Model Meta Regression 2.1 (DisMod, sometimes DisMod MR) is a statistical modeling tool developed for the Global
 Burden of Disease study to estimate non-fatal disease burden. It is the most frequently used tool for non-fatal modeling
-in the GBD and models that are run outside of it are frequently called *custom models*. 
+in the GBD and models that are run outside of it are frequently called *custom models*.
 
-DisMod has a user interface. The 
+DisMod has a user interface. The
 `External Version
 <https://vizhub.healthdata.org/epi/>`_
 shows published and final models for GBD 2017.
-The 
+The
 `Internal Version
 <https://internal.ihme.washington.edu/epi/>`_
-is where new and ongoing modeling occurs and is for GBD 2019 (but shows GBD 2017 best models). 
+is where new and ongoing modeling occurs and is for GBD 2019 (but shows GBD 2017 best models).
 
-There are three main components to DisMod: 
+There are three main components to DisMod:
 
-1. It is a meta-regression statistical model. This means that it uses point estimates with uncertainty around those 
+1. It is a meta-regression statistical model. This means that it uses point estimates with uncertainty around those
 estimates and covariates to predict disease burden for every location/year/age/sex.
 These predictions are produced separately for each estimation year (every 5 years from 1990 to 2015 and the year 2017) and
-there is no cohort component to DisMod meaning that there is no enforcement in incidence and prevalence over time and age.  
-   
-2. It is a compartmental model of disease. This means that DisMod is solving differential equations while fitting meta-regression 
-estimates to enforce consistency between disparate measures of disease like incidence, prevalence, remission, and excess mortality. 
-  
-3. It is age-integrating. Input data in DisMod must have an age or age range associated with those data, ranges which may be noisy. 
+there is no cohort component to DisMod meaning that there is no enforcement in incidence and prevalence over time and age.
+
+2. It is a compartmental model of disease. This means that DisMod is solving differential equations while fitting meta-regression
+estimates to enforce consistency between disparate measures of disease like incidence, prevalence, remission, and excess mortality.
+
+3. It is age-integrating. Input data in DisMod must have an age or age range associated with those data, ranges which may be noisy.
 DisMod can account for ranges in age in the input data by integrating across age-specific rates to help it produce continuous estimates of disease burden across all ages.
 
 Input data for DisMod can be any of the measures of disease that are estimated within it. These include prevalence, incidence,
@@ -145,7 +146,7 @@ remission, excess mortality, and cause-specific mortality. Input data will be de
 Results from DisMod are internally consistent *within* that model. Incidence, prevalence, remission, and excess mortality are
 linked in the DisMod estimation process and so the results from a model will include all these measures of disease. However, results
 from DisMod will *not* be consistent with final GBD estimates because of processes like COMO that rescale prevalence and sometimes
-incidence of different non-fatal disease models to achieve consistency across all models. 
+incidence of different non-fatal disease models to achieve consistency across all models.
 
 **Other Modeling tools- ST-GPR**
 
@@ -163,12 +164,12 @@ incidence of different non-fatal disease models to achieve consistency across al
 
 - How to get input data for GBD non-fatal models
 
-- Key term definitions  
+- Key term definitions
 
 	- Crosswalks
 	- modelable_entity_id
 	- Bundles
-	
+
 **Epi Computation and COMO**
 
 - What is Comorbidity adjustment (COMO)


### PR DESCRIPTION
I made some minor changes to 2 files to get rid of warnings when building html with Sphinx:

In `docs/source/models/cause.rst`:

- Fix broken links to "Duration" and "Progression" sections in the Data Definitions table

In `docs/source/models/gbd2017/causes/causes.rst`

- Change the document's internal hyperlink target to `2017_cause_models_gbd` because it conflicted with the one in `docs/source/models/gbd2017/causes/index.rst`
- Fix title underlines that were too short
- Minor edits in first paragraph (fix typo plus clarify definition of cause in first sentence)

All the other changes shown by git appear to be removal of extraneous whitespace, which must have happened automatically in my text editor.