### PR TITLE
LBWSG Risk Effects - GBD 2019 Modeling Section

### DIFF
--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -190,6 +190,14 @@ that reverse causality could not be excluded.**
      - Mortality (GBD YLLs)
      -
 
+.. note::
+
+  There are 12 causes affected by LBWSG in GBD 2019, whereas GBD 2017 included
+  15 affected causes. The only difference is that meningitis (c332) had four
+  subcauses in GBD 2017 (c333, c334, c335, c336, corresponding to different
+  etiologies), whereas in GBD 2019, c332 is the most detailed cause, and the
+  subcauses have been removed.
+
 Restrictions
 ++++++++++++
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -101,7 +101,8 @@ mortality risk. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
   refers to location-specific mortality risks, the relative risks in GBD 2019
   are the same for all locations. Pulling LBWSG RR's with ``get_draws`` for any
   location returns RR's with location_id = 1 (Global), and they are stratified
-  by year/age_group/sex.
+  by year/age_group/sex. If we need clarification on exactly how the relative
+  risks were calculated, we should consult the GBD modelers.
 
 Affected Outcomes
 +++++++++++++++++
@@ -222,10 +223,10 @@ Restrictions
 
 .. note::
 
-  GBD 2019 attributes 100% of the DALYs due to Neonatal Preterm Birth to the
-  LBWSG risk factor. In particular, the attribution includes YLDs as well as
-  YLLs, and the age restrictions for the LBWSG-attributale DALYs are the same as
-  the age restrictions for Neonatal Preterm Birth.
+  GBD attributes 100% of the DALYs due to Neonatal Preterm Birth to the LBWSG
+  risk factor. In particular, the attribution includes YLDs as well as YLLs, and
+  the age restrictions for the LBWSG-attributable DALYs are the same as the age
+  restrictions for Neonatal Preterm Birth.
 
   * **YLLs due to Neonatal preterm birth**, 100% attributable to LBWSG:
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -58,12 +58,18 @@ In all datasets except for the USA, sex-specific data were combined to maximise 
 Details of Relative Risk Estimation
 +++++++++++++++++++++++++++++++++++
 
+In the Norway, New Zealand, and USA Linked Birth/Death Cohort microdata datasets, livebirths are reported with gestational age, birthweight, and an indicator of death at 7 days and 28 days. For this analysis, gestational age was grouped into two-week categories, and birthweight was grouped into 500-gram categories. The Taiwan, Japan, and Singapore datasets were prepared in tabulations of joint 500-gram and two-week categories. A pooled country analysis of mortality risk in the early neonatal period and late neonatal period by “small for gestational age” category in developing countries in Asia and sub-Saharan Africa were also used to inform the relative risk analysis.
+
 To calculate relative risk at each 500-gram and two-week combination, logistic regression was first used to calculate mortality odds for each joint two-week gestational age and 500-gram birthweight category. Mortality odds were smoothed with Gaussian process regression, with the independent distributions of mortality odds by birthweight and mortality odds by gestational age serving as priors in the regression.
 A pooled country analysis of mortality risk in the early neonatal period and late neonatal period by SGA category in developing countries in Asia and sub-Saharan Africa were also converted into 500-gram and two-week bin mortality odds surfaces.
 
 The relative risk surfaces produced from microdata and the Asia and Africa surfaces produced from the pooled country analysis were meta-analysed, resulting in a meta- analysed mortality odds surface for each location. The meta-analysed mortality odds surface for each location was smoothed using Gaussian process regression and then converted into mortality risk.
 
 To calculate mortality relative risks, the risk of each joint two-week gestational age and 500-gram birthweight category were divided by the risk of mortality in the joint gestational age and birthweight category with the lowest mortality risk. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
+
+.. note::
+
+  Although the above description from the GBD 2019 risk appendix sometimes refers to location-specific mortality risks, the relative risks in GBD 2019 are the same for all locations. Pulling LBWSG RR's with ``get_draws`` for any location returns RR's with location_id = 1 (Global), and they are stratified by year/age_group/sex.
 
 Affected Outcomes
 +++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -50,30 +50,24 @@ GBD 2019 Modeling Strategy
 
 	This section will describe the GBD modeling strategy for risk effects. For a description of GBD modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
-.. todo::
+**The available data for deriving relative risk was only for all-cause mortality.**
+For each location, data were pooled across years, and the risk of all-cause mortality at the **early neonatal** period and **late neonatal period** at joint birthweight and gestational age combinations was calculated.
+In all datasets except for the USA, sex-specific data were combined to maximise sample size. The USA analyses were sex-specific.
+Relative risks of mortality were calculated for each 500g and 2wk category of birthweight and gestational age.
 
-	Provide a brief overview of how the risk affects different outcomes, including data sources used by GBD, GBD assumptions, etc. Note that the [GBD-2019-Risk-Factors-Appendix]_ is a good source for this information in addition to the GBD risk modeler.
+To calculate relative risk at each 500-gram and two-week combination, logistic regression was first used to calculate mortality odds for each joint two-week gestational age and 500-gram birthweight category. Mortality odds were smoothed with Gaussian process regression, with the independent distributions of mortality odds by birthweight and mortality odds by gestational age serving as priors in the regression.
+A pooled country analysis of mortality risk in the early neonatal period and late neonatal period by SGA category in developing countries in Asia and sub-Saharan Africa were also converted into 500-gram and two-week bin mortality odds surfaces.
 
-.. todo::
+The relative risk surfaces produced from microdata and the Asia and Africa surfaces produced from the pooled country analysis were meta-analysed, resulting in a meta- analysed mortality odds surface for each location. The meta-analysed mortality odds surface for each location was smoothed using Gaussian process regression and then converted into mortality risk.
 
