### PR TITLE
LBWSG relative risk interpolation

### DIFF
--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -326,7 +326,7 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
 #.  **Take logarithms:** Since the LBWSG relative risks vary widely between categories (from 1.0 in
     the TMREL up to more than 1600 in the highest risk category in some draws), we will do
     the interpolation in log space to keep everything at a reasonable scale, and then exponentiate the results.
-    Thus, we compute :math:`\log\bigl(\mathit{RR}(x_\text{cat}, y_\text{cat})\bigr)` for each of the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where :math:`\mathit{RR}` denotes the relative risk function as defined above, and :math:`\log` denotes the natural logarithm.
+    Thus, we compute :math:`\log(\mathit{RR}(x_\text{cat}, y_\text{cat}))` for each of the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where :math:`\mathit{RR}` denotes the relative risk function as defined above, and :math:`\log` denotes the natural logarithm.
 
 #.  **Define a rectangular grid:** In order to get SciPy's
     interpolation functions to work well, it helps to have the initial data
@@ -375,17 +375,28 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
 
     We can think of the grid :math:`G` as a "stepping stone" on our path to interpolating :math:`\log(\mathit{RR})` on the entire GAxBW rectangle :math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
 
-#.  **Extrapolate to the rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate :math:`\log(\mathit{RR})` from the category midpoints to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
+#.  **Extrapolate to the rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate :math:`\log(\mathit{RR})` from the category midpoints :math:`(x_\text{cat}, y_\text{cat})` to all points on the rectangular grid :math:`G`. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` before computing distances since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g). Explicitly,
+
+    - Divide all the GA coordinates of points in :math:`G` by 42, and divide
+      all the BW coordinates of points in :math:`G` by 4500.
+
+    - For each rescaled grid point :math:`(x_i/42, y_i/4500)`, find the
+      nearest rescaled category midpoint :math:`(x_\text{cat}/42,
+      y_\text{cat}/4500)`, and set :math:`\log (\mathit{RR}(x_i,
+      y_j)) = \log(\mathit{RR}(x_\text{cat}, y_\text{cat}))`.
 
 #.  **Interpolate to the full rectangle:** Use `bilinear interpolation`_ to fill in all values
     of :math:`\log(\mathit{RR})` in the entire GAxBW rectangle
     :math:`[0,42\text{wk}] \times [0,4500\text{g}]` from the
-    extrapolated values of :math:`\log(\mathit{RR})` on the grid in the previous
-    step. The interpolating function :math:`f` is continuous and piecewise
+    extrapolated values of :math:`\log(\mathit{RR})` on the grid :math:`G`. The interpolating function :math:`f = \log(\mathit{RR})` is continuous and piecewise
     bilinear. On each rectangle whose corners are neighboring grid points, it
-    has has the form :math:`f(x,y) = a + bx + cy + dxy` (where :math:`x` is
+    has has the form
+
+    .. math:: \log(\mathit{RR}(x,y)) = f(x,y) = a + bx + cy + dxy,
+
+    where :math:`x` is
     gestational age, :math:`y` is birthweight, and :math:`a,b,c,d` are
-    constants), so each "piece" of :math:`f` is linear in each variable
+    constants that depend on the function values at the rectangle's corners, so each "piece" of :math:`f` is linear in :math:`x` and :math:`y`
     separately and is quadratic as a function of two variables.
 
 #.  **Exponentiate:**

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -265,6 +265,27 @@ Vivarium Modeling Strategy
 Interpolation of Relative Risks
 +++++++++++++++++++++++++++++++
 
+GBD models the relative risk for all-cause mortality on each 500g and 2wk
+category of birthweight (BW) and gestational age (GA). Thus, if we assume a
+constant relative risk on each rectangular LBWSG category, the relative risk
+estimates define a piecewise constant function on the union of the LBWSG
+categories, which is a subset of the GAxBW rectangle :math:`[0,42\text{wk}]
+\times [0,4500\text{g}]`. This relative risk function is discontinuous,
+jumping from one value to another at the rectangle boundaries between the LBWSG
+categories (i.e. when GA is a multiple of 2 or BW is a multiple of 500).
+
+We are interested in coming up with a smooth (or at least continuous) risk
+surface that interpolates between the relative risks estimated by GBD. The main
+reasons for doing so are:
+
+- With piecewise constant RRs, any intervention that has an effect on
+  birthweight or gestational age will only affect simulants that are near the
+  boundary of one of the LBWSG categories. If we can create a continuously
+  varying RR function instead, then every simulant will have the opportunity to
+  get the effect of the intervention.
+
+- A continuously varying RR function probably better matches reality.
+
 Affected Outcomes
 +++++++++++++++++
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -314,8 +314,8 @@ Since the region on which the GBD RRs are defined is `non-convex <convex set_>`_
 interpolating between the RRs is not completely straightforward. Using SciPy's interpolation package, it required a two-step process of
 first *extrapolating* the relative risks to a complete rectangular grid, and
 then *interpolating the extrapolated values* to the full rectangular GAxBW
-domain. Here is a summary of the procedure Nathaniel used to interpolate the
-LBWSG RRs for the large-scale food fortification project in 2021.
+domain. Here is a description of the procedure Nathaniel used to interpolate the
+LBWSG RRs for the large-scale food fortification project in March 2021.
 
 #.  **Start at category midpoints:** We will assume that the relative risk
     at the *midpoint* of each
@@ -328,18 +328,19 @@ LBWSG RRs for the large-scale food fortification project in 2021.
     the interpolation in log space to keep everything at a reasonable scale, and then exponentiate the results.
     Thus, we compute :math:`\log\bigl(\mathit{RR}(x_\text{cat}, y_\text{cat})\bigr)` for each of the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where :math:`\mathit{RR}` denotes the relative risk function as defined above, and :math:`\log` denotes the natural logarithm.
 
-#.  **Define a complete rectangular grid:** In order to get SciPy's
+#.  **Define a rectangular grid:** In order to get SciPy's
     interpolation functions to work well, it helps to have the initial data
-    points defined on a rectangular grid. The LBWSG category midpoints
-    :math:`(x_\text{cat}, y_\text{cat})` define a *partial* rectangular grid, so
-    we would like to extrapolate the values of log(RR) to the "missing" points
-    on the full grid :math:`G` spanned by these midpoints. We will use a simple interpolation
-    strategy (nearest-neighbor) to extrapolate to the grid :math:`G`, then use a more sophisticated method (bilinear interpolation) to fill in values between the grid points. In addition to the midpoints, we will
+    points defined on a rectangular grid.
+    The LBWSG category midpoints
+    :math:`(x_\text{cat}, y_\text{cat})` define a *partial* rectangular grid,
+    so our strategy will be to use a simple interpolation method (`nearest-neighbor <nearest-neighbor interpolation_>`_) to extrapolate values of :math:`\log(\mathit{RR})` to the "missing" points
+    on the full grid :math:`G` spanned by the category midpoints, and then use a more sophisticated method (`bilinear interpolation`_) to fill in values of :math:`\log(\mathit{RR})` between the grid points.
+
+    In addition to the category midpoints, we will
     also include grid points on the GAxBW rectangle's boundary to guarantee that
     our interpolation will cover the entire domain defined by the LBWSG
     categories.
-
-    To define the rectangular grid :math:`G` more precisely, we first take the the unique GA and BW coordinates of the category midpoints plus the boundary values,
+    To define the rectangular grid :math:`G` precisely, we first take the the unique GA and BW coordinates of the 58 category midpoints, plus the boundary values,
 
     .. math::
 
@@ -348,9 +349,9 @@ LBWSG RRs for the large-scale food fortification project in 2021.
         \cup \{0,42\}\\
       \text{bw_grid} &=
         \{ y_\text{cat} : \text{cat is a LBWSG category}\}
