### PR TITLE
Risk exposure template

### DIFF
--- a/docs/source/gbd2017_models/risks/risk_exposure_template.rst
+++ b/docs/source/gbd2017_models/risks/risk_exposure_template.rst
@@ -84,35 +84,97 @@ in a different document.
 Risk Exposures Description in GBD
 ---------------------------------
 
-  - What type of risk model does Type of risk (categorical, continuous, etc.)
+Include a description of this exposure model in the context of GBD, involving
+but not limited to:
+
+  - What type of statistical model? (categorical, continuous?)
+
+  - How is the exposure estimated? (DisMod, STGPR?)
 
   - Which outcomes are affected by this risk?
 
-  - TMREL (high level overview. does it vary by outcome?)
+  - TMREL? (This should be a very high level overview. Namely, does the TMREL 
+  vary by outcome? The details of the TMREL will be included in the 
+  *Risk Outcome Relationship Model* section)
 
 Vivarium Modeling Strategy
 --------------------------
 
-Scope
-+++++
+Include here an overview of the Vivarium modeling section
+
+Restrictions
+++++++++++++
+
+.. list-table:: GBD 2017 Exposure Restrictions
+   :widths: 15 15 20
+   :header-rows: 1
+
+   * - Restriction Type
+     - Value
+     - Notes
+   * - Male only
+     -
+     -
+   * - Female only
+     -
+     -
+   * - Age group start
+     -
+     -
+   * - Age group end
+     -
+     -
+
+..	todo::
+
+	Determine if there's something analogous to "YLL/YLD only" for this section
 
 Assumptions and Limitations
 +++++++++++++++++++++++++++
 
+Describe the clinical and mathematical assumptions made for this cause model,
+and the limitations these assumptions impose on the applicability of the
+model.
+
 Exposure Model Diagram
 ++++++++++++++++++++++
+
+Include diagram of Vivarium exposure model.
 
 Data Description Tables
 +++++++++++++++++++++++
 
- - Constants table
+As of 02/10/2020: follow the template created by Ali for Iron Deficiency, copied 
+below. If we discover it's not general enough to accommodate all exposure types,
+we need to revise the format in coworking. 
 
- - Parameters table
+.. list-table:: Constants 
+	:widths: 10, 5, 15
+	:header-rows: 1
 
- *We discussed following Ali's example with iron deficiency.*
+	* - Constant
+	  - Value
+	  - Note
+	* - 
+	  - 
+	  - 
+
+.. list-table:: Distribution Parameters
+	:widths: 15, 30, 10
+	:header-rows: 1
+
+	* - Parameter
+	  - Value
+	  - Note
+	* - 
+	  - 
+	  -
 
 Validation Criteria
 +++++++++++++++++++
+
+..	todo::
+	Fill in directives for this section
 
 References
 ----------

--- a/docs/source/gbd2017_models/risks/risk_exposure_template.rst
+++ b/docs/source/gbd2017_models/risks/risk_exposure_template.rst
@@ -80,15 +80,13 @@ Note that this is only for the exposure; you will include information on the
 relative risk of the relevant outcomes, and the cause models for those outcomes, 
 in a different document.
 
-Risk Exposure description
--------------------------
 
 Risk Exposures Description in GBD
-------------------------------
+---------------------------------
 
   - What type of risk model does Type of risk (categorical, continuous, etc.)
 
-  - What is this a risk for?
+  - Which outcomes are affected by this risk?
 
   - TMREL (high level overview. does it vary by outcome?)
 
@@ -101,15 +99,15 @@ Scope
 Assumptions and Limitations
 +++++++++++++++++++++++++++
 
-Cause Model Diagram
-+++++++++++++++++++
+Exposure Model Diagram
+++++++++++++++++++++++
 
 Data Description Tables
 +++++++++++++++++++++++
 
  - Constants table
 
- - parameters table
+ - Parameters table
 
  *We discussed following Ali's example with iron deficiency.*
 

--- a/docs/source/gbd2017_models/risks/risk_exposure_template.rst
+++ b/docs/source/gbd2017_models/risks/risk_exposure_template.rst
@@ -1,8 +1,8 @@
-.. _2017_exposure_template:
+.. _2017_risk_exposure_template:
 
-======================
+----------------------
 Risk Exposure Template
-======================
+----------------------
 
 .. important::
 
@@ -10,11 +10,13 @@ Risk Exposure Template
    following these steps (after you have :ref:`created a new git branch
    <contributing>` to work in):
 
