### PR TITLE
Fixed the A/P state discrepency.

### DIFF
--- a/docs/source/gbd2019_models/causes/afib/index.rst
+++ b/docs/source/gbd2019_models/causes/afib/index.rst
@@ -192,7 +192,7 @@ Definitions
      - **S**\ usceptible to Atrial fibrillation and flutter 
      - Simulant that has not been diagnosed with atrial fibrillation and flutter.
    * - A
-     - **P**\ revalent Atrial fibrillation and flutter 
+     - Prevalent **A**\ trial fibrillation and flutter 
      - Simulant with prevalent atrial fibrillation and flutter diagnosed by ECG .
 
 
@@ -251,7 +251,7 @@ Transition Data
      - Notes
    * - 1
      - S
-     - P
+     - A
      - :math:`{incidence}_c500`
      - This is cause-level incidence which is equivalent to the “population rate”
 	 


### PR DESCRIPTION
I accidently merged the last PR before making these changes, so I created a new PR.
I chose to use "A" instead of "P" or "C" for the prevalent state to match the cause model diagram, but noticed that Nikki chose to go with "C", and am happy to change it to "C" and update the diagram if people prefer them to match.