-        \cup \{0,4500\}
+        \cup \{0,4500\},
 
-    and then define the rectangular grid as the Cartesian product
+    and then define the rectangular grid :math:`G` as the `Cartesian product`_,
 
     .. math:: G = \text{ga_grid} \times \text{bw_grid}.
 
@@ -364,7 +365,7 @@ LBWSG RRs for the large-scale food fortification project in 2021.
         &x_9&=37.5,\, &x_{10}&=39,\,
         &&x_{11}=41, x_{12}=42\\
       y_0&=0,\, &y_1&=250,\, &y_2&=750,\, &&\ldots,\,
-        &y_9&=4250,\, &y_{10}&=4500\,
+        &y_9&=4250,\, &y_{10}&=4500,\,
         &&
       \end{alignat*}
 
@@ -394,6 +395,7 @@ LBWSG RRs for the large-scale food fortification project in 2021.
 .. _convex set: https://en.wikipedia.org/wiki/Convex_set
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation
 .. _bilinear interpolation: https://en.wikipedia.org/wiki/Bilinear_interpolation
+.. _Cartesian product: https://en.wikipedia.org/wiki/Cartesian_product
 
 Implementation of RR Interpolation in SciPy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -329,39 +329,32 @@ LBWSG RRs for the large-scale food fortification project in 2021.
     Thus, we compute :math:`\log\bigl(\mathit{RR}(x_\text{cat}, y_\text{cat})\bigr)` for each of the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where :math:`\mathit{RR}` denotes the relative risk function as defined above, and :math:`\log` denotes the natural logarithm.
 
 #.  **Define a complete rectangular grid:** In order to get SciPy's
-
     interpolation functions to work well, it helps to have the initial data
     points defined on a rectangular grid. The LBWSG category midpoints
     :math:`(x_\text{cat}, y_\text{cat})` define a *partial* rectangular grid, so
     we would like to extrapolate the values of log(RR) to the "missing" points
-    on the full grid spanned by these midpoints, using a simple interpolation
-    strategy such as nearest-neighbor. In addition to the midpoints, we will
+    on the full grid :math:`G` spanned by these midpoints. We will use a simple interpolation
+    strategy (nearest-neighbor) to extrapolate to the grid :math:`G`, then use a more sophisticated method (bilinear interpolation) to fill in values between the grid points. In addition to the midpoints, we will
     also include grid points on the GAxBW rectangle's boundary to guarantee that
     our interpolation will cover the entire domain defined by the LBWSG
     categories.
 
-    We will use the rectangular grid as a "stepping stone" to actual interpolation we want to do.
-
-    To define the rectangular grid, we first define sequences :math:`x_i` and :math:`y_j` of the unique category midpoints plus the boundary values for GA and BW:
+    To define the rectangular grid :math:`G` more precisely, we first take the the unique GA and BW coordinates of the category midpoints plus the boundary values,
 
     .. math::
 
-      \text{bw_grid} &=
-        \{ x : (x,y) \text{ is a LBWSG category midpoint or }
-        x\in \{0,42\}\}\\
       \text{ga_grid} &=
-        \{ y : (x,y) \text{ is a LBWSG category midpoint or }
-        y\in \{0,4500\}\}\\
-      \text{bw_grid} &=
-        \{ x : x = x_\text{cat} \text{ for some LBWSG category cat or }
-        x\in \{0,42\}\}\\
-      \text{bw_grid} &=
         \{ x_\text{cat} : \text{cat is a LBWSG category}\}
         \cup \{0,42\}\\
+      \text{bw_grid} &=
+        \{ y_\text{cat} : \text{cat is a LBWSG category}\}
+        \cup \{0,4500\}
 
-    and define :math:`G = \text{bw_grid} \times \text{ga_grid}`
+    and then define the rectangular grid as the Cartesian product
 
-    More explicitly, we can list the 13 points in :math:`\text{bw_grid}` and 11 points in :math:`\text{ga_grid}` in increasing order and define :math:`G` as the set of 143 pairs coming from these two sets:
+    .. math:: G = \text{ga_grid} \times \text{bw_grid}.
+
+    More explicitly, we can list the 13 :math:`x`-coordinates in :math:`\text{ga_grid}` and 11 :math:`y`-coordinates in :math:`\text{bw_grid}` in increasing order,
 
     .. math::
       :nowrap:
@@ -371,12 +364,15 @@ LBWSG RRs for the large-scale food fortification project in 2021.
         &x_9&=37.5,\, &x_{10}&=39,\,
         &&x_{11}=41, x_{12}=42\\
       y_0&=0,\, &y_1&=250,\, &y_2&=750,\, &&\ldots,\,
-      &y_9&=4250,\, &y_{10}&=4500\, &&
-      %x_0 &=0, x_1=12, x_2=25, \ldots, x_9=37.5, x_{10}=39, x_{11}=41, x_{12}=42\\
-      %y_0 &=0, y_1=250, y_2=750, \ldots, y_9=4250, y_{10}=4500,
+        &y_9&=4250,\, &y_{10}&=4500\,
+        &&
       \end{alignat*}
 
-    and define a rectangular grid of 143 points by :math:`G = \{(x_i,y_j) : 0\le i\le 12, 0\le j\le 10\}`.
+    and then the rectangular grid of 143 points is
+
+    .. math:: G = \{(x_i,y_j) : 0\le i\le 12, 0\le j\le 10\}.
+
+    We can think of the grid :math:`G` as a "stepping stone" on our path to interpolating :math:`\log(\mathit{RR})` on the entire GAxBW rectangle :math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
 
 #.  **Extrapolate to the rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate :math:`\log(\mathit{RR})` from the category midpoints to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -333,6 +333,16 @@ March 2021.
     \times [0,4500\text{g}]`, starting with the values
     :math:`\mathit{RR}(x_\text{cat},y_\text{cat})` at the 58 category midpoints.
 
+    .. note::
+
+      One could consider using points other than the category midpoints to
+      anchor the RRs. For example, perhaps it would be better to assign the GBD
+      relative risk to the "average location of the category" with respect to
+      prevalence, or to choose a point so that the average RR for the category
+      matches the RR from GBD. However, this would (1) require using exposure
+      data as well as RR data, which varies by location, and would (2) require
+      more time on the parts of the human and the computer to implement.
+
 #.  **Take logarithms:** Since the LBWSG relative risks vary widely between
     categories (from 1.0 in the TMREL up to more than 1600 in the highest risk
     category in some draws), we will do the interpolation in log space to keep

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -399,9 +399,9 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
     constants that depend on the function values at the rectangle's corners, so each "piece" of :math:`f` is linear in :math:`x` and :math:`y`
     separately and is quadratic as a function of two variables.
 
-#.  **Exponentiate:**
+#.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, recover the relative risks by computing :math:`\mathit{RR}(x,y) = \exp(f(x,y))`. The above interpolation strategy guarantees that the interpolated RRs will remain between the minimum and maximum RR values in GBD.
 
-#.  **Reset RRs in TMREL categories to 1:**
+#.  **Reset RRs in TMREL categories to 1:** Since we assumed that the RR values were equal to the GBD RRs at the *midpoints* of the LBWSG categories, and the interpolated RRs vary continuously, the interpolated RRs in the TMREL categories will be greater than 1 as GA or BW approaches a category of higher relative risk. In order to be consistent with GBD, we reset the RR to 1.0 in each of the four TMREL categories (cat53, cat54, cat55, cat56) after interpolation. This will introduce some discontinuity at the boundaries of the TMREL categories, but that is an acceptable tradeoff for consistency with GBD.
 
 .. _convex set: https://en.wikipedia.org/wiki/Convex_set
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -262,6 +262,12 @@ Vivarium Modeling Strategy
 
 	This section will describe the Vivarium modeling strategy for risk effects. For a description of Vivarium modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
+Interpolation of Relative Risks
++++++++++++++++++++++++++++++++
+
+Affected Outcomes
++++++++++++++++++
+
 .. todo::
 
   List the risk-outcome relationships that will be included in the risk effects model for this risk factor. Note whether the outcome in a risk-outcome relationship is a standard GBD risk-outcome relationship or is a custom relationship we are modeling for our simulation.

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -474,6 +474,17 @@ March 2021.
         if it would actually be better to keep the interpolated RRs even though
         they are greater than 1 in some regions of the TMREL categories.
 
+        Another option would be to add grid points at the corners of the TMREL
+        categories, and set the RRs of these points to 1 before interpolating.
+        This would force the the interpolated RRs to be 1 on the entire TMREL
+        region while keeping the RR function continuous. This strategy would
+        introduce 2 new :math:`x`-coordinates and 2 new :math:`y`-coordinates,
+        increasing the grid size to :math:`15\times 13 = 195` and the number of
+        interpolation rectangles to :math:`14\times 12 = 168`. This may or may
+        not slow down the interpolation by a noticeable amount. Some care should
+        be taken if using this approach, as it's possible that the interpolated
+        RR values near the TMREL categories could change in undesirable ways.
+
 .. _large-scale food fortification project: https://github.com/ihmeuw/vivarium_research_lsff
 
 .. _convex set: https://en.wikipedia.org/wiki/Convex_set

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -315,7 +315,7 @@ interpolating between the RRs is not completely straightforward. Using `SciPy's 
 first *extrapolating* the relative risks to a complete rectangular grid, and
 then *interpolating the extrapolated values* to the full rectangular GAxBW
 domain. Here is a description of the procedure Nathaniel used to interpolate the