-   #. Make a subdirectory :file:`{exposure_name}/` in the folder
-      :file:`gbd2017/risks/` , where :file:`{exposure_name}` is replaced with the
-      (potentially shortened) name of the exposure you are modeling, such as :file:`unsafe_water_source/` or :file:`low_birthweight_short_gestation/`.  This
-      subdirectory is where you will put all the files for your exposure model
-      documentation, including this document, image files, .csv files, etc.
+   #. Make a subdirectory :file:`{risk_exposure_name}/` in the folder
+      :file:`gbd2017/risks/` , where :file:`{risk_exposure_name}` is replaced 
+      with the (potentially shortened) name of the risk exposure you are 
+      modeling, such as :file:`unsafe_water_source/` or 
+      :file:`low_birthweight_short_gestation/`.  This subdirectory is where you 
+      will put all the files for your exposure model documentation, including 
+      this document, image files, .csv files, etc.
 
 
    #. Copy this template into your subdirectory and rename
@@ -22,11 +24,12 @@ Risk Exposure Template
 
    #. Replace the `internal hyperlink target
       <https://docutils.sourceforge.io/docs/user/rst/quickref.html#internal-hyperlink-targets>`_
-      :code:`.. _2017_cause_model_template:` at the top of this file with a
+      :code:`.. _2017_risk_exposure_template:` at the top of this file with a
       unique reference label for your cause. The reference label should have the
       form :samp:`.. _2017_exposure_{\{exposure_name\}}:`, where
       :samp:`{\{exposure_name\}}` is replaced with a unique descriptive name or
-      abbreviation for your risk exposure, e.g. :code:`.. _2017_exposure_unsafe_water:`.
+      abbreviation for your risk exposure, e.g.
+      :code:`.. _2017_risk_exposure_unsafe_water:`.
 
    #. Delete this document's title above:
 
@@ -40,7 +43,9 @@ Risk Exposure Template
       promoted up one level.
 
    #. The subtitle below should now be the document's title. Replace the text
-      in the below (sub)title with the full name of your exposure in GBD 2017. For example, if you were modeling the exposure "Low Birth Weight and Short Gestation," then the title
+      in the below (sub)title with the full name of your risk exposure in GBD 
+      2017. For example, if you were modeling the exposure "Low Birth Weight 
+      and Short Gestation," then the title
 
       .. code:: reStructuredText
 
@@ -75,10 +80,10 @@ Full Name of Risk Exposure in GBD 2017
 Risk Exposure Overview
 ----------------------
 
-Include here a clinical background and overview of the exposure you're modeling.
-Note that this is only for the exposure; you will include information on the 
-relative risk of the relevant outcomes, and the cause models for those outcomes, 
-in a different document.
+Include here a clinical background and overview of the risk exposure you're 
+modeling. Note that this is only for the exposure; you will include information 
+on the relative risk of the relevant outcomes, and the cause models for those 
+outcomes, in a different document.
 
 
 Risk Exposures Description in GBD
@@ -93,9 +98,7 @@ but not limited to:
 
   - Which outcomes are affected by this risk?
 
-  - TMREL? (This should be a very high level overview. Namely, does the TMREL 
-  vary by outcome? The details of the TMREL will be included in the 
-  *Risk Outcome Relationship Model* section)
+  - TMREL? (This should be a very high level overview. Namely, does the TMREL vary by outcome? The details of the TMREL will be included in the *Risk Outcome Relationship Model* section)
 
 Vivarium Modeling Strategy
 --------------------------

--- a/docs/source/gbd2017_models/risks/risk_exposure_template.rst
+++ b/docs/source/gbd2017_models/risks/risk_exposure_template.rst
@@ -1,17 +1,84 @@
-.. _2017_risk_exposure_template:
+.. _2017_exposure_template:
 
-----------------------
+======================
 Risk Exposure Template
-----------------------
+======================
 
