### PR TITLE
GBD 2019 LBWSG Risk Effects: Add some validation strategies

### DIFF
--- a/docs/source/gbd2017_models/risk_exposure/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2017_models/risk_exposure/low_birthweight_short_gestation/index.rst
@@ -616,6 +616,8 @@ When implementing :eq:`mortality_hazard`, recall that
   "attributable fraction among cases" instead of the *population* attributable
   fraction?
 
+.. _2017_risk_lbwsg_todo_alternative_approaches:
+
 .. todo::
 
    - add more description of the all-causes PAF and most-detailed-cause PAF and the logical reasoning for using one over the other.
@@ -749,6 +751,8 @@ random choices.
 
 Assumptions and Limitations
 +++++++++++++++++++++++++++
+
+.. _2017_risk_lbwsg_rr_strategy_assumptions_limitations:
 
 Apply relative risks only to causes affected by LBWSG in GBD
 ------------------------------------------------------------

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -346,6 +346,18 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
     each age group, and compare the simulated prevalences with the ENN and LNN
     category prevalences pulled from GBD.
 
+.. note::
+
+  It would be worth checking with the GBD modelers to see whether it is accurate
+  to interpret the ENN exposure and LNN exposure as average LBWSG category
+  prevalences for the 0-7 day period and 7-28 day period (or equivalently(?),
+  the point prevalence at the midpoint of each interval).
+
+  Also, it would be worth finding out whether the modelers have data on the
+  LBWSG category prevalences **at** 7 days and 28 days, as the risk appendix
+  indicates that these point prevalences were estimated as part of the analysis.
+  If so, these would provide additional data to validate against.
+
 Assumptions and Limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -346,7 +346,11 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
 #.  Record the person-time in the early neonatal age group (0-7 days) and late
     neonatal age group (7-28 days) **in each of the 58 LBWSG categories**. Use
     the person time to compute the person-time-weighted average prevalence of
-    each LBWSG catgory in each age group, and compare the simulated prevalences
+    each LBWSG catgory in each age group as
+
+      average = (person-time in category for age group) / (total person time for age group),
+
+    and compare the simulated prevalences
     with the ENN and LNN category prevalences pulled from GBD.
 
 #.  Record deaths in the ENN and LNN age groups, and compare the mortality
@@ -393,6 +397,48 @@ for each project that uses LBWSG, depending on which causes are modeled.
   LBWSG category prevalences **at** 7 days and 28 days, as the risk appendix
   indicates that these point prevalences were estimated as part of the analysis.
   If so, these would provide additional data to validate against.
+
+  We should ask the GBD modelers exactly how to interpret the ENN and LNN
+  prevalences pulled from GBD. According to
+  [GBD-2019-Risk-Factors-Appendix-LBWSG-Risk-Effects]_ (p. 175), the final step
+  of modeling LBWSG exposure is:
+
+    **Step C: Model joint distributions from birth to the end of the neonatal period, by l/y/s**
+
+    Early neonatal prevalence and late neonatal prevalence were estimated using
+    life table approaches for each 500g and 2-week bin. Using the all-cause
+    early neonatal mortality rate for each location-year-sex, births per
+    location-year-sex-bin, and the relative risks for each location-year-sex-bin
+    in the early neonatal period, the all-cause early neonatal mortality rate
+    was calculated for each location-year-sex- bin. The early neonatal mortality
+    rate per bin was used to calculate the number of survivors at seven days and
+    prevalence in the early neonatal period. Using the same process, the
+    all-cause late neonatal mortality rate for each location-year-sex was paired
+    with the number of survivors at seven days and late neonatal relative risks
+    per bin to calculate late neonatal prevalence and survivors at 28 days.
+
+  Specifically, we should ask the following:
+
+  - How exactly were the ENN and LNN prevalences computed in the above life
+    table approach? In particular:
+
+    - Can we interpret the ENN and LNN prevalences as person-time-weighted
+      average LBWSG category prevalences for the 0-7 day period and 7-28 day
+      periods, as described in the validation strategy above?
+
+    - Should the ENN and LNN prevalences instead be interpreted as the point
+      prevalence at the *midpoint* of each interval? The point prevalence at the
+      midpoint approximates the person-time-weighted average prevalence using the
+      midpoint rule with one rectangle, so these should be close to the average
+      prevalences but perhaps slightly different.
+
+    - Is there some other interpretation that would be more accurate?
+
+  - In addition to the ENN and LNN prevalences from GBD, can the modelers give
+    us the prevalences *at* 7 days and 28 days, since the above description
+    indicates that these point prevalences were computed as well?
+
+
 
 Assumptions and Limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -330,6 +330,9 @@ Validation and Verification Criteria
 
   List validation and verification criteria, including a list of variables that will need to be tracked and reported in the Vivarium simulation to ensure that the risk outcome relationship is modeled correctly
 
