### PR TITLE
Cause Model Template: add references to YLD & CoD appendices

### DIFF
--- a/docs/source/models/gbd2017/causes/cause_model_template.rst
+++ b/docs/source/models/gbd2017/causes/cause_model_template.rst
@@ -216,7 +216,7 @@ References
 
 .. [GBD-2017-YLD-Appendix-Cause-Model-Template]
 
-   Pages ???-??? in `Supplementary appendex 1 to the GBD 2017 YLD Capstone <YLD
+   Pages ???-??? in `Supplementary appendix 1 to the GBD 2017 YLD Capstone <YLD
    appendix on ScienceDirect_>`_:
 
      **(GBD 2017 YLD Capstone)** GBD 2017 Disease and Injury Incidence and

--- a/docs/source/models/gbd2017/causes/cause_model_template.rst
+++ b/docs/source/models/gbd2017/causes/cause_model_template.rst
@@ -8,6 +8,7 @@ Cause Model Template
 .. _Pull Request 76: https://github.com/ihmeuw/vivarium_research/pull/76
 .. _Pull Request 91: https://github.com/ihmeuw/vivarium_research/pull/91
 .. _Pull Request 93: https://github.com/ihmeuw/vivarium_research/pull/93
+.. _Pull Request 99: https://github.com/ihmeuw/vivarium_research/pull/99
 
 .. important::
 
@@ -263,7 +264,8 @@ References
 
    Delete this :code:`.. tip::` `directive
    <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives>`_
-   once you fill in the correct page numbers for your cause in the appendices.
+   once you fill in the correct page numbers for your cause in the appendices
+   and rename the references appropriately.
 
 .. admonition:: Todo for template development
 
@@ -273,6 +275,10 @@ References
   The same "append a suffix" rule would also apply to other common citations
   like WHO, CDC, UpToDate, and Wikipedia. For example, the WHO citation for
   Measles would be [WHO-Measles].
+
+  In `Pull Request 99`_, we decided to go with the above naming convention for
+  now. But @James said it should be possible to adapt the sphinx builder to
+  resolve citations to the most local level if desired.
 
 .. admonition:: Todo for template development
 

--- a/docs/source/models/gbd2017/causes/cause_model_template.rst
+++ b/docs/source/models/gbd2017/causes/cause_model_template.rst
@@ -214,6 +214,66 @@ Validation Criteria
 References
 ----------
 
+.. [GBD-2017-YLD-Appendix-Cause-Model-Template]
+
+   Pages ???-??? in `Supplementary appendex 1 to the GBD 2017 YLD Capstone <YLD
+   appendix on ScienceDirect_>`_:
+
+     **(GBD 2017 YLD Capstone)** GBD 2017 Disease and Injury Incidence and
+     Prevalence Collaborators. :title:`Global, regional, and national incidence,
+     prevalence, and years lived with disability for 354 diseases and injuries
+     for 195 countries and territories, 1990–2017: a systematic analysis for the
+     Global Burden of Disease Study 2017`. Lancet 2018; 392: 1789–858. DOI:
+     https://doi.org/10.1016/S0140-6736(18)32279-7
+
+.. _YLD appendix on ScienceDirect: https://ars.els-cdn.com/content/image/1-s2.0-S0140673618322797-mmc1.pdf
+.. _YLD appendix on Lancet.com: https://www.thelancet.com/cms/10.1016/S0140-6736(18)32279-7/attachment/6db5ab28-cdf3-4009-b10f-b87f9bbdf8a9/mmc1.pdf
+
+
+.. [GBD-2017-CoD-Appendix-Cause-Model-Template]
+
+   Pages ???-??? in `Supplementary appendix 1 to the GBD 2017 CoD Capstone <CoD
+   appendix on ScienceDirect_>`_:
+
+     **(GBD 2017 CoD Capstone)** GBD 2017 Causes of Death Collaborators.
+     :title:`Global, regional, and national age-sex-specific mortality for 282
+     causes of death in 195 countries and territories, 1980–2017: a systematic
+     analysis for the Global Burden of Disease Study 2017`. Lancet 2018; 392:
+     1736–88. DOI: http://dx.doi.org/10.1016/S0140-6736(18)32203-7
+
+.. _CoD appendix on ScienceDirect: https://ars.els-cdn.com/content/image/1-s2.0-S0140673618322037-mmc1.pdf
+.. _CoD appendix on Lancet.com: https://www.thelancet.com/cms/10.1016/S0140-6736(18)32203-7/attachment/5045652a-fddf-48e2-9a84-0da99ff7ebd4/mmc1.pdf
+
+.. tip::
+
+   In the `citations
+   <https://docutils.sourceforge.io/docs/user/rst/quickref.html#citations>`_
+   above, replace "Pages ???-???" with the correct page numbers for your cause
+   in the two appendices, and replace the `Cause-Model-Template` suffix in the
+   citation names with the name of your cause. The suffix is necessary because
+   Sphinx requires citation names to be unique `throughout the entire
+   documentation
+   <http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#citations>`_.
+
+   You can follow the syntax above to add your own references, and you can cite
+   the references such as [GBD-2017-YLD-Appendix-Cause-Model-Template]_ and
+   [GBD-2017-CoD-Appendix-Cause-Model-Template]_ from within your text by
+   enclosing the full citation name in brackets and adding a trailing
+   underscore, like this: :code:`[Full-Citation-Name]_`.
+
+   Delete this :code:`.. tip::` `directive
+   <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives>`_
+   once you fill in the correct page numbers for your cause in the appendices.
+
+.. admonition:: Todo for template development
+
+  Is there a better solution to the global citation problem than making citation
+  names longer to ensure that they're unique?
+
+  The same "append a suffix" rule would also apply to other common citations
+  like WHO, CDC, UpToDate, and Wikipedia. For example, the WHO citation for
+  Measles would be [WHO-Measles].
+
 .. admonition:: Todo for template development
 
   Decide on section names and overall structure.


### PR DESCRIPTION
Switching gears temporarily from section structure, here are some proposed templates for the YLD/CoD appendix references. There are several issues where it would be good to get feedback:

- Does the formatting look good?
- Is it clear what is being referenced? I included a link to the appendix, plus the full citation for the capstone paper. Does this make sense? Is there a better way to cite the appendices?
- I put in question marks (???-???) as a place holder to fill in the correct pages in the appendices. Is this useful, or will it be annoying to fill in the correct page numbers in each document?
- What do people think of the "Tip" directive I put after the citations? Is it helpful? Should it be an "Important" directive instead, like the one at the beginning of the document?
- I proposed a solution to Sphinx's "global citation" problem: Append the cause name to any source that will get cited on multiple pages (see the Tip and Todo directives within the document). I don't particularly like that solution -- does anyone have any better ideas?