-LBWSG RRs for the large-scale food fortification project in March 2021.
+LBWSG RRs for the `large-scale food fortification project`_ in March 2021.
 
 #.  **Start at category midpoints:** We will assume that the relative risk
     at the *midpoint* of each
@@ -414,6 +414,8 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
 
         It may be worth discussing the strategy of resetting the RRs to 1 with the GBD modelers to see if it matches their conception of the TMREL, or if it would actually be better to keep the interpolated RRs even though they are greater than 1 in some regions of the TMREL categories.
 
+.. _large-scale food fortification project: https://github.com/ihmeuw/vivarium_research_lsff
+
 .. _convex set: https://en.wikipedia.org/wiki/Convex_set
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation
 .. _bilinear interpolation: https://en.wikipedia.org/wiki/Bilinear_interpolation
@@ -428,6 +430,23 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
 
 Implementation of RR Interpolation in SciPy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. todo::
+
+  Show Python code that implements the above procedure. In the meantime, here
+  are the original notebooks where I figured out how to do it:
+
+  - https://github.com/ihmeuw/vivarium_data_analysis/blob/main/pre_processing/lbwsg/2021_03_09b_plot_lbwsg_rr_interpolation_using_griddata.ipynb
+  - https://github.com/ihmeuw/vivarium_data_analysis/blob/main/pre_processing/lbwsg/2021_03_10a_plot_two_step_interpolated_rrs_for_lbwsg.ipynb
+  - https://github.com/ihmeuw/vivarium_data_analysis/blob/main/pre_processing/lbwsg/2021_03_16a_lbwsg_compare_two_step_interpolation_plots.ipynb
+
+  Here's a link to Jupyter nbviewer in case GitHub sucks:
+
+  - https://nbviewer.jupyter.org/
+
+  And here's my implementation of RR interpolation for a nanosim:
+
+  - https://github.com/ihmeuw/vivarium_research_lsff/blob/main/nanosim_models/lbwsg.py#L722
 
 Affected Outcomes in Vivarium
 +++++++++++++++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -68,8 +68,8 @@ category of birthweight and gestational age.**
 
   - 2 of the 58 categories (cat2 and cat8) have an age range of 0-24 weeks.
 
-  - 14 of the 58 categories have a 1-week age range, either 36-37 weeks or 37-38 weeks, because 37 weeks
-    is the usual cutoff for defining preterm birth.
+  - 14 of the 58 categories have a 1-week age range, either 36-37 weeks or 37-38
+    weeks, because 37 weeks is the usual cutoff for defining preterm birth.
 
   For simplicity, we will generally refer to "500g and 2wk categories," with the understanding that there are some exceptions.
 
@@ -284,15 +284,15 @@ relative risk estimates define a `piecewise constant function`_ on the union of
 the LBWSG categories, which is a subset of the GAxBW rectangle
 :math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
 
-This piecewise constant relative risk function is `discontinuous <continuous function_>`_, jumping from
-one value to another at the linear boundaries between the LBWSG categories
-(usually when GA is a multiple of 2 or BW is a multiple of 500), and the
-relative risk does not change at all within each LBWSG category. Therefore, any
-simulated intervention that affects birthweight or gestational age (e.g. a
-nutritional supplement given to pregnant mothers to increase the birthweight of
-their newborns) can only have an effect on a small percentage of our simulants,
-namely those whose birthweight or gestational age is near the boundary of one of
-the LBWSG categories.
+This piecewise constant relative risk function is `discontinuous <continuous
+function_>`_, jumping from one value to another at the linear boundaries between
+the LBWSG categories (usually when GA is a multiple of 2 or BW is a multiple of
+500), and the relative risk does not change at all within each LBWSG category.
+Therefore, any simulated intervention that affects birthweight or gestational
+age (e.g. a nutritional supplement given to pregnant mothers to increase the
+birthweight of their newborns) can only have an effect on a small percentage of
+our simulants, namely those whose birthweight or gestational age is near the
+boundary of one of the LBWSG categories.
 
 To correct for this deficiency, we are interested in coming up with a
 continuously varying risk surface that interpolates between the relative risks
@@ -310,37 +310,53 @@ risk surface.
 Strategy for Interpolating Relative Risks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since the region on which the GBD RRs are defined is `non-convex <convex set_>`_,
-interpolating between the RRs is not completely straightforward. Using `SciPy's interpolation package <scipy.interpolate_>`_, it required a two-step process of
-first *extrapolating* the relative risks to a complete rectangular grid, and
-then *interpolating the extrapolated values* to the full rectangular GAxBW
-domain. Here is a description of the procedure Nathaniel used to interpolate the
-LBWSG RRs for the `large-scale food fortification project`_ in March 2021.
+Since the region on which the GBD RRs are defined is `non-convex <convex
+set_>`_, interpolating between the RRs is not completely straightforward. Using
+`SciPy's interpolation package <scipy.interpolate_>`_, it required a two-step
+process of first *extrapolating* the relative risks to a complete rectangular
+grid, and then *interpolating the extrapolated values* to the full rectangular
+GAxBW domain. Here is a description of the procedure Nathaniel used to
+interpolate the LBWSG RRs for the `large-scale food fortification project`_ in
+March 2021.
 