+Validation of Mortality Rates, Relative Risks, and Exposure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Here is a validation that can be run in isolation prior to putting the LBWSG model into a full simulation with other model components:
 
 #.  Initialize a birth cohort with birthweights and gestational ages
@@ -348,8 +351,8 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
 
 #.  Record deaths in the ENN and LNN age groups, and compare the mortality
     rates with the corresponding all-cause mortality rates in GBD. Deaths could
-    also be stratified by LBWSG category to validate simulated RRs against the
-    RR input data.
+    also be stratified by LBWSG category to verify simulated RRs against the RR
+    input data.
 
 This validation could be run with increasing degrees of complexity:
 
@@ -367,6 +370,14 @@ d.  The validation could also be done by initializing a cohort in the ENN age
     group or LNN age group based on GBD prevalences, to ensure that the LBWSG
     relative risks will work correctly for simulants initialized into these age
     groups in our models.
+
+This validation strategy requires recording outputs stratified by all 58 LBWSG
+exposure categories, so it would be best to do the validation with as few model
+components as possible, then remove the stratified outputs once satisfactory
+behavior has been verified. In fact, it would be worth writing a reusable
+simulation specifically to do the (a), (b), and (d) validations above,
+independent of any specific project we're working on, and do the (c) validation
+for each project that uses LBWSG, depending on which causes are modeled.
 
 .. note::
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -346,6 +346,23 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
     each age group, and compare the simulated prevalences with the ENN and LNN
     category prevalences pulled from GBD.
 
+#.  Record deaths in the ENN and LNN age groups, and compare the mortality
+    rates with the corresponding all-cause mortality rates in GBD. Deaths could
+    also be stratified by LBWSG category to validate simulated RRs against the
+    RR input data.
+
+This validation could be run with increasing degrees of complexity:
+
+a.  Apply the RRs directly to the all-cause mortality rate of the simulants.
+
+b.  Do not explicitly model any causes, but distinguish between causes affected
+    by LBWSG vs. unaffected by LBWSG, and apply the RRs only to the CSMRs of the
+    affected causes.
+
+c.  Add in one or more explicitly modeled causes, and apply the the RRs to the
+    EMR or CSMR of the affected causes, depending on whether the cause is
+    explicitly modeled.
+
 .. note::
 
   It would be worth checking with the GBD modelers to see whether it is accurate

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -356,7 +356,8 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
 
 This validation could be run with increasing degrees of complexity:
 
-a.  Apply the RRs directly to the all-cause mortality rate of the simulants.
+a.  Apply the RRs directly to the all-cause mortality rate of the simulants (or
+    did we already try this and decide it was a bad idea?).
 
 b.  Do not explicitly model any causes, but distinguish between causes affected
     by LBWSG vs. unaffected by LBWSG, and apply the RRs only to the CSMRs of the

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -330,6 +330,22 @@ Validation and Verification Criteria
 
   List validation and verification criteria, including a list of variables that will need to be tracked and reported in the Vivarium simulation to ensure that the risk outcome relationship is modeled correctly
 
+Here is a validation that can be run in isolation prior to putting the LBWSG model into a full simulation with other model components:
+
+#.  Initialize a birth cohort with birthweights and gestational ages
+    distributed according to the LBWSG exposure distribution at birth
+    (age_group_id=164).
+
+#.  Age the population to 7 days and to 28 days, subjecting the population to
+    the LBWSG relative risks of all-cause mortality based on their LBWSG
+    category.
+
+#.  Record the person-time in the early neonatal age group (0-7 days) and late
+    neonatal age group (7-28 days) **in each of the 58 LBWSG categories**. Use
+    the person time to compute the average prevalence of each LBWSG catgory in
+    each age group, and compare the simulated prevalences with the ENN and LNN
+    category prevalences pulled from GBD.
+
 Assumptions and Limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -363,6 +363,11 @@ c.  Add in one or more explicitly modeled causes, and apply the the RRs to the
     EMR or CSMR of the affected causes, depending on whether the cause is
     explicitly modeled.
 
+d.  The validation could also be done by initializing a cohort in the ENN age
+    group or LNN age group based on GBD prevalences, to ensure that the LBWSG
+    relative risks will work correctly for simulants initialized into these age
+    groups in our models.
+
 .. note::
 
   It would be worth checking with the GBD modelers to see whether it is accurate

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -330,8 +330,8 @@ Validation and Verification Criteria
 
   List validation and verification criteria, including a list of variables that will need to be tracked and reported in the Vivarium simulation to ensure that the risk outcome relationship is modeled correctly
 
-Validation of Mortality Rates, Relative Risks, and Exposure
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Validation of Mortality Rates, Relative Risks, and Change in Exposure
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is a validation that can be run in isolation prior to putting the LBWSG model into a full simulation with other model components:
 