-.. todo::
-  Add instructions, following Nathaniel's cause model template instructions. Flesh out all headings.
+.. important::
+
+   To begin documenting a risk exposure in GBD 2017 for a Vivarium simulation, start by
+   following these steps (after you have :ref:`created a new git branch
+   <contributing>` to work in):
+
+   #. Make a subdirectory :file:`{exposure_name}/` in the folder
+      :file:`gbd2017/risks/` , where :file:`{exposure_name}` is replaced with the
+      (potentially shortened) name of the exposure you are modeling, such as :file:`unsafe_water_source/` or :file:`low_birthweight_short_gestation/`.  This
+      subdirectory is where you will put all the files for your exposure model
+      documentation, including this document, image files, .csv files, etc.
+
+
+   #. Copy this template into your subdirectory and rename
+      it :code:`index.rst`.
+
+   #. Replace the `internal hyperlink target
+      <https://docutils.sourceforge.io/docs/user/rst/quickref.html#internal-hyperlink-targets>`_
+      :code:`.. _2017_cause_model_template:` at the top of this file with a
+      unique reference label for your cause. The reference label should have the
+      form :samp:`.. _2017_exposure_{\{exposure_name\}}:`, where
+      :samp:`{\{exposure_name\}}` is replaced with a unique descriptive name or
+      abbreviation for your risk exposure, e.g. :code:`.. _2017_exposure_unsafe_water:`.
+
+   #. Delete this document's title above:
+
+      .. code:: reStructuredText
+
+         ----------------------
+         Risk Exposure Template
+         ----------------------
+
+      Once the above title is deleted, all the other section titles will be
+      promoted up one level.
+
+   #. The subtitle below should now be the document's title. Replace the text
+      in the below (sub)title with the full name of your exposure in GBD 2017. For example, if you were modeling the exposure "Low Birth Weight and Short Gestation," then the title
+
+      .. code:: reStructuredText
+
+         ======================================
+         Full Name of Risk Exposure in GBD 2017
+         ======================================
+
+      should be replaced by
+
+      .. code:: reStructuredText
+
+         ====================================
+         Low Birth Weight and Short Gestation
+         ====================================
+
+      **Note:** Be sure to adjust the length of the title's underline
+      :code:`======` and overline :code:`======` to match the length of your
+      new document title, or you will get errors in the `section structure
+      <https://docutils.sourceforge.io/docs/user/rst/quickref.html#section-structure>`_
+      when Sphinx builds HTML from the :file:`index.rst` file.
+
+   #. Once you complete these steps, delete this :code:`.. important::`
+      `directive <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives>`_
+      from :file:`index.rst`.
+
+
+======================================
+Full Name of Risk Exposure in GBD 2017
+======================================
 
 
 Risk Exposure Overview
 ----------------------
 
- - expert opinion
+Include here a clinical background and overview of the exposure you're modeling.
+Note that this is only for the exposure; you will include information on the 
+relative risk of the relevant outcomes, and the cause models for those outcomes, 
+in a different document.
 
 Risk Exposure description
 -------------------------
@@ -19,7 +86,7 @@ Risk Exposure description
 Risk Exposures Description in GBD
 ------------------------------
 
-  - Type of risk (categorical, continuous, etc.)
+  - What type of risk model does Type of risk (categorical, continuous, etc.)
 
   - What is this a risk for?
 

--- a/docs/source/gbd2017_models/risks/risk_exposure_template.rst
+++ b/docs/source/gbd2017_models/risks/risk_exposure_template.rst
@@ -26,8 +26,8 @@ Risk Exposure Template
       <https://docutils.sourceforge.io/docs/user/rst/quickref.html#internal-hyperlink-targets>`_
       :code:`.. _2017_risk_exposure_template:` at the top of this file with a
       unique reference label for your cause. The reference label should have the
-      form :samp:`.. _2017_exposure_{\{exposure_name\}}:`, where
-      :samp:`{\{exposure_name\}}` is replaced with a unique descriptive name or
+      form :samp:`.. _2017_risk_exposure_{\{risk_exposure_name\}}:`, where
+      :samp:`{\{risk_exposure_name\}}` is replaced with a unique descriptive name or
       abbreviation for your risk exposure, e.g.
       :code:`.. _2017_risk_exposure_unsafe_water:`.
 
@@ -89,8 +89,8 @@ outcomes, in a different document.
 Risk Exposures Description in GBD
 ---------------------------------
 
-Include a description of this exposure model in the context of GBD, involving
-but not limited to:
+Include a description of this risk exposure model in the context of GBD, 
+involving but not limited to:
 
   - What type of statistical model? (categorical, continuous?)
 
@@ -108,7 +108,7 @@ Include here an overview of the Vivarium modeling section
 Restrictions
 ++++++++++++
 
-.. list-table:: GBD 2017 Exposure Restrictions
+.. list-table:: GBD 2017 Risk Exposure Restrictions
    :widths: 15 15 20
    :header-rows: 1
 
@@ -139,10 +139,10 @@ Describe the clinical and mathematical assumptions made for this cause model,
 and the limitations these assumptions impose on the applicability of the
 model.
 
-Exposure Model Diagram
+Risk Exposure Model Diagram
 ++++++++++++++++++++++
 
-Include diagram of Vivarium exposure model.
+Include diagram of Vivarium risk exposure model.
 
 Data Description Tables
 +++++++++++++++++++++++


### PR DESCRIPTION
I accidentally merged the risks_stub branch without incorporating your comments. They've been incorporated here.

I've also expanded the risk exposure template to have more detail. I didn't do it in @NathanielBlairStahn 's to-do form; I found it somewhat confusing to discern which todos were for the template page, vs for the specific cause page---so wanted to check out this version. happy to convert over if we prefer the todo format!