-#.  **Start at category midpoints:** We will assume that the relative risk
-    at the *midpoint* of each
-    rectangular LBWSG category is equal to the relative risk for that category
-    as estimated by GBD.
-    That is, if :math:`\mathit{RR}_\text{cat}` is the GBD relative risk for the LBWSG category ':math:`\text{cat}`', and the midpoint of :math:`\text{cat}` is :math:`(x_\text{cat}, y_\text{cat})`, we will assume that :math:`\mathit{RR}(x_\text{cat},y_\text{cat}) = \mathit{RR}_\text{cat}`, where :math:`\mathit{RR}(x,y)` denotes the relative risk at gestational age :math:`x` and birthweight :math:`y`. Our goal is to assign an interpolated value to :math:`\mathit{RR}(x,y)` for all :math:`(x,y)\in [0,42\text{wk}] \times [0,4500\text{g}]`, starting with the values :math:`\mathit{RR}(x_\text{cat},y_\text{cat})` at the 58 category midpoints.
+#.  **Start at category midpoints:** We will assume that the relative risk at
+    the *midpoint* of each rectangular LBWSG category is equal to the relative
+    risk for that category as estimated by GBD. That is, if
+    :math:`\mathit{RR}_\text{cat}` is the GBD relative risk for the LBWSG
+    category ':math:`\text{cat}`', and the midpoint of :math:`\text{cat}` is
+    :math:`(x_\text{cat}, y_\text{cat})`, we will assume that
+    :math:`\mathit{RR}(x_\text{cat},y_\text{cat}) = \mathit{RR}_\text{cat}`,
+    where :math:`\mathit{RR}(x,y)` denotes the relative risk at gestational age
+    :math:`x` and birthweight :math:`y`. Our goal is to assign an interpolated
+    value to :math:`\mathit{RR}(x,y)` for all :math:`(x,y)\in [0,42\text{wk}]
+    \times [0,4500\text{g}]`, starting with the values
+    :math:`\mathit{RR}(x_\text{cat},y_\text{cat})` at the 58 category midpoints.
 
-#.  **Take logarithms:** Since the LBWSG relative risks vary widely between categories (from 1.0 in
-    the TMREL up to more than 1600 in the highest risk category in some draws), we will do
-    the interpolation in log space to keep everything at a reasonable scale, and then exponentiate the results.
-    Thus, we compute :math:`\log(\mathit{RR}(x_\text{cat}, y_\text{cat}))` for each of the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where :math:`\mathit{RR}` denotes the relative risk function as defined above, and :math:`\log` denotes the natural logarithm.
+#.  **Take logarithms:** Since the LBWSG relative risks vary widely between
+    categories (from 1.0 in the TMREL up to more than 1600 in the highest risk
+    category in some draws), we will do the interpolation in log space to keep
+    everything at a reasonable scale, and then exponentiate the results. Thus,
+    we compute :math:`\log(\mathit{RR}(x_\text{cat}, y_\text{cat}))` for each of
+    the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where
+    :math:`\mathit{RR}` denotes the relative risk function as defined above, and
+    :math:`\log` denotes the natural logarithm.
 
-#.  **Define a rectangular grid:** In order to get SciPy's
-    interpolation functions to work well, it helps to have the initial data
-    points defined on a rectangular grid.
-    The LBWSG category midpoints
-    :math:`(x_\text{cat}, y_\text{cat})` define a *partial* rectangular grid,
-    so our strategy will be to use a simple interpolation method (`nearest-neighbor <nearest-neighbor interpolation_>`_) to extrapolate values of :math:`\log(\mathit{RR})` to the "missing" points
-    on the full grid :math:`G` spanned by the category midpoints, and then use a more sophisticated method (`bilinear interpolation`_) to fill in values of :math:`\log(\mathit{RR})` between the grid points.
+#.  **Define a rectangular grid:** In order to get SciPy's interpolation
+    functions to work well, it helps to have the initial data points defined on
+    a rectangular grid. The LBWSG category midpoints :math:`(x_\text{cat},
+    y_\text{cat})` define a *partial* rectangular grid, so our strategy will be
+    to use a simple interpolation method (`nearest-neighbor <nearest-neighbor
+    interpolation_>`_) to extrapolate values of :math:`\log(\mathit{RR})` to the
+    "missing" points on the full grid :math:`G` spanned by the category
+    midpoints, and then use a more sophisticated method (`bilinear
+    interpolation`_) to fill in values of :math:`\log(\mathit{RR})` between the
+    grid points.
 
-    In addition to the category midpoints, we will
-    also include grid points on the GAxBW rectangle's boundary to guarantee that
-    our interpolation will cover the entire domain defined by the LBWSG
-    categories.
-    To define the rectangular grid :math:`G` precisely, we first take the the unique GA and BW coordinates of the 58 category midpoints, plus the boundary values,
+    In addition to the category midpoints, we will also include grid points on
+    the GAxBW rectangle's boundary to guarantee that our interpolation will
+    cover the entire domain defined by the LBWSG categories. To define the
+    rectangular grid :math:`G` precisely, we first take the the unique GA and BW
+    coordinates of the 58 category midpoints, plus the boundary values,
 
     .. math::
 
@@ -356,7 +372,9 @@ LBWSG RRs for the `large-scale food fortification project`_ in March 2021.
 
     .. math:: G = \text{ga_grid} \times \text{bw_grid}.
 
-    More explicitly, we can list the 13 :math:`x`-coordinates in :math:`\text{ga_grid}` and 11 :math:`y`-coordinates in :math:`\text{bw_grid}` in increasing order,
+    More explicitly, we can list the 13 :math:`x`-coordinates in
+    :math:`\text{ga_grid}` and 11 :math:`y`-coordinates in
+    :math:`\text{bw_grid}` in increasing order,
 
     .. math::
       :nowrap:
@@ -374,9 +392,17 @@ LBWSG RRs for the `large-scale food fortification project`_ in March 2021.
 
     .. math:: G = \{(x_i,y_j) : 0\le i\le 12, 0\le j\le 10\}.
 
-    We can think of the grid :math:`G` as a "stepping stone" on our path to interpolating :math:`\log(\mathit{RR})` on the entire GAxBW rectangle :math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
+    We can think of the grid :math:`G` as a "stepping stone" on our path to
+    interpolating :math:`\log(\mathit{RR})` on the entire GAxBW rectangle
+    :math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
 
-#.  **Extrapolate to the rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate :math:`\log(\mathit{RR})` from the category midpoints :math:`(x_\text{cat}, y_\text{cat})` to all points on the rectangular grid :math:`G`. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` before computing distances since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g). Explicitly,
+#.  **Extrapolate to the rectangular grid:** Use `nearest-neighbor
+    interpolation`_ to extrapolate :math:`\log(\mathit{RR})` from the category
+    midpoints :math:`(x_\text{cat}, y_\text{cat})` to all points on the
+    rectangular grid :math:`G`. When doing this extrapolation, we rescale both
+    the GA and BW coordinates to the interval :math:`[0,1]` before computing
+    distances since the scales of gestational age and birthweight are
+    incomparable and drastically different (0-42wk vs. 0-4500g). Explicitly,
 
     - Divide all the GA coordinates of points in :math:`G` by 42, and divide
       all the BW coordinates of points in :math:`G` by 4500.
@@ -386,33 +412,56 @@ LBWSG RRs for the `large-scale food fortification project`_ in March 2021.
       y_\text{cat}/4500)`, and set :math:`\log (\mathit{RR}(x_i,
       y_j)) = \log(\mathit{RR}(x_\text{cat}, y_\text{cat}))`.
 
-    The rescaled nearest-neighbor interpolation can be easily implemented using SciPy's `griddata`_ function (with ``method='nearest'`` and ``rescale='True'``) or `NearestNDInterpolator`_ class (with ``rescale='True'``).
+    The rescaled nearest-neighbor interpolation can be easily implemented using
+    SciPy's `griddata`_ function (with ``method='nearest'`` and
+    ``rescale='True'``) or `NearestNDInterpolator`_ class (with
+    ``rescale='True'``).
 