-	Fill out the following table so that it reflects *all* entities affected by the risk in GBD 2019.
+To calculate mortality relative risks, the risk of each joint two-week gestational age and 500-gram birthweight category were divided by the risk of mortality in the joint gestational age and birthweight category with the lowest mortality risk. [GBD-2019-Risk-Factors-Appendix]_
 
-  .. code:: Python
+Affected Outcomes
++++++++++++++++++
 
-    [
-      (302, 'diarrheal_diseases'),
-      (322, 'lower_respiratory_infections'),
-      (328, 'upper_respiratory_infections'),
-      (329, 'otitis_media'),
-      (332, 'meningitis'),
-      (337, 'encephalitis'),
-      (381, 'neonatal_preterm_birth'),
-      (382, 'neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma'),
-      (383, 'neonatal_sepsis_and_other_neonatal_infections'),
-      (384, 'hemolytic_disease_and_other_neonatal_jaundice'),
-      (385, 'other_neonatal_disorders'),
-      (686, 'sudden_infant_death_syndrome')
-    ]
+The available data for deriving relative risk was only for *all-cause mortality* rather than for cause-specific outcomes. The exception was the USA linked infant birth-death cohort data, which contained three-digit ICD causes of death, but also had nearly 30% of deaths coded to causes that are ill-defined, or intermediate, in the GBD cause classification system.
+
+Therefore, the GBD modelers analysed the relative risk of all-cause mortality across all available sources and selected outcomes based on criteria of biological plausibility. **Some causes, most notably congenital birth defects, haemoglobinopathies, malaria, and HIV/AIDS, were excluded based on the criteria that reverse causality could not be excluded.** [GBD-2019-Risk-Factors-Appendix]_
 
 .. list-table:: Affected Entities
    :widths: 5 5 5 5 5
@@ -115,7 +109,7 @@ GBD 2019 Modeling Strategy
      - Mortality (GBD YLLs)
      -
    * - Neonatal preterm birth
-     - Cause
+     - Cause (PAF-of-1)
      - 381
      - Mortality and Morbidity (GBD YLLs and YLDs)
      - 100% attributable to Low birthweight and short gestation
@@ -144,6 +138,11 @@ GBD 2019 Modeling Strategy
      - 686
      - Mortality (GBD YLLs)
      -
+
+Restrictions
+++++++++++++
+
+
 Vivarium Modeling Strategy
 --------------------------
 
@@ -183,7 +182,7 @@ Risk Outcome Pair #1
 
 .. todo::
 
-	Describe which entitity the relative risks apply to (incidence rate, prevalence, excess mortality rate, etc.) and *how* to apply them (e.g. :code:`affected_measure * (1 - PAF) * RR`).
+  Describe which entitity the relative risks apply to (incidence rate, prevalence, excess mortality rate, etc.) and *how* to apply them (e.g. :code:`affected_measure * (1 - PAF) * RR`).
 
   Be sure to specify the exact PAF that should be used in the above equation and either how to calculate it (see the `Population Attributable Fraction` section of the :ref:`Modeling Risk Factors <models_risk_factors>` document) or pull it (:code:`vivarium_inputs.interface.get_measure(risk_factor.{risk_name}, 'population_attributable_fraction')`, noting which affected entity and measure should be used)
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -50,33 +50,74 @@ GBD 2019 Modeling Strategy
 
 	This section will describe the GBD modeling strategy for risk effects. For a description of GBD modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