@@ -348,10 +348,17 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
     the person time to compute the person-time-weighted average prevalence of
     each LBWSG catgory in each age group as
 
-      average = (person-time in category for age group) / (total person time for age group),
+    .. math::
 
-    and compare the simulated prevalences
-    with the ENN and LNN category prevalences pulled from GBD.
+      \left(\genfrac{}{}{0}{}
+        {\text{person-time-weighted}}
+        {\text{average prevalence}}\right)
+      = \frac
+        {\text{person-time in category for age group}}
+        {\text{total person time for age group}},
+
+    and compare the simulated prevalences with the ENN and LNN category
+    prevalences pulled from GBD.
 
 #.  Record deaths in the ENN and LNN age groups, and compare the mortality
     rates with the corresponding all-cause mortality rates in GBD. Deaths could
@@ -385,18 +392,6 @@ independent of any specific project we're working on, and do the (c) validation
 for each project that uses LBWSG, depending on which causes are modeled.
 
 .. note::
-
-  It would be worth checking with the GBD modelers to see whether it is accurate
-  to interpret the ENN exposure and LNN exposure as person-time-weighted average
-  LBWSG category prevalences for the 0-7 day period and 7-28 day period (or
-  perhaps the point prevalence at the midpoint of each interval, which
-  approximates the average prevalence using the midpoint rule with one
-  rectangle).
-
-  Also, it would be worth finding out whether the modelers have data on the
-  LBWSG category prevalences **at** 7 days and 28 days, as the risk appendix
-  indicates that these point prevalences were estimated as part of the analysis.
-  If so, these would provide additional data to validate against.
 
   We should ask the GBD modelers exactly how to interpret the ENN and LNN
   prevalences pulled from GBD. According to
@@ -437,6 +432,9 @@ for each project that uses LBWSG, depending on which causes are modeled.
   - In addition to the ENN and LNN prevalences from GBD, can the modelers give
     us the prevalences *at* 7 days and 28 days, since the above description
     indicates that these point prevalences were computed as well?
+
+  The answers to these questions may dictate some adjuststments to the
+  validation strategy outlined above.
 
 
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -367,8 +367,12 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
 
 This validation could be run with increasing degrees of complexity:
 
-a.  Apply the RRs directly to the all-cause mortality rate of the simulants (or
-    did we already try this and decide it was a bad idea?).
+a.  Apply the RRs directly to the all-cause mortality rate of the simulants. (Or
+    did we already try this and decide it was a bad idea? See this :ref:`Todo
+    about different approaches <2017_risk_lbwsg_todo_alternative_approaches>`
+    and the :ref:`assumptions and limitations of our approach to applying the
+    relative risks <2017_risk_lbwsg_rr_strategy_assumptions_limitations>` in the
+    GBD 2017 LBWSG model.)
 
 b.  Do not explicitly model any causes, but distinguish between causes affected
     by LBWSG vs. unaffected by LBWSG, and apply the RRs only to the CSMRs of the

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -345,9 +345,9 @@ Here is a validation that can be run in isolation prior to putting the LBWSG mod
 
 #.  Record the person-time in the early neonatal age group (0-7 days) and late
     neonatal age group (7-28 days) **in each of the 58 LBWSG categories**. Use
-    the person time to compute the average prevalence of each LBWSG catgory in
-    each age group, and compare the simulated prevalences with the ENN and LNN
-    category prevalences pulled from GBD.
+    the person time to compute the person-time-weighted average prevalence of
+    each LBWSG catgory in each age group, and compare the simulated prevalences
+    with the ENN and LNN category prevalences pulled from GBD.
 
 #.  Record deaths in the ENN and LNN age groups, and compare the mortality
     rates with the corresponding all-cause mortality rates in GBD. Deaths could
@@ -383,9 +383,11 @@ for each project that uses LBWSG, depending on which causes are modeled.
 .. note::
 
   It would be worth checking with the GBD modelers to see whether it is accurate
-  to interpret the ENN exposure and LNN exposure as average LBWSG category
-  prevalences for the 0-7 day period and 7-28 day period (or equivalently(?),
-  the point prevalence at the midpoint of each interval).
+  to interpret the ENN exposure and LNN exposure as person-time-weighted average
+  LBWSG category prevalences for the 0-7 day period and 7-28 day period (or
+  perhaps the point prevalence at the midpoint of each interval, which
+  approximates the average prevalence using the midpoint rule with one
+  rectangle).
 
   Also, it would be worth finding out whether the modelers have data on the
   LBWSG category prevalences **at** 7 days and 28 days, as the risk appendix


### PR DESCRIPTION
This describes a mini simulation we can run to validate the application of the relative risks.

I couldn't remember the details of why we decided to apply the RRs only to affected causes instead of all-cause mortality, so I put a question about it in here that should be addressed at some point.