-#.  **Interpolate to the full rectangle:** Use `bilinear interpolation`_ to fill in all values
-    of :math:`\log(\mathit{RR})` in the entire GAxBW rectangle
-    :math:`[0,42\text{wk}] \times [0,4500\text{g}]` from the
-    extrapolated values of :math:`\log(\mathit{RR})` on the grid :math:`G`. The interpolating function :math:`f = \log(\mathit{RR})` is continuous and piecewise
-    bilinear. On each rectangle whose corners are neighboring grid points, it
-    has has the form
+#.  **Interpolate to the full rectangle:** Use `bilinear interpolation`_ to
+    fill in all values of :math:`\log(\mathit{RR})` in the entire GAxBW
+    rectangle :math:`[0,42\text{wk}] \times [0,4500\text{g}]` from the
+    extrapolated values of :math:`\log(\mathit{RR})` on the grid :math:`G`. The
+    interpolating function :math:`f = \log(\mathit{RR})` is continuous and
+    piecewise bilinear. On each rectangle whose corners are neighboring grid
+    points, it has has the form
 
     .. math::
 
       \log(\mathit{RR}(x,y)) = f(x,y) = a + bx + cy + dxy
       \quad (x_i\le x\le x_{i+1}, y_j\le y\le y_{j+1}),
 
-    where :math:`x` is
-    gestational age, :math:`y` is birthweight, and :math:`a,b,c,d` are
-    constants that depend on the function values at the rectangle's corners. There are 120 such rectangles indexed by :math:`i` and :math:`j`, and  each such rectangular "piece" of :math:`f` is linear in :math:`x` and :math:`y`
-    separately and is quadratic as a function of two variables.
-    The bilinear interpolation can be easily implemented using either SciPy's `RectBivariateSpline`_ class (with ``kx=1,ky=1``), or `interp2d`_ function (with ``kind='linear'``), or `RegularGridInterpolator`_ class (with ``method='linear'``).
+    where :math:`x` is gestational age, :math:`y` is birthweight, and
+    :math:`a,b,c,d` are constants that depend on the function values at the
+    rectangle's corners. There are 120 such rectangles indexed by :math:`i` and
+    :math:`j`, and  each such rectangular "piece" of :math:`f` is linear in
+    :math:`x` and :math:`y` separately and is quadratic as a function of two
+    variables. The bilinear interpolation can be easily implemented using either
+    SciPy's `RectBivariateSpline`_ class (with ``kx=1,ky=1``), or `interp2d`_
+    function (with ``kind='linear'``), or `RegularGridInterpolator`_ class (with
+    ``method='linear'``).
 
-#.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, we recover the relative risks by computing :math:`\mathit{RR}(x,y) = \exp(f(x,y))`. The above interpolation strategy guarantees that the interpolated RRs will remain between the minimum and maximum RR values in GBD.
+#.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, we
+    recover the relative risks by computing :math:`\mathit{RR}(x,y) =
+    \exp(f(x,y))`. The above interpolation strategy guarantees that the
+    interpolated RRs will remain between the minimum and maximum RR values in
+    GBD.
 
-#.  **Reset RRs in TMREL categories to 1:** Since we assumed that the RR values were equal to the GBD RRs at the *midpoints* of the LBWSG categories, and the interpolated RRs vary continuously, the interpolated RRs in the TMREL categories will be greater than 1 as GA or BW approaches a category of higher relative risk. In order to be consistent with GBD, we reset the RR to 1.0 in each of the four TMREL categories (cat53, cat54, cat55, cat56) after interpolation. This will introduce some discontinuity at the boundaries of the TMREL categories, but that is an acceptable tradeoff for consistency with GBD.
+#.  **Reset RRs in TMREL categories to 1:** Since we assumed that the RR values
+    were equal to the GBD RRs at the *midpoints* of the LBWSG categories, and
+    the interpolated RRs vary continuously, the interpolated RRs in the TMREL
+    categories will be greater than 1 as GA or BW approaches a category of
+    higher relative risk. In order to be consistent with GBD, we reset the RR to
+    1.0 in each of the four TMREL categories (cat53, cat54, cat55, cat56) after
+    interpolation. This will introduce some discontinuity at the boundaries of
+    the TMREL categories, but that is an acceptable tradeoff for consistency
+    with GBD.
 
     .. note::
 