-**The available data for deriving relative risk was only for all-cause mortality.**
-For each location, data were pooled across years, and the risk of all-cause mortality at the **early neonatal period** and **late neonatal period** at joint birthweight and gestational age combinations was calculated.
-In all datasets except for the USA, sex-specific data were combined to maximise sample size. The USA analyses were sex-specific.
-**Relative risks of all-cause mortality were calculated for each 500g and 2wk category of birthweight and gestational age.** [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
+**The available data for deriving relative risk was only for all-cause
+mortality.**
+For each location, data were pooled across years, and the risk of all-cause
+mortality at the **early neonatal period** and **late neonatal period** at joint
+birthweight and gestational age combinations was calculated. In all datasets
+except for the USA, sex-specific data were combined to maximise sample size. The
+USA analyses were sex-specific.
+**Relative risks of all-cause mortality were calculated for each 500g and 2wk
+category of birthweight and gestational age.**
+[GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
 Details of Relative Risk Estimation
 +++++++++++++++++++++++++++++++++++
 
-In the Norway, New Zealand, and USA Linked Birth/Death Cohort microdata datasets, livebirths are reported with gestational age, birthweight, and an indicator of death at 7 days and 28 days. For this analysis, gestational age was grouped into two-week categories, and birthweight was grouped into 500-gram categories. The Taiwan, Japan, and Singapore datasets were prepared in tabulations of joint 500-gram and two-week categories. A pooled country analysis of mortality risk in the early neonatal period and late neonatal period by “small for gestational age” category in developing countries in Asia and sub-Saharan Africa were also used to inform the relative risk analysis.
+In the Norway, New Zealand, and USA Linked Birth/Death Cohort microdata
+datasets, livebirths are reported with gestational age, birthweight, and an
+indicator of death at 7 days and 28 days. For this analysis, gestational age was
+grouped into two-week categories, and birthweight was grouped into 500-gram
+categories. The Taiwan, Japan, and Singapore datasets were prepared in
+tabulations of joint 500-gram and two-week categories. A pooled country analysis
+of mortality risk in the early neonatal period and late neonatal period by
+“small for gestational age” category in developing countries in Asia and
+sub-Saharan Africa were also used to inform the relative risk analysis.
 
-To calculate relative risk at each 500-gram and two-week combination, logistic regression was first used to calculate mortality odds for each joint two-week gestational age and 500-gram birthweight category. Mortality odds were smoothed with Gaussian process regression, with the independent distributions of mortality odds by birthweight and mortality odds by gestational age serving as priors in the regression.
-A pooled country analysis of mortality risk in the early neonatal period and late neonatal period by SGA category in developing countries in Asia and sub-Saharan Africa were also converted into 500-gram and two-week bin mortality odds surfaces.
+To calculate relative risk at each 500-gram and two-week combination, logistic
+regression was first used to calculate mortality odds for each joint two-week
+gestational age and 500-gram birthweight category. Mortality odds were smoothed
+with Gaussian process regression, with the independent distributions of
+mortality odds by birthweight and mortality odds by gestational age serving as
+priors in the regression. A pooled country analysis of mortality risk in the
+early neonatal period and late neonatal period by SGA category in developing
+countries in Asia and sub-Saharan Africa were also converted into 500-gram and
+two-week bin mortality odds surfaces.
 
-The relative risk surfaces produced from microdata and the Asia and Africa surfaces produced from the pooled country analysis were meta-analysed, resulting in a meta- analysed mortality odds surface for each location. The meta-analysed mortality odds surface for each location was smoothed using Gaussian process regression and then converted into mortality risk.
+The relative risk surfaces produced from microdata and the Asia and Africa
+surfaces produced from the pooled country analysis were meta-analysed, resulting
+in a meta- analysed mortality odds surface for each location. The meta-analysed
+mortality odds surface for each location was smoothed using Gaussian process
+regression and then converted into mortality risk.
 
-To calculate mortality relative risks, the risk of each joint two-week gestational age and 500-gram birthweight category were divided by the risk of mortality in the joint gestational age and birthweight category with the lowest mortality risk. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
+To calculate mortality relative risks, the risk of each joint two-week
+gestational age and 500-gram birthweight category were divided by the risk of
+mortality in the joint gestational age and birthweight category with the lowest
+mortality risk. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
 .. note::
 
-  Although the above description from the GBD 2019 risk appendix sometimes refers to location-specific mortality risks, the relative risks in GBD 2019 are the same for all locations. Pulling LBWSG RR's with ``get_draws`` for any location returns RR's with location_id = 1 (Global), and they are stratified by year/age_group/sex.
+  Although the above description from the GBD 2019 risk appendix sometimes
+  refers to location-specific mortality risks, the relative risks in GBD 2019
+  are the same for all locations. Pulling LBWSG RR's with ``get_draws`` for any
+  location returns RR's with location_id = 1 (Global), and they are stratified
+  by year/age_group/sex.
 
 Affected Outcomes
 +++++++++++++++++
 
-The available data for deriving relative risk was only for *all-cause mortality* rather than for cause-specific outcomes. The exception was the USA linked infant birth-death cohort data, which contained three-digit ICD causes of death, but also had nearly 30% of deaths coded to causes that are ill-defined, or intermediate, in the GBD cause classification system.
+The available data for deriving relative risk was only for *all-cause mortality*
+rather than for cause-specific outcomes. The exception was the USA linked infant
+birth-death cohort data, which contained three-digit ICD causes of death, but
+also had nearly 30% of deaths coded to causes that are ill-defined, or
+intermediate, in the GBD cause classification system.
 
-Therefore, the GBD modelers analysed the relative risk of all-cause mortality across all available sources and selected outcomes based on criteria of biological plausibility. **Some causes, most notably congenital birth defects, haemoglobinopathies, malaria, and HIV/AIDS, were excluded based on the criteria that reverse causality could not be excluded.** [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
+Therefore, the GBD modelers analysed the relative risk of all-cause mortality
+across all available sources and selected outcomes based on criteria of
+biological plausibility. **Some causes, most notably congenital birth defects,
+haemoglobinopathies, malaria, and HIV/AIDS, were excluded based on the criteria
+that reverse causality could not be excluded.**
+[GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
 .. list-table:: Entities Affected by LBWSG in GBD 2019
    :widths: 5 5 5 5 5
@@ -181,7 +222,10 @@ Restrictions
 
 .. note::
 
-  GBD 2019 attributes 100% of the DALYs due to Neonatal Preterm Birth to the LBWSG risk factor. In particular, the attribution includes YLDs as well as YLLs, and the age restrictions for the LBWSG-attributale DALYs are the same as the age restrictions for Neonatal Preterm Birth.
+  GBD 2019 attributes 100% of the DALYs due to Neonatal Preterm Birth to the
+  LBWSG risk factor. In particular, the attribution includes YLDs as well as
+  YLLs, and the age restrictions for the LBWSG-attributale DALYs are the same as
+  the age restrictions for Neonatal Preterm Birth.
 
   * **YLLs due to Neonatal preterm birth**, 100% attributable to LBWSG:
 
@@ -193,7 +237,11 @@ Restrictions
     - Age group start = 2 (Early neonatal, 0-7 days)
     - Age group end = 235 (95+)
 
-  Note that this attribution of DALYs is **not** based on the relative risks for all-cause mortality, but instead is based on the logic that all preterm births are due to short gestation by definition. Thus, if we include Neonatal Preterm Birth in our models, the relative risks likely must be handled differently for this cause.
+  Note that this attribution of DALYs is **not** based on the relative risks for
+  all-cause mortality, but instead is based on the logic that all preterm births
+  are due to short gestation by definition. Thus, if we include Neonatal Preterm
+  Birth in our models, the relative risks likely must be handled differently for
+  this cause.
 
 Risk Exposure Categories and TMREL
 ++++++++++++++++++++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -1,0 +1,251 @@
+.. _2019_risk_effect_lbwsg:
+
+..
+  Section title decorators for this document:
+
+  ==============
+  Document Title
+  ==============
+
+  Section Level 1
+  ---------------
+
+  Section Level 2
+  +++++++++++++++
+
+  Section Level 3
+  ^^^^^^^^^^^^^^^
+
+  Section Level 4
+  ~~~~~~~~~~~~~~~
+
+  Section Level 5
+  '''''''''''''''
+
+  The depth of each section level is determined by the order in which each
+  decorator is encountered below. If you need an even deeper section level, just
+  choose a new decorator symbol from the list here:
+  https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
+  And then add it to the list of decorators above.
+
+================================================
+Low Birthweight and Short Gestation Risk Effects
+================================================
+
+.. important::
+
+   To begin documenting a risk effects in GBD 2019 for a Vivarium simulation, start by following these steps (after you have :ref:`created a new git branch
+   <contributing>` to work in):
+
+   #. Make a subdirectory :file:`{risk_name}/` in the folder
+      :file:`gbd2019/risk_effects/`, where :file:`{risk_name}` is replaced with the
+      (potentially shortened) name of the risk you are modeling, such as :file:`lbwsg/` or :file:`iron_deficiency/`. This
+      subdirectory is where you will put all the files for your risk effects model
+      documentation, including this document, image files, .csv files, etc.
+
+   #. Copy this template into your subdirectory and rename
+      it :code:`index.rst`.
+
+   #. Replace the `internal hyperlink target
+      <https://docutils.sourceforge.io/docs/user/rst/quickref.html#internal-hyperlink-targets>`_
+      :code:`.. _2019_risk_effect_template:` at the top of this file with a
+      unique reference label for your cause. The reference label should have the
+      form :samp:`.. _2019_{\{risk_name\}}_risk_effects:`, where
+      :samp:`{\{risk_name\}}` is replaced with a unique descriptive name or
+      abbreviation for your cause, e.g. :code:`.. _2019_lbwsg_risk_effects:`.
+
+   #. Delete this document's title above:
+
+      .. code:: reStructuredText
+
+         ===========================
+         Risk Effects Model Template
+         ===========================
+
+      Once the above title is deleted, all the other section titles will be
+      promoted up one level.
+
+   #. The subtitle below should now be the document's title. Replace the {Risk Name} text
+      in the below (sub)title with the full name of your risk in GBD 2019.
+
+      **Note:** Be sure to adjust the length of the title's underline
+      :code:`======` and overline :code:`======` to match the length of your
+      new document title, or you will get errors in the `section structure
+      <https://docutils.sourceforge.io/docs/user/rst/quickref.html#section-structure>`_
+      when Sphinx builds HTML from the :file:`index.rst` file.
+
+   #. Once you complete these steps, delete this :code:`.. important::`
+      `directive <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives>`_
+      from :file:`index.rst`.
+
+.. todo::
+
+  Create the document title (insert appropriate risk name and remove from this to-do)
+
+  ========================
+  {Risk Name} Risk Effects
+  ========================
+
+.. contents::
+   :local:
+   :depth: 2
+
+Risk Overview
+-------------
+
+.. todo::
+
+	Provide a brief description of the risk, including potential opportunities for confounding (factors that may cause or be associated with the risk exposure), effect modification/generalizability, etc. by any relevant variables. Note that literature reviews and speaking with the GBD risk modeler will be good resources for this.
+
+GBD 2019 Modeling Strategy
+--------------------------
+
+.. note::
+
+	This section will describe the GBD modeling strategy for risk effects. For a description of GBD modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_page_link>` page.
+
+.. todo::
+
+	Replace '2019_risk_exposure_page_link' with a reference to the appropriate risk exposure page in the above note.
+
+.. todo::
+
+	Provide a brief overview of how the risk affects different outcomes, including data sources used by GBD, GBD assumptions, etc. Note that the [GBD-2019-Risk-Factors-Appendix-Risk-Effects-Model-Template]_ is a good source for this information in addition to the GBD risk modeler.
+
+.. todo::
+
+	Fill out the following table so that it reflects *all* entities affected by the risk in GBD 2019.
+
+.. list-table:: Affected Entities
+   :widths: 5 5 5 5 5
+   :header-rows: 1
+
+   * - Outcome
+     - Outcome type
+     - Outcome ID
+     - Affected measure
+     - Note
+   * -
+     -
+     -
+     -
+     -
+
+Vivarium Modeling Strategy
+--------------------------
+
+.. note::
+
+	This section will describe the Vivarium modeling strategy for risk effects. For a description of Vivarium modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_page_link>` page.
+
+.. todo::
+
+	Replace '2019_risk_exposure_page_link' with a reference to the appropriate risk exposure page in the above note.
+
+.. todo::
+
+  List the risk-outcome relationships that will be included in the risk effects model for this risk factor. Note whether the outcome in a risk-outcome relationship is a standard GBD risk-outcome relationship or is a custom relationship we are modeling for our simulation.
+
+.. list-table:: Risk Outcome Relationships for Vivarium
+   :widths: 5 5 5 5 5
+   :header-rows: 1
+
+   * - Outcome
+     - Outcome type
+     - Outcome ID
+     - Affected measure
+     - Note
+   * -
+     -
+     -
+     -
+     -
+
+Risk Outcome Pair #1
+++++++++++++++++++++
+
+.. todo::
+
+	Replace "Risk Outcome Pair #1" with the name of an affected entity for which a modeling strategy will be detailed. For additional risk outcome pairs, copy this section as many times as necessary and update the titles accordingly.
+
+.. todo::
+
+  Link to existing cause model document or other documentation of the outcome in the risk outcome pair.
+
+.. todo::
+
+	Describe which entitity the relative risks apply to (incidence rate, prevalence, excess mortality rate, etc.) and *how* to apply them (e.g. :code:`affected_measure * (1 - PAF) * RR`).
+
+  Be sure to specify the exact PAF that should be used in the above equation and either how to calculate it (see the `Population Attributable Fraction` section of the :ref:`Modeling Risk Factors <models_risk_factors>` document) or pull it (:code:`vivarium_inputs.interface.get_measure(risk_factor.{risk_name}, 'population_attributable_fraction')`, noting which affected entity and measure should be used)
+
+.. todo::
+
+  Complete the following table to list the relative risks for each risk exposure category on the outcome. Note that if there are many exposure categories, another format may be preferable.
+
+  Relative risks for a risk factor may be pulled from GBD at the draw-level using :code:`vivarium_inputs.interface.get_measure(risk_factor.{risk_name}, 'relative_risk')`. You can then calculate the mean value as well as 2.5th, and 97.5th percentiles across draws.
+
+  The relative risks in the table below should be included for easy reference and should match the relative risks pulled from GBD using the above code. In this case, update the :code:`Note` below to include the appropriate :code:`{risk_name}`.
+
+  If for any reason the modeling strategy uses non-GBD relative risks, update the :code:`Note` below to explain that the relative risks in the table are a custom, non-GBD data source and include a sampling strategy.
+
+.. note::
+
+  The following relative risks are displayed below for convenient reference. The relative risks in the table below should match the relative risks that can be pulled at the draw level using :code:`vivarium_inputs.interface.get_measure(risk_factor.{risk_name}, 'relative_risk')`.
+
+.. list-table:: Relative Risks
+   :widths: 5 5 5
+   :header-rows: 1
+
+   * - Exposure Category
+     - Relative Risk
+     - Note
+   * -
+     -
+     -
+
+Validation and Verification Criteria
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. todo::
+
+  List validation and verification criteria, including a list of variables that will need to be tracked and reported in the Vivarium simulation to ensure that the risk outcome relationship is modeled correctly
+
+Assumptions and Limitations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. todo::
+
+	List assumptions and limitations of this modeling strategy, including any potential issues regarding confounding, mediation, effect modification, and/or generalizability with the risk-outcome pair.
+
+Bias in the Population Attributable Fraction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As noted in the `Population Attributable Fraction` section of the :ref:`Modeling Risk Factors <models_risk_factors>` document, using a relative risk adjusted for confounding to compute a population attributable fraction at the population level will introduce bias.
+
+.. todo::
+
+	Outline the potential direction and magnitude of the potential PAF bias in GBD based on what is understood about the relationship of confounding between the risk and outcome pair using the framework discussed in the `Population Attributable Fraction` section of the :ref:`Modeling Risk Factors <models_risk_factors>` document.
+
+References
+----------
+
+.. todo::
+
+  Update references to GBD 2019 once published
+
+.. todo::
+
+  Update the GBD 2017 Risk Factor Methods appendix citation to be unique to your risk effects page (replace 'Risk-Effects-Model-Template' with '{Risk Name}-Effects')
+
+  Update the appropriate page numbers in the GBD risk factors methods appendix below
+
+  Add additional references as necessary
+
+.. [GBD-2017-Risk-Factors-Appendix-Risk-Effects-Model-Template]
+
+   Pages ???-??? in `Supplementary appendix 1 to the GBD 2017 Risk Factors Capstone <risk_factors_methods_appendix_>`_:
+
+     **(GBD 2017 Risk Factors Capstone)** GBD 2017 Risk Factor Collaborators. :title:`Global, regional, and national comparative risk assessment of 84 behavioural, environmental and occupational, and metabolic risks or clusters of risks for 195 countries and territories, 1990–2017: a systematic analysis for the Global Burden of Disease Study 2017`. Lancet 2018; 392: 1923-1994. DOI:
+     https://doi.org/10.1016/S0140-6736(18)32225-6
+
+.. _risk_factors_methods_appendix: https://www.thelancet.com/cms/10.1016/S0140-6736(18)32225-6/attachment/be595013-2d8b-4552-86e3-6c622827d2e9/mmc1.pdf

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -48,11 +48,7 @@ GBD 2019 Modeling Strategy
 
 .. note::
 
-	This section will describe the GBD modeling strategy for risk effects. For a description of GBD modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_page_link>` page.
-
-.. todo::
-
-	Replace '2019_risk_exposure_page_link' with a reference to the appropriate risk exposure page in the above note.
+	This section will describe the GBD modeling strategy for risk effects. For a description of GBD modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
 .. todo::
 
@@ -82,11 +78,7 @@ Vivarium Modeling Strategy
 
 .. note::
 
-	This section will describe the Vivarium modeling strategy for risk effects. For a description of Vivarium modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_page_link>` page.
-
-.. todo::
-
-	Replace '2019_risk_exposure_page_link' with a reference to the appropriate risk exposure page in the above note.
+	This section will describe the Vivarium modeling strategy for risk effects. For a description of Vivarium modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
 .. todo::
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -51,9 +51,12 @@ GBD 2019 Modeling Strategy
 	This section will describe the GBD modeling strategy for risk effects. For a description of GBD modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
 **The available data for deriving relative risk was only for all-cause mortality.**
-For each location, data were pooled across years, and the risk of all-cause mortality at the **early neonatal** period and **late neonatal period** at joint birthweight and gestational age combinations was calculated.
+For each location, data were pooled across years, and the risk of all-cause mortality at the **early neonatal period** and **late neonatal period** at joint birthweight and gestational age combinations was calculated.
 In all datasets except for the USA, sex-specific data were combined to maximise sample size. The USA analyses were sex-specific.
-Relative risks of mortality were calculated for each 500g and 2wk category of birthweight and gestational age.
+**Relative risks of all-cause mortality were calculated for each 500g and 2wk category of birthweight and gestational age.** [GBD-2019-Risk-Factors-Appendix]_
+
+Details of Relative Risk Estimation
++++++++++++++++++++++++++++++++++++
 
 To calculate relative risk at each 500-gram and two-week combination, logistic regression was first used to calculate mortality odds for each joint two-week gestational age and 500-gram birthweight category. Mortality odds were smoothed with Gaussian process regression, with the independent distributions of mortality odds by birthweight and mortality odds by gestational age serving as priors in the regression.
 A pooled country analysis of mortality risk in the early neonatal period and late neonatal period by SGA category in developing countries in Asia and sub-Saharan Africa were also converted into 500-gram and two-week bin mortality odds surfaces.
@@ -142,6 +145,8 @@ Therefore, the GBD modelers analysed the relative risk of all-cause mortality ac
 Restrictions
 ++++++++++++
 
+Risk Exposure Categories and TMREL
+++++++++++++++++++++++++++++++++++
 
 Vivarium Modeling Strategy
 --------------------------

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -53,7 +53,7 @@ GBD 2019 Modeling Strategy
 **The available data for deriving relative risk was only for all-cause mortality.**
 For each location, data were pooled across years, and the risk of all-cause mortality at the **early neonatal period** and **late neonatal period** at joint birthweight and gestational age combinations was calculated.
 In all datasets except for the USA, sex-specific data were combined to maximise sample size. The USA analyses were sex-specific.
-**Relative risks of all-cause mortality were calculated for each 500g and 2wk category of birthweight and gestational age.** [GBD-2019-Risk-Factors-Appendix]_
+**Relative risks of all-cause mortality were calculated for each 500g and 2wk category of birthweight and gestational age.** [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
 Details of Relative Risk Estimation
 +++++++++++++++++++++++++++++++++++
@@ -63,14 +63,14 @@ A pooled country analysis of mortality risk in the early neonatal period and lat
 
 The relative risk surfaces produced from microdata and the Asia and Africa surfaces produced from the pooled country analysis were meta-analysed, resulting in a meta- analysed mortality odds surface for each location. The meta-analysed mortality odds surface for each location was smoothed using Gaussian process regression and then converted into mortality risk.
 
-To calculate mortality relative risks, the risk of each joint two-week gestational age and 500-gram birthweight category were divided by the risk of mortality in the joint gestational age and birthweight category with the lowest mortality risk. [GBD-2019-Risk-Factors-Appendix]_
+To calculate mortality relative risks, the risk of each joint two-week gestational age and 500-gram birthweight category were divided by the risk of mortality in the joint gestational age and birthweight category with the lowest mortality risk. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
 Affected Outcomes
 +++++++++++++++++
 
 The available data for deriving relative risk was only for *all-cause mortality* rather than for cause-specific outcomes. The exception was the USA linked infant birth-death cohort data, which contained three-digit ICD causes of death, but also had nearly 30% of deaths coded to causes that are ill-defined, or intermediate, in the GBD cause classification system.
 
-Therefore, the GBD modelers analysed the relative risk of all-cause mortality across all available sources and selected outcomes based on criteria of biological plausibility. **Some causes, most notably congenital birth defects, haemoglobinopathies, malaria, and HIV/AIDS, were excluded based on the criteria that reverse causality could not be excluded.** [GBD-2019-Risk-Factors-Appendix]_
+Therefore, the GBD modelers analysed the relative risk of all-cause mortality across all available sources and selected outcomes based on criteria of biological plausibility. **Some causes, most notably congenital birth defects, haemoglobinopathies, malaria, and HIV/AIDS, were excluded based on the criteria that reverse causality could not be excluded.** [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
 .. list-table:: Affected Entities
    :widths: 5 5 5 5 5
@@ -242,7 +242,7 @@ As noted in the `Population Attributable Fraction` section of the :ref:`Modeling
 References
 ----------
 
-.. [GBD-2019-Risk-Factors-Appendix]
+.. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]
 
  Pages 167-177 in `Supplementary appendix 1 to the GBD 2019 Risk Factors Capstone <2019_risk_factors_methods_appendix_>`_:
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -78,7 +78,7 @@ The available data for deriving relative risk was only for *all-cause mortality*
 
 Therefore, the GBD modelers analysed the relative risk of all-cause mortality across all available sources and selected outcomes based on criteria of biological plausibility. **Some causes, most notably congenital birth defects, haemoglobinopathies, malaria, and HIV/AIDS, were excluded based on the criteria that reverse causality could not be excluded.** [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
-.. list-table:: Affected Entities
+.. list-table:: Entities Affected by LBWSG in GBD 2019
    :widths: 5 5 5 5 5
    :header-rows: 1
 
@@ -150,6 +150,48 @@ Therefore, the GBD modelers analysed the relative risk of all-cause mortality ac
 
 Restrictions
 ++++++++++++
+
+.. list-table:: Age, Sex, and Outcome Restrictions for LBWSG Relative Risks in GBD 2019
+  :widths: 15 15 20
+  :header-rows: 1
+
+  * - Restriction Type
+    - Value
+    - Notes
+  * - Male only
+    - False
+    -
+  * - Female only
+    - False
+    -
+  * - YLL only
+    - True
+    - Except for Neonatal preterm birth; see note below
+  * - YLD only
+    - False
+    -
+  * - Age group start
+    - Early neonatal (0-7 days, age_group_id = 2)
+    -
+  * - Age group end
+    - Late neonatal (7-28 days, age_group_id = 3)
+    - Except for Neonatal preterm birth; see note below
+
+.. note::
+
+  GBD 2019 attributes 100% of the DALYs due to Neonatal Preterm Birth to the LBWSG risk factor. In particular, the attribution includes YLDs as well as YLLs, and the age restrictions for the LBWSG-attributale DALYs are the same as the age restrictions for Neonatal Preterm Birth.
+
+  * **YLLs due to Neonatal preterm birth**, 100% attributable to LBWSG:
+
+    - Age group start = 2 (Early neonatal, 0-7 days)
+    - Age group end = 5 (1 to 4)
+
+  * **YLDs due to Neonatal preterm birth**, 100% attributable to LBWSG:
+
+    - Age group start = 2 (Early neonatal, 0-7 days)
+    - Age group end = 235 (95+)
+
+  Note that this attribution of DALYs is **not** based on the relative risks for all-cause mortality, but instead is based on the logic that all preterm births are due to short gestation by definition. Thus, if we include Neonatal Preterm Birth in our models, the relative risks likely must be handled differently for this cause.
 
 Risk Exposure Categories and TMREL
 ++++++++++++++++++++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -58,6 +58,23 @@ GBD 2019 Modeling Strategy
 
 	Fill out the following table so that it reflects *all* entities affected by the risk in GBD 2019.
 
+  .. code:: Python
+
+    [
+      (302, 'diarrheal_diseases'),
+      (322, 'lower_respiratory_infections'),
+      (328, 'upper_respiratory_infections'),
+      (329, 'otitis_media'),
+      (332, 'meningitis'),
+      (337, 'encephalitis'),
+      (381, 'neonatal_preterm_birth'),
+      (382, 'neonatal_encephalopathy_due_to_birth_asphyxia_and_trauma'),
+      (383, 'neonatal_sepsis_and_other_neonatal_infections'),
+      (384, 'hemolytic_disease_and_other_neonatal_jaundice'),
+      (385, 'other_neonatal_disorders'),
+      (686, 'sudden_infant_death_syndrome')
+    ]
+
 .. list-table:: Affected Entities
    :widths: 5 5 5 5 5
    :header-rows: 1
@@ -67,12 +84,66 @@ GBD 2019 Modeling Strategy
      - Outcome ID
      - Affected measure
      - Note
-   * -
+   * - Diarrheal diseases
+     - Cause
+     - 302
+     - Mortality (GBD YLLs)
      -
+   * - Lower respiratory infections
+     - Cause
+     - 322
+     - Mortality (GBD YLLs)
      -
+   * - Upper respiratory infections
+     - Cause
+     - 328
+     - Mortality (GBD YLLs)
      -
+   * - Otitis media
+     - Cause
+     - 329
+     - Mortality (GBD YLLs)
      -
-
+   * - Meningitis
+     - Cause
+     - 332
+     - Mortality (GBD YLLs)
+     -
+   * - Encephalitis
+     - Cause
+     - 337
+     - Mortality (GBD YLLs)
+     -
+   * - Neonatal preterm birth
+     - Cause
+     - 381
+     - Mortality and Morbidity (GBD YLLs and YLDs)
+     - 100% attributable to Low birthweight and short gestation
+   * - Neonatal encephalopathy due to birth asphyxia and trauma
+     - Cause
+     - 382
+     - Mortality (GBD YLLs)
+     -
+   * - Neonatal sepsis and other neonatal infections
+     - Cause
+     - 383
+     - Mortality (GBD YLLs)
+     -
+   * - Hemolytic disease and other neonatal jaundice
+     - Cause
+     - 384
+     - Mortality (GBD YLLs)
+     -
+   * - Other neonatal disorders
+     - Cause
+     - 385
+     - Mortality (GBD YLLs)
+     -
+   * - Sudden infant death syndrome
+     - Cause
+     - 686
+     - Mortality (GBD YLLs)
+     -
 Vivarium Modeling Strategy
 --------------------------
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -32,60 +32,6 @@
 Low Birthweight and Short Gestation Risk Effects
 ================================================
 
-.. important::
-
-   To begin documenting a risk effects in GBD 2019 for a Vivarium simulation, start by following these steps (after you have :ref:`created a new git branch
-   <contributing>` to work in):
-
-   #. Make a subdirectory :file:`{risk_name}/` in the folder
-      :file:`gbd2019/risk_effects/`, where :file:`{risk_name}` is replaced with the
-      (potentially shortened) name of the risk you are modeling, such as :file:`lbwsg/` or :file:`iron_deficiency/`. This
-      subdirectory is where you will put all the files for your risk effects model
-      documentation, including this document, image files, .csv files, etc.
-
-   #. Copy this template into your subdirectory and rename
-      it :code:`index.rst`.
-
-   #. Replace the `internal hyperlink target
-      <https://docutils.sourceforge.io/docs/user/rst/quickref.html#internal-hyperlink-targets>`_
-      :code:`.. _2019_risk_effect_template:` at the top of this file with a
-      unique reference label for your cause. The reference label should have the
-      form :samp:`.. _2019_{\{risk_name\}}_risk_effects:`, where
-      :samp:`{\{risk_name\}}` is replaced with a unique descriptive name or
-      abbreviation for your cause, e.g. :code:`.. _2019_lbwsg_risk_effects:`.
-
-   #. Delete this document's title above:
-
-      .. code:: reStructuredText
-
-         ===========================
-         Risk Effects Model Template
-         ===========================
-
-      Once the above title is deleted, all the other section titles will be
-      promoted up one level.
-
-   #. The subtitle below should now be the document's title. Replace the {Risk Name} text
-      in the below (sub)title with the full name of your risk in GBD 2019.
-
-      **Note:** Be sure to adjust the length of the title's underline
-      :code:`======` and overline :code:`======` to match the length of your
-      new document title, or you will get errors in the `section structure
-      <https://docutils.sourceforge.io/docs/user/rst/quickref.html#section-structure>`_
-      when Sphinx builds HTML from the :file:`index.rst` file.
-
-   #. Once you complete these steps, delete this :code:`.. important::`
-      `directive <https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#directives>`_
-      from :file:`index.rst`.
-
-.. todo::
-
-  Create the document title (insert appropriate risk name and remove from this to-do)
-
-  ========================
-  {Risk Name} Risk Effects
-  ========================
-
 .. contents::
    :local:
    :depth: 2

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -56,7 +56,7 @@ GBD 2019 Modeling Strategy
 
 .. todo::
 
-	Provide a brief overview of how the risk affects different outcomes, including data sources used by GBD, GBD assumptions, etc. Note that the [GBD-2019-Risk-Factors-Appendix-Risk-Effects-Model-Template]_ is a good source for this information in addition to the GBD risk modeler.
+	Provide a brief overview of how the risk affects different outcomes, including data sources used by GBD, GBD assumptions, etc. Note that the [GBD-2019-Risk-Factors-Appendix]_ is a good source for this information in addition to the GBD risk modeler.
 
 .. todo::
 
@@ -175,23 +175,14 @@ As noted in the `Population Attributable Fraction` section of the :ref:`Modeling
 References
 ----------
 
-.. todo::
+.. [GBD-2019-Risk-Factors-Appendix]
 
-  Update references to GBD 2019 once published
+ Pages 167-177 in `Supplementary appendix 1 to the GBD 2019 Risk Factors Capstone <2019_risk_factors_methods_appendix_>`_:
 
-.. todo::
+   **(GBD 2019 Risk Factors Capstone)** GBD 2019 Risk Factors Collaborators.
+   :title:`Global burden of 87 risk factors in 204 countries and territories,
+   1990–2019: a systematic analysis for the Global Burden of Disease Study
+   2019`. Lancet 2020; **396:** 1223–49. DOI:
+   https://doi.org/10.1016/S0140-6736(20)30752-2
 
-  Update the GBD 2017 Risk Factor Methods appendix citation to be unique to your risk effects page (replace 'Risk-Effects-Model-Template' with '{Risk Name}-Effects')
-
-  Update the appropriate page numbers in the GBD risk factors methods appendix below
-
-  Add additional references as necessary
-
-.. [GBD-2017-Risk-Factors-Appendix-Risk-Effects-Model-Template]
-
-   Pages ???-??? in `Supplementary appendix 1 to the GBD 2017 Risk Factors Capstone <risk_factors_methods_appendix_>`_:
-
-     **(GBD 2017 Risk Factors Capstone)** GBD 2017 Risk Factor Collaborators. :title:`Global, regional, and national comparative risk assessment of 84 behavioural, environmental and occupational, and metabolic risks or clusters of risks for 195 countries and territories, 1990–2017: a systematic analysis for the Global Burden of Disease Study 2017`. Lancet 2018; 392: 1923-1994. DOI:
-     https://doi.org/10.1016/S0140-6736(18)32225-6
-
-.. _risk_factors_methods_appendix: https://www.thelancet.com/cms/10.1016/S0140-6736(18)32225-6/attachment/be595013-2d8b-4552-86e3-6c622827d2e9/mmc1.pdf
+.. _2019_risk_factors_methods_appendix: https://www.thelancet.com/cms/10.1016/S0140-6736(20)30752-2/attachment/54711c7c-216e-485e-9943-8c6e25648e1e/mmc1.pdf

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -166,7 +166,7 @@ Restrictions
     -
   * - YLL only
     - True
-    - Except for Neonatal preterm birth; see note below
+    - Except for Neonatal preterm birth; see :ref:`note <note_on_preterm_birth_DALYs>` below
   * - YLD only
     - False
     -
@@ -175,7 +175,9 @@ Restrictions
     -
   * - Age group end
     - Late neonatal (7-28 days, age_group_id = 3)
-    - Except for Neonatal preterm birth; see note below
+    - Except for Neonatal preterm birth; see :ref:`note <note_on_preterm_birth_DALYs>` below
+
+.. _note_on_preterm_birth_DALYs:
 
 .. note::
 


### PR DESCRIPTION
Here's the start of the LBWSG Risk Effects document for GBD 2019. I have only worked on the "GBD 2019 Modeling Strategy" section, **not** the "Vivarium Modeling Strategy" section (all that content is from the template). Specifically:

* I added a citation to the GBD 2019 risk appendix
* I copied in a bunch of text (lightly edited) from the risk appendix to describe the GBD modeling strategy
* I made a table of the affected causes
* I made a table of the age/sex/outcome restrictions in GBD, with a note about how the PAF-of-1 cause Neonatal Preterm Birth is different