### PR TITLE
Make citation in 2019 risk effects template unique to the page

### DIFF
--- a/docs/source/gbd2019_models/risk_effects/risk_effects_template.rst
+++ b/docs/source/gbd2019_models/risk_effects/risk_effects_template.rst
@@ -106,7 +106,7 @@ GBD 2019 Modeling Strategy
 
 .. todo::
 
-	Provide a brief overview of how the risk affects different outcomes, including data sources used by GBD, GBD assumptions, etc. Note that the [GBD-2019-Risk-Factors-Appendix]_ is a good source for this information in addition to the GBD risk modeler.
+	Provide a brief overview of how the risk affects different outcomes, including data sources used by GBD, GBD assumptions, etc. Note that the [GBD-2019-Risk-Factors-Appendix-Risk-Effects-Model-Template]_ is a good source for this information in addition to the GBD risk modeler.
 
 .. todo::
 
@@ -227,11 +227,15 @@ References
 
 .. todo::
 
+  Update the GBD 2019 Risk Factor Methods appendix citation to be unique to your
+  risk effects page (replace 'Risk-Effects-Model-Template' with '{Risk
+  Name}-Effects')
+
   Update the appropriate page numbers in the GBD risk factors methods appendix below
 
   Add additional references as necessary
 
-.. [GBD-2019-Risk-Factors-Appendix]
+.. [GBD-2019-Risk-Factors-Appendix-Risk-Effects-Model-Template]
 
   Pages ???-??? in `Supplementary appendix 1 to the GBD 2019 Risk Factors Capstone <2019_risk_factors_methods_appendix_>`_:
 


### PR DESCRIPTION
My assumption in PR https://github.com/ihmeuw/vivarium_research/pull/482 was wrong -- we have **not** done anything to fix the global citation problem discussed in PR https://github.com/ihmeuw/vivarium_research/pull/99.

Therefore I am reverting the citation in the GBD 2019 Risk Effects Model Template to the original version with the page name appended, and adding back in the instructions to do the same thing for pages based on the template.

For reference, here's an example of the "global citation problem":

* The [CDC] citations in the first paragraph of the [2017 Measles document](https://vivarium-research.readthedocs.io/en/latest/gbd2017_models/causes/measles/index.html) and the [2019 Measles document](https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/causes/measles/index.html) both point to the [CDC reference in the 2019 Body Mass Index document](https://vivarium-research.readthedocs.io/en/latest/gbd2019_models/risk_exposures/bmi/index.html#cdc).
* Also, the [WHO] and [Wikipedia] citations in the 2017 Measles document point to the corresponding references in the 2019 Measles document.