-        It may be worth discussing the strategy of resetting the RRs to 1 with the GBD modelers to see if it matches their conception of the TMREL, or if it would actually be better to keep the interpolated RRs even though they are greater than 1 in some regions of the TMREL categories.
+        It may be worth discussing the strategy of resetting the RRs to 1 with
+        the GBD modelers to see if it matches their conception of the TMREL, or
+        if it would actually be better to keep the interpolated RRs even though
+        they are greater than 1 in some regions of the TMREL categories.
 
 .. _large-scale food fortification project: https://github.com/ihmeuw/vivarium_research_lsff
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -61,6 +61,22 @@ USA analyses were sex-specific.
 category of birthweight and gestational age.**
 [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
 
+.. note::
+
+  The risk appendix's description of 2-week age bins is not totally accurate;
+  there are two exceptions:
+
+  - There are two 1-week age bins, 36-37 weeks and 37-38 weeks, because 37 weeks
+    is the usual cutoff for defining "preterm birth." 14 of the 58 LBWSG
+    categories have an age window of 1 week: cat24, cat25, cat35, cat36, cat40,
+    cat42, cat45, cat46, cat47, cat48, cat49, cat50, cat106, cat124.
+
+  - There are two low-prevalence, high-risk categories (cat2 and cat8) where
+    the age range is 0-24 weeks.
+
+  Despite the non-uniformity in gestational age cutoffs, for simplicity this
+  documentation page will generally refer to "500g and 2wk categories," with the understanding that some categories span more or less than 2 weeks.
+
 Details of Relative Risk Estimation
 +++++++++++++++++++++++++++++++++++
 
@@ -104,8 +120,8 @@ mortality risk. [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_
   by year/age_group/sex. If we need clarification on exactly how the relative
   risks were calculated, we should consult the GBD modelers.
 
-Affected Outcomes
-+++++++++++++++++
+Affected Outcomes in GBD 2019
++++++++++++++++++++++++++++++
 
 The available data for deriving relative risk was only for *all-cause mortality*
 rather than for cause-specific outcomes. The exception was the USA linked infant
@@ -262,10 +278,10 @@ Vivarium Modeling Strategy
 
 	This section will describe the Vivarium modeling strategy for risk effects. For a description of Vivarium modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
-Interpolation of Relative Risks
-+++++++++++++++++++++++++++++++
+Interpolation of LBwSG Relative Risks
++++++++++++++++++++++++++++++++++++++
 
-The GBD LBWSG modelers estimate the relative risk for all-cause mortality on
+The GBD LBWSG modelers estimated the relative risk for all-cause mortality on
 each 500g and 2wk category of birthweight (BW) and gestational age (GA). If we
 assume a constant relative risk on each rectangular LBWSG category, these
 relative risk estimates define a `piecewise constant function`_ on the union of
@@ -299,7 +315,7 @@ Summary of Strategy for Interpolating Relative Risks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since the region on which the GBD RRs are defined is `nonconvex <convex set_>`_,
-interpolating between them is not completely straightforward using standard
+interpolating between the RRs is not completely straightforward using standard
 tools. Using SciPy's interpolation package, it required a two-step process of
 first *extrapolating* the relative risks to a complete rectangular grid, and
 then *interpolating the extrapolated values* to the full rectangular GAxBW
@@ -307,14 +323,13 @@ domain. Here is a summary of the procedure Nathaniel used to interpolate the
 LBWSG RRs for the large-scale food fortification project in 2021.
 
 1.  **Starting assumption:** We will assume that the relative risk
-    at the midpoint of each
+    at the *midpoint* of each
     rectangular LBWSG category is equal to the relative risk for that category
     estimated by GBD.
 
 2.  **Preprocessing step:** Since the LBWSG relative risks vary widely between categories (from 1.0 in
     the TMREL up to more than 1600 in the highest risk category), we will do
     the interpolation in log space and then exponentiate the results.
-    .. So first we compute the logarithms of the relative risks.
     Thus we start by computing :math:`\log(\mathit{RR})`, where :math:`\mathit{RR}` denotes the relative risk function defined at the LBWSG category midpoints, and :math:`\log` denotes the natural logarithm.
 
 3.  **Extrapolation step:** Use `nearest-neighbor interpolation`_ to extrapolate the logarithms of the relative risks to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
@@ -334,8 +349,8 @@ LBWSG RRs for the large-scale food fortification project in 2021.
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation
 .. _bilinear interpolation: https://en.wikipedia.org/wiki/Bilinear_interpolation
 
-Affected Outcomes
-+++++++++++++++++
+Affected Outcomes in Vivarium
++++++++++++++++++++++++++++++
 
 .. todo::
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -265,26 +265,43 @@ Vivarium Modeling Strategy
 Interpolation of Relative Risks
 +++++++++++++++++++++++++++++++
 
-GBD models the relative risk for all-cause mortality on each 500g and 2wk
-category of birthweight (BW) and gestational age (GA). Thus, if we assume a
-constant relative risk on each rectangular LBWSG category, the relative risk
-estimates define a piecewise constant function on the union of the LBWSG
-categories, which is a subset of the GAxBW rectangle :math:`[0,42\text{wk}]
-\times [0,4500\text{g}]`. This relative risk function is discontinuous,
-jumping from one value to another at the rectangle boundaries between the LBWSG
-categories (i.e. when GA is a multiple of 2 or BW is a multiple of 500).
+The GBD modelers of LBWSG estimate the relative risk for all-cause mortality on
+each 500g and 2wk category of birthweight (BW) and gestational age (GA). If we
+assume a constant relative risk on each rectangular LBWSG category, these
+relative risk estimates define a `piecewise constant function`_ on the union of
+the LBWSG categories, which is a subset of the GAxBW rectangle
+:math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
 
-We are interested in coming up with a smooth (or at least continuous) risk
+This piecewise constant relative risk function is discontinuous, jumping from
+one value to another at the linear boundaries between the LBWSG categories
+(usually when GA is a multiple of 2 or BW is a multiple of 500), and the
+relative risk does not change at all within each LBWSG category. Therefore, any
+simulated intervention that affects birthweight or gestational age (e.g. a
+nutritional supplement given to pregnant mothers to increase the birthweight of
+their newborns) can only have an effect on a small percentage of our simulants,
+namely those whose birthweight or gestational age is near the boundary of one of
+the LBWSG categories.
+
+Thus, we are interested in coming up with a smooth (or `continuous`_),
+continuously varying risk surface that interpolates between the relative risks
+estimated by GBD. In addition to (probably) being a better model of reality,
+this would allow every simulant the opportunity to get the effect of an
+intervention that affects birthweight or gestational age.
+
+We are interested in coming up with a smooth (or `continuous`_) risk
 surface that interpolates between the relative risks estimated by GBD. The main
 reasons for doing so are:
 
-- With piecewise constant RRs, any intervention that has an effect on
-  birthweight or gestational age will only affect simulants that are near the
-  boundary of one of the LBWSG categories. If we can create a continuously
-  varying RR function instead, then every simulant will have the opportunity to
-  get the effect of the intervention.
-
 - A continuously varying RR function probably better matches reality.
+
+- With piecewise constant RRs, any intervention that has an effect on
+  birthweight or gestational age can only affect simulants whose birthweight or
+  gestational age lies near the boundary of one of the LBWSG categories. If we
+  can create a continuously varying RR function instead, then every simulant
+  will have the opportunity to get the effect of the intervention.
+
+.. _piecewise constant function: https://mathworld.wolfram.com/PiecewiseConstantFunction.html
+.. _continuous: https://en.wikipedia.org/wiki/Continuous_function
 
 Affected Outcomes
 +++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -72,17 +72,6 @@ category of birthweight and gestational age.**
     is the usual cutoff for defining "preterm birth."
 
   For simplicity, we will generally refer to "500g and 2wk categories," with the understanding that there are some exceptions.
-..
-  - There are two 1-week age bins, 36-37 weeks and 37-38 weeks, because 37 weeks
-    is the usual cutoff for defining "preterm birth." 14 of the 58 LBWSG
-    categories have an age window of 1 week: cat24, cat25, cat35, cat36, cat40,
-    cat42, cat45, cat46, cat47, cat48, cat49, cat50, cat106, cat124.
-
-  - There are two low-prevalence, high-risk categories (cat2 and cat8) where
-    the age range is 0-24 weeks.
-
-  Despite the non-uniformity in gestational age cutoffs, for simplicity this
-  documentation page will generally refer to "500g and 2wk categories," with the understanding that some categories span more or less than 2 weeks.
 
 Details of Relative Risk Estimation
 +++++++++++++++++++++++++++++++++++
@@ -321,9 +310,8 @@ risk surface.
 Summary of Strategy for Interpolating Relative Risks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since the region on which the GBD RRs are defined is `nonconvex <convex set_>`_,
-interpolating between the RRs is not completely straightforward using standard
-tools. Using SciPy's interpolation package, it required a two-step process of
+Since the region on which the GBD RRs are defined is `non-convex <convex set_>`_,
+interpolating between the RRs is not completely straightforward. Using SciPy's interpolation package, it required a two-step process of
 first *extrapolating* the relative risks to a complete rectangular grid, and
 then *interpolating the extrapolated values* to the full rectangular GAxBW
 domain. Here is a summary of the procedure Nathaniel used to interpolate the
@@ -332,14 +320,15 @@ LBWSG RRs for the large-scale food fortification project in 2021.
 1.  **Start at category midpoints:** We will assume that the relative risk
     at the *midpoint* of each
     rectangular LBWSG category is equal to the relative risk for that category
-    estimated by GBD.
+    as estimated by GBD.
+    That is, if :math:`\mathit{RR}_\text{cat}` is the GBD relative risk for the LBWSG category ':math:`\text{cat}`', and the midpoint of :math:`\text{cat}` is :math:`(x_\text{cat}, y_\text{cat})`, we will assume that :math:`\mathit{RR}(x_\text{cat},y_\text{cat}) = \mathit{RR}_\text{cat}`, where :math:`\mathit{RR}(x,y)` denotes the relative risk at gestational age :math:`x` and birthweight :math:`y`. Our goal is to assign an interpolated value to :math:`\mathit{RR}(x,y)` for all :math:`(x,y)\in [0,42\text{wk}] \times [0,4500\text{g}]`, starting with the values :math:`\mathit{RR}(x_\text{cat},y_\text{cat})` at the 58 category midpoints.
 
 2.  **Take logarithms:** Since the LBWSG relative risks vary widely between categories (from 1.0 in
-    the TMREL up to more than 1600 in the highest risk category), we will do
-    the interpolation in log space and then exponentiate the results.
-    Thus we start by computing :math:`\log(\mathit{RR})`, where :math:`\mathit{RR}` denotes the relative risk function defined at the LBWSG category midpoints, and :math:`\log` denotes the natural logarithm.
+    the TMREL up to more than 1600 in the highest risk category in some draws), we will do
+    the interpolation in log space to keep everything at a reasonable scale, and then exponentiate the results.
+    Thus, we compute :math:`\log\bigl(\mathit{RR}(x_\text{cat}, y_\text{cat})\bigr)` for each of the 58 category midpoints :math:`(x_\text{cat}, y_\text{cat})`, where :math:`\mathit{RR}` denotes the relative risk function as defined above, and :math:`\log` denotes the natural logarithm.
 
-3.  **Extrapolate to a rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate the logarithms of the relative risks to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
+3.  **Extrapolate to a rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate :math:`\log(\mathit{RR})` from the category midpoints to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
 
 4.  **Interpolate to the full rectangle:** Use `bilinear interpolation`_ to fill in all values
     of :math:`\log(\mathit{RR})` in the entire GAxBW rectangle

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -71,7 +71,8 @@ category of birthweight and gestational age.**
   - 14 of the 58 categories have a 1-week age range, either 36-37 weeks or 37-38
     weeks, because 37 weeks is the usual cutoff for defining preterm birth.
 
-  For simplicity, we will generally refer to "500g and 2wk categories," with the understanding that there are some exceptions.
+  For simplicity, we will generally refer to "500g and 2wk categories," with
+  the understanding that there are some exceptions.
 
 Details of Relative Risk Estimation
 +++++++++++++++++++++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -69,7 +69,7 @@ category of birthweight and gestational age.**
   - 2 of the 58 categories (cat2 and cat8) have an age range of 0-24 weeks.
 
   - 14 of the 58 categories have a 1-week age range, either 36-37 weeks or 37-38 weeks, because 37 weeks
-    is the usual cutoff for defining "preterm birth."
+    is the usual cutoff for defining preterm birth.
 
   For simplicity, we will generally refer to "500g and 2wk categories," with the understanding that there are some exceptions.
 
@@ -404,9 +404,9 @@ LBWSG RRs for the `large-scale food fortification project`_ in March 2021.
     gestational age, :math:`y` is birthweight, and :math:`a,b,c,d` are
     constants that depend on the function values at the rectangle's corners. There are 120 such rectangles indexed by :math:`i` and :math:`j`, and  each such rectangular "piece" of :math:`f` is linear in :math:`x` and :math:`y`
     separately and is quadratic as a function of two variables.
-    The bilinear interpolation can be easily implemented using SciPy's `RectBivariateSpline`_ class (with ``kx=1,ky=1``), `interp2d`_ function (with ``kind='linear'``), or `RegularGridInterpolator`_ class (with ``method='linear'``).
+    The bilinear interpolation can be easily implemented using either SciPy's `RectBivariateSpline`_ class (with ``kx=1,ky=1``), or `interp2d`_ function (with ``kind='linear'``), or `RegularGridInterpolator`_ class (with ``method='linear'``).
 
-#.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, recover the relative risks by computing :math:`\mathit{RR}(x,y) = \exp(f(x,y))`. The above interpolation strategy guarantees that the interpolated RRs will remain between the minimum and maximum RR values in GBD.
+#.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, we recover the relative risks by computing :math:`\mathit{RR}(x,y) = \exp(f(x,y))`. The above interpolation strategy guarantees that the interpolated RRs will remain between the minimum and maximum RR values in GBD.
 
 #.  **Reset RRs in TMREL categories to 1:** Since we assumed that the RR values were equal to the GBD RRs at the *midpoints* of the LBWSG categories, and the interpolated RRs vary continuously, the interpolated RRs in the TMREL categories will be greater than 1 as GA or BW approaches a category of higher relative risk. In order to be consistent with GBD, we reset the RR to 1.0 in each of the four TMREL categories (cat53, cat54, cat55, cat56) after interpolation. This will introduce some discontinuity at the boundaries of the TMREL categories, but that is an acceptable tradeoff for consistency with GBD.
 
@@ -434,7 +434,7 @@ Implementation of RR Interpolation in SciPy
 .. todo::
 
   Show Python code that implements the above procedure. In the meantime, here
-  are the original notebooks where I figured out how to do it:
+  are the original notebooks where I figured out how to do it (with pictures!):
 
   - https://github.com/ihmeuw/vivarium_data_analysis/blob/main/pre_processing/lbwsg/2021_03_09b_plot_lbwsg_rr_interpolation_using_griddata.ipynb
   - https://github.com/ihmeuw/vivarium_data_analysis/blob/main/pre_processing/lbwsg/2021_03_10a_plot_two_step_interpolated_rrs_for_lbwsg.ipynb

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -392,16 +392,23 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
     bilinear. On each rectangle whose corners are neighboring grid points, it
     has has the form
 
-    .. math:: \log(\mathit{RR}(x,y)) = f(x,y) = a + bx + cy + dxy,
+    .. math::
+
+      \log(\mathit{RR}(x,y)) = f(x,y) = a + bx + cy + dxy
+      \quad (x_i\le x\le x_{i+1}, y_j\le y\le y_{j+1}),
 
     where :math:`x` is
     gestational age, :math:`y` is birthweight, and :math:`a,b,c,d` are
-    constants that depend on the function values at the rectangle's corners, so each "piece" of :math:`f` is linear in :math:`x` and :math:`y`
+    constants that depend on the function values at the rectangle's corners. There are 120 such rectangles indexed by :math:`i` and :math:`j`, and  each such rectangular "piece" of :math:`f` is linear in :math:`x` and :math:`y`
     separately and is quadratic as a function of two variables.
 
 #.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, recover the relative risks by computing :math:`\mathit{RR}(x,y) = \exp(f(x,y))`. The above interpolation strategy guarantees that the interpolated RRs will remain between the minimum and maximum RR values in GBD.
 
 #.  **Reset RRs in TMREL categories to 1:** Since we assumed that the RR values were equal to the GBD RRs at the *midpoints* of the LBWSG categories, and the interpolated RRs vary continuously, the interpolated RRs in the TMREL categories will be greater than 1 as GA or BW approaches a category of higher relative risk. In order to be consistent with GBD, we reset the RR to 1.0 in each of the four TMREL categories (cat53, cat54, cat55, cat56) after interpolation. This will introduce some discontinuity at the boundaries of the TMREL categories, but that is an acceptable tradeoff for consistency with GBD.
+
+    .. note::
+
+        It may be worth discussing the strategy of resetting the RRs to 1 with the GBD modelers to see if it matches their conception of the TMREL, or if it would actually be better to keep the interpolated RRs even though they are greater than 1 in some regions of the TMREL categories.
 
 .. _convex set: https://en.wikipedia.org/wiki/Convex_set
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -63,9 +63,16 @@ category of birthweight and gestational age.**
 
 .. note::
 
-  The risk appendix's description of 2-week age bins is not totally accurate;
-  there are two exceptions:
+  The risk appendix's description of 2-week age bins is not totally accurate
+  --- there are two exceptions:
 
+  - 2 of the 58 categories (cat2 and cat8) have an age range of 0-24 weeks.
+
+  - 14 of the 58 categories have a 1-week age range, either 36-37 weeks or 37-38 weeks, because 37 weeks
+    is the usual cutoff for defining "preterm birth."
+
+  For simplicity, we will generally refer to "500g and 2wk categories," with the understanding that there are some exceptions.
+..
   - There are two 1-week age bins, 36-37 weeks and 37-38 weeks, because 37 weeks
     is the usual cutoff for defining "preterm birth." 14 of the 58 LBWSG
     categories have an age window of 1 week: cat24, cat25, cat35, cat36, cat40,
@@ -278,7 +285,7 @@ Vivarium Modeling Strategy
 
 	This section will describe the Vivarium modeling strategy for risk effects. For a description of Vivarium modeling strategy for risk exposure, see the :ref:`risk exposure <2019_risk_exposure_lbwsg>` page.
 
-Interpolation of LBwSG Relative Risks
+Interpolation of LBWSG Relative Risks
 +++++++++++++++++++++++++++++++++++++
 
 The GBD LBWSG modelers estimated the relative risk for all-cause mortality on
@@ -322,19 +329,19 @@ then *interpolating the extrapolated values* to the full rectangular GAxBW
 domain. Here is a summary of the procedure Nathaniel used to interpolate the
 LBWSG RRs for the large-scale food fortification project in 2021.
 
-1.  **Starting assumption:** We will assume that the relative risk
+1.  **Start at category midpoints:** We will assume that the relative risk
     at the *midpoint* of each
     rectangular LBWSG category is equal to the relative risk for that category
     estimated by GBD.
 
-2.  **Preprocessing step:** Since the LBWSG relative risks vary widely between categories (from 1.0 in
+2.  **Take logarithms:** Since the LBWSG relative risks vary widely between categories (from 1.0 in
     the TMREL up to more than 1600 in the highest risk category), we will do
     the interpolation in log space and then exponentiate the results.
     Thus we start by computing :math:`\log(\mathit{RR})`, where :math:`\mathit{RR}` denotes the relative risk function defined at the LBWSG category midpoints, and :math:`\log` denotes the natural logarithm.
 
-3.  **Extrapolation step:** Use `nearest-neighbor interpolation`_ to extrapolate the logarithms of the relative risks to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
+3.  **Extrapolate to a rectangular grid:** Use `nearest-neighbor interpolation`_ to extrapolate the logarithms of the relative risks to all points on a complete rectangular grid. When doing this extrapolation, we rescale both the GA and BW coordinates to the interval :math:`[0,1]` since the scales of gestational age and birthweight are incomparable and drastically different (0-42wk vs. 0-4500g).
 
-4.  **Interpolation step:** Use `bilinear interpolation`_ to fill in all values
+4.  **Interpolate to the full rectangle:** Use `bilinear interpolation`_ to fill in all values
     of :math:`\log(\mathit{RR})` in the entire GAxBW rectangle
     :math:`[0,42\text{wk}] \times [0,4500\text{g}]` from the
     extrapolated values of :math:`\log(\mathit{RR})` on the grid in the previous
@@ -344,6 +351,10 @@ LBWSG RRs for the large-scale food fortification project in 2021.
     gestational age, :math:`y` is birthweight, and :math:`a,b,c,d` are
     constants), so each "piece" of :math:`f` is linear in each variable
     separately and is quadratic as a function of two variables.
+
+5.  **Exponentiate:**
+
+6.  **Reset RRs in TMREL categories to 1:**
 
 .. _convex set: https://en.wikipedia.org/wiki/Convex_set
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -478,7 +478,7 @@ March 2021.
 .. _RegularGridInterpolator: https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html
 
 Implementation of RR Interpolation in SciPy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. todo::
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -284,7 +284,7 @@ relative risk estimates define a `piecewise constant function`_ on the union of
 the LBWSG categories, which is a subset of the GAxBW rectangle
 :math:`[0,42\text{wk}] \times [0,4500\text{g}]`.
 
-This piecewise constant relative risk function is discontinuous, jumping from
+This piecewise constant relative risk function is `discontinuous <continuous function_>`_, jumping from
 one value to another at the linear boundaries between the LBWSG categories
 (usually when GA is a multiple of 2 or BW is a multiple of 500), and the
 relative risk does not change at all within each LBWSG category. Therefore, any
@@ -294,7 +294,7 @@ their newborns) can only have an effect on a small percentage of our simulants,
 namely those whose birthweight or gestational age is near the boundary of one of
 the LBWSG categories.
 
-To correct for this deficiency, we are interested in coming up with a smooth (or `continuous`_),
+To correct for this deficiency, we are interested in coming up with a
 continuously varying risk surface that interpolates between the relative risks
 estimated by GBD. In addition to (probably) being a better model of reality,
 this would allow every simulant the opportunity to get the effect of an
@@ -305,13 +305,13 @@ experiencing a larger change in relative risk if we used the piecewise constant
 risk surface.
 
 .. _piecewise constant function: https://mathworld.wolfram.com/PiecewiseConstantFunction.html
-.. _continuous: https://en.wikipedia.org/wiki/Continuous_function
+.. _continuous function: https://en.wikipedia.org/wiki/Continuous_function
 
 Strategy for Interpolating Relative Risks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Since the region on which the GBD RRs are defined is `non-convex <convex set_>`_,
-interpolating between the RRs is not completely straightforward. Using SciPy's interpolation package, it required a two-step process of
+interpolating between the RRs is not completely straightforward. Using `SciPy's interpolation package <scipy.interpolate_>`_, it required a two-step process of
 first *extrapolating* the relative risks to a complete rectangular grid, and
 then *interpolating the extrapolated values* to the full rectangular GAxBW
 domain. Here is a description of the procedure Nathaniel used to interpolate the
@@ -351,7 +351,8 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
         \{ y_\text{cat} : \text{cat is a LBWSG category}\}
         \cup \{0,4500\},
 
-    and then define the rectangular grid :math:`G` as the `Cartesian product`_,
+    and then define the rectangular grid :math:`G` as the `Cartesian product`_
+    of these coordinates,
 
     .. math:: G = \text{ga_grid} \times \text{bw_grid}.
 
@@ -385,6 +386,8 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
       y_\text{cat}/4500)`, and set :math:`\log (\mathit{RR}(x_i,
       y_j)) = \log(\mathit{RR}(x_\text{cat}, y_\text{cat}))`.
 
+    The rescaled nearest-neighbor interpolation can be easily implemented using SciPy's `griddata`_ function (with ``method='nearest'`` and ``rescale='True'``) or `NearestNDInterpolator`_ class (with ``rescale='True'``).
+
 #.  **Interpolate to the full rectangle:** Use `bilinear interpolation`_ to fill in all values
     of :math:`\log(\mathit{RR})` in the entire GAxBW rectangle
     :math:`[0,42\text{wk}] \times [0,4500\text{g}]` from the
@@ -401,6 +404,7 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
     gestational age, :math:`y` is birthweight, and :math:`a,b,c,d` are
     constants that depend on the function values at the rectangle's corners. There are 120 such rectangles indexed by :math:`i` and :math:`j`, and  each such rectangular "piece" of :math:`f` is linear in :math:`x` and :math:`y`
     separately and is quadratic as a function of two variables.
+    The bilinear interpolation can be easily implemented using SciPy's `RectBivariateSpline`_ class (with ``kx=1,ky=1``), `interp2d`_ function (with ``kind='linear'``), or `RegularGridInterpolator`_ class (with ``method='linear'``).
 
 #.  **Exponentiate:** Once we interpolate :math:`f = \log(\mathit{RR})`, recover the relative risks by computing :math:`\mathit{RR}(x,y) = \exp(f(x,y))`. The above interpolation strategy guarantees that the interpolated RRs will remain between the minimum and maximum RR values in GBD.
 
@@ -414,6 +418,13 @@ LBWSG RRs for the large-scale food fortification project in March 2021.
 .. _nearest-neighbor interpolation: https://en.wikipedia.org/wiki/Nearest-neighbor_interpolation
 .. _bilinear interpolation: https://en.wikipedia.org/wiki/Bilinear_interpolation
 .. _Cartesian product: https://en.wikipedia.org/wiki/Cartesian_product
+
+.. _scipy.interpolate: https://docs.scipy.org/doc/scipy/reference/interpolate.html
+.. _griddata: https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.griddata.html
+.. _NearestNDInterpolator: https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NearestNDInterpolator.html
+.. _RectBivariateSpline: https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RectBivariateSpline.html
+.. _interp2d: https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp2d.html
+.. _RegularGridInterpolator: https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.RegularGridInterpolator.html
 
 Implementation of RR Interpolation in SciPy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Here's a description of the method I used to interpolate the Low Birthweight & Short Gestation relative risks for the large-scale food fortification project.

The section got kind of long because I was trying to describe the procedure in enough detail to reproduce what I did.  If it's too much to digest in one PR, let me know and I can try to split it up.