### PR TITLE
CIFF SAM Concept Model: Add links to pages for model components

### DIFF
--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -214,11 +214,11 @@ Scale up the coverage of treatment and prevention interventions to 90%.
 5.2.1 Population description
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  - Location: Ethiopia
-  - Cohort type: Prospective open cohort of 0-5 years
-  - Size of largest starting population: 100,000 simulants
-  - Time span: Jan 1, 2022 to Dec 31, 2026
-  - Time step: 1 day
+- Location: Ethiopia
+- Cohort type: Prospective open cohort of 0-5 years
+- Size of largest starting population: 100,000 simulants
+- Time span: Jan 1, 2022 to Dec 31, 2026
+- Time step: 1 day
 
 
 .. _5.2.2:

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -11,7 +11,7 @@
 
   Section Level 1 (#.0)
   +++++++++++++++++++++
-  
+
   Section Level 2 (#.#)
   ---------------------
 
@@ -53,7 +53,7 @@ Vivarium ACUTE MALNUTRITION
 1.0 Background
 ++++++++++++++
 
-Malnutrition is an imbalance between the body’s needs and its use and intake of nutrients. The imbalance can be caused by poor or lacking diet, poor hygiene, disease states, lack of knowledge, and cultural practices, among others. Underweight, stunting, wasting, obesity, and vitamin and mineral deficiencies are all forms of malnutrition. Acute malnutrition (AM), also referred to as wasting, is recent rapid weight loss or a failure to gain weight that results from illness, lack of appropriate foods, or other underlying causes. For an individual, AM is not a chronic condition: children with AM either recover or die and recovered children can relapse to AM1. It is measured in weight-for-height z-scores (WFH) which is a comparison of a child’s WFH from the median value of the global reference population. A z-score between -2 to -3 indicates moderate acute malnutrition (MAM) and a z-score below -3 indicate severe acute malnutrition (SAM). SAM and MAM together is referred to as global acute malnutrition (GAM). Although MAM is less severe, it affects a greater number of children and is associated with more nutrition-related deaths than SAM. Children with AM are at greater risk of death from diarrhea and other infectious diseases than well-nourished children. They also face greater risk of morbidity from infectious diseases and delayed physical and cognitive development. MAM tends to peak during seasonal hunger, disease outbreaks, or during food security ‘shocks’ (e.g. economic or climatic crises) and stresses including humanitarian crises. However, MAM is a problem that not only occurs in emergencies, but also can be endemic in development contexts. MAM should not be neglected, as untreated, it can deteriorate to SAM and possible death. Furthermore, evidence is emerging that repeated episodes of MAM can have a significant impact on stunting; prevention of wasting could potentially increase height in children. 
+Malnutrition is an imbalance between the body’s needs and its use and intake of nutrients. The imbalance can be caused by poor or lacking diet, poor hygiene, disease states, lack of knowledge, and cultural practices, among others. Underweight, stunting, wasting, obesity, and vitamin and mineral deficiencies are all forms of malnutrition. Acute malnutrition (AM), also referred to as wasting, is recent rapid weight loss or a failure to gain weight that results from illness, lack of appropriate foods, or other underlying causes. For an individual, AM is not a chronic condition: children with AM either recover or die and recovered children can relapse to AM1. It is measured in weight-for-height z-scores (WFH) which is a comparison of a child’s WFH from the median value of the global reference population. A z-score between -2 to -3 indicates moderate acute malnutrition (MAM) and a z-score below -3 indicate severe acute malnutrition (SAM). SAM and MAM together is referred to as global acute malnutrition (GAM). Although MAM is less severe, it affects a greater number of children and is associated with more nutrition-related deaths than SAM. Children with AM are at greater risk of death from diarrhea and other infectious diseases than well-nourished children. They also face greater risk of morbidity from infectious diseases and delayed physical and cognitive development. MAM tends to peak during seasonal hunger, disease outbreaks, or during food security ‘shocks’ (e.g. economic or climatic crises) and stresses including humanitarian crises. However, MAM is a problem that not only occurs in emergencies, but also can be endemic in development contexts. MAM should not be neglected, as untreated, it can deteriorate to SAM and possible death. Furthermore, evidence is emerging that repeated episodes of MAM can have a significant impact on stunting; prevention of wasting could potentially increase height in children.
 
 
 .. _1.1:
@@ -61,13 +61,13 @@ Malnutrition is an imbalance between the body’s needs and its use and intake o
 1.1 Project overview
 --------------------
 
-Wasting is commonly considered an acute condition and is categorized into moderate (MAM), and severe (SAM).  Compared to other manifestations of undernutrition it can be relatively rapid in onset and resolution. While management and treatment of children with MAM and SAM improves recovery, these children are still at risk of relapse. One possible explanation for this is that treatment does not adequately correct the metabolic disturbances or biological mechanisms that lead to wasting and children are left with a deficient immune defense after a wasting episode. Another reason for vulnerability to relapse is that the same environmental or external condition that initially caused the wasting remains, or even that an earlier risk factor during fetal development leaves a child more vulnerable to becoming wasted. Concrete evidence is still lacking on the role of metabolic and persistent environmental factors play in the progression of wasting and relapse, but potential involvement underlines the importance of catching children early in the process of wasting with wasting prevention interventions before these metabolic disturbances occur. 
+Wasting is commonly considered an acute condition and is categorized into moderate (MAM), and severe (SAM).  Compared to other manifestations of undernutrition it can be relatively rapid in onset and resolution. While management and treatment of children with MAM and SAM improves recovery, these children are still at risk of relapse. One possible explanation for this is that treatment does not adequately correct the metabolic disturbances or biological mechanisms that lead to wasting and children are left with a deficient immune defense after a wasting episode. Another reason for vulnerability to relapse is that the same environmental or external condition that initially caused the wasting remains, or even that an earlier risk factor during fetal development leaves a child more vulnerable to becoming wasted. Concrete evidence is still lacking on the role of metabolic and persistent environmental factors play in the progression of wasting and relapse, but potential involvement underlines the importance of catching children early in the process of wasting with wasting prevention interventions before these metabolic disturbances occur.
 
-In addition to management and treatment of MAM and SAM, we will model a number of sufficiently robust interventions that directly prevent AM. We will also model interventions that affect risk factors for wasting including birthweight and infectious disease. For each intervention, we obtain current population coverage levels, effect sizes and costs for cost-effectiveness analysis. 
+In addition to management and treatment of MAM and SAM, we will model a number of sufficiently robust interventions that directly prevent AM. We will also model interventions that affect risk factors for wasting including birthweight and infectious disease. For each intervention, we obtain current population coverage levels, effect sizes and costs for cost-effectiveness analysis.
 
-We will model wasting in an individual as a collection of distinct states, where an individual is in a single state and may transition to other states following the arrows between states (see wasting exposure model). In GBD, wasting has four categories corresponding to different WFH z-score ranges. Simulants transition forward through the four wasting states by the incidence rate and backward towards healthier states by the recovery rate. Risk factors such as low birthweight (LBW) or infectious diseases increases the forward incidence rates. We will model differential incidence and recovery rates based on intervention coverage: simulants covered by direct wasting preventive interventions will experience lower forward incidence rates compared to those not covered and simulants covered by therapeutic interventions will experience a higher recovery rate than those not covered.  Wasting prevalence and incidence will be reduced either by greater effectiveness of interventions or greater coverage of interventions. Interventions that address birthweight or infectious diseases will affect wasting through the risk factor causal pathway. 
+We will model wasting in an individual as a collection of distinct states, where an individual is in a single state and may transition to other states following the arrows between states (see wasting exposure model). In GBD, wasting has four categories corresponding to different WFH z-score ranges. Simulants transition forward through the four wasting states by the incidence rate and backward towards healthier states by the recovery rate. Risk factors such as low birthweight (LBW) or infectious diseases increases the forward incidence rates. We will model differential incidence and recovery rates based on intervention coverage: simulants covered by direct wasting preventive interventions will experience lower forward incidence rates compared to those not covered and simulants covered by therapeutic interventions will experience a higher recovery rate than those not covered.  Wasting prevalence and incidence will be reduced either by greater effectiveness of interventions or greater coverage of interventions. Interventions that address birthweight or infectious diseases will affect wasting through the risk factor causal pathway.
 
-This model will allow us to understand and quantify the impact of different combinations of preventive and treatment strategies on wasting and wasting attributable DALYs at the national level. 
+This model will allow us to understand and quantify the impact of different combinations of preventive and treatment strategies on wasting and wasting attributable DALYs at the national level.
 
 
 .. _1.2:
@@ -82,7 +82,7 @@ This model will allow us to understand and quantify the impact of different comb
 2.0 Modeling aims and objectives
 ++++++++++++++++++++++++++++++++
 
-The primary objective of this project is to answer the following question: what is the cost and impact of combinations of preventive and therapeutic strategies for reducing overall wasting prevalence and eliminating SAM in Ethiopia? 
+The primary objective of this project is to answer the following question: what is the cost and impact of combinations of preventive and therapeutic strategies for reducing overall wasting prevalence and eliminating SAM in Ethiopia?
 We will use data from the 2019 GBD and published literature to inform the parameters for our simulation. We will simulate the changes in MAM and SAM disease incidence, prevalence and mortality from 2022 to 2027 in response to a combination of preventive and therapeutic treatment interventions in Ethiopia.
 
 
@@ -132,7 +132,7 @@ While there are various well-studied risk factors that are associated with becom
 4.0 Intervention
 ++++++++++++++++
 
-Historically, prevention research has primarily focused on stunting, and, as a research outcome, wasting has been considered primarily within the context of humanitarian emergencies. Although the volume of studies related to wasting prevention through direct and indirect health-care sector areas has increased in recent years, this evidence base is mixed and often inconclusive. We reviewed the literature from the recent Keats et al 2021 update of effective interventions to address maternal and child malnutrition and selected interventions that have moderate or strong evidence for implementation5. We selected interventions that:  
+Historically, prevention research has primarily focused on stunting, and, as a research outcome, wasting has been considered primarily within the context of humanitarian emergencies. Although the volume of studies related to wasting prevention through direct and indirect health-care sector areas has increased in recent years, this evidence base is mixed and often inconclusive. We reviewed the literature from the recent Keats et al 2021 update of effective interventions to address maternal and child malnutrition and selected interventions that have moderate or strong evidence for implementation5. We selected interventions that:
 
 1)	Directly prevent acute malnutrition, moderate or severe;
 2)	Treat or manage acute malnutrition, moderate or severe;
@@ -149,13 +149,13 @@ Historically, prevention research has primarily focused on stunting, and, as a r
 ------------------------
 
 **Baseline**
-The baseline scenario will project GBD 2019 demographic and disease trends out from 2022 to 2027 and coverage rates for all preventive and therapeutic interventions will be held constant across the 5 years of the microsimulation to simulate a business-as-usual treatment scenario. 
+The baseline scenario will project GBD 2019 demographic and disease trends out from 2022 to 2027 and coverage rates for all preventive and therapeutic interventions will be held constant across the 5 years of the microsimulation to simulate a business-as-usual treatment scenario.
 
 **Alternative scenario 1**
 Scale up the coverage of MAM management and MAM treatment interventions to 90%
 
 **Alternative scenario 2**
-Scale up the coverage of treatment and prevention interventions to 90%. 
+Scale up the coverage of treatment and prevention interventions to 90%.
 
 .. _5.0:
 
@@ -164,10 +164,11 @@ Scale up the coverage of treatment and prevention interventions to 90%.
 
 .. _5.1:
 
-5.1 Vivarium concept model 
+5.1 Vivarium concept model
 --------------------------
 
 .. image:: sam_concept_model_diagram.svg
+
 
 
 .. _5.2:

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -164,12 +164,45 @@ Scale up the coverage of treatment and prevention interventions to 90%.
 
 .. _5.1:
 
-5.1 Vivarium concept model
---------------------------
+5.1 Vivarium concept model diagram
+----------------------------------
 
 .. image:: sam_concept_model_diagram.svg
 
+5.1.1 Cause Models
+~~~~~~~~~~~~~~~~~~
 
+* Diarrheal Diseases (GBD 2019)
+
+* Lower Respiratory Infections (GBD 2019)
+
+* Measles (GBD 2019)
+
+5.1.2 Joint Cause-Risk Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Child Wasting / Protein Energy Malnutrition (GBD 2020)
+
+5.1.3 Risk Exposure Models
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Non-exclusive Breastfeeding
+
+* Discontinued Breastfeeding
+
+* Child Stunting (GBD 2020)
+
+* Low Birthweight and Short Gestation (GBD 2019)
+
+5.1.4 Risk Effects Models
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Low Birthweight and Short Gestation Risk Effects (GBD 2019)
+
+5.1.5 Intervention Models
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Treatment and management for acute malnutrition
 
 .. _5.2:
 

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -172,16 +172,16 @@ Scale up the coverage of treatment and prevention interventions to 90%.
 5.1.1 Cause Models
 ~~~~~~~~~~~~~~~~~~
 
-* Diarrheal Diseases (GBD 2019)
+* :ref:`Diarrheal Diseases (GBD 2019) <2019_cause_diarrhea>`
 
-* Lower Respiratory Infections (GBD 2019)
+* :ref:`Lower Respiratory Infections (GBD 2019) <2019_cause_lower_respiratory_infections>`
 
-* Measles (GBD 2019)
+* :ref:`Measles (GBD 2019) <2019_cause_measles>`
 
 5.1.2 Joint Cause-Risk Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Child Wasting / Protein Energy Malnutrition (GBD 2020)
+* :ref:`Child Wasting / Protein Energy Malnutrition (GBD 2020) <2020_risk_exposure_wasting_state_exposure>`
 
 5.1.3 Risk Exposure Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -190,19 +190,19 @@ Scale up the coverage of treatment and prevention interventions to 90%.
 
 * Discontinued Breastfeeding
 
-* Child Stunting (GBD 2020)
+* :ref:`Child Stunting (GBD 2020) <2020_risk_exposure_child_stunting>`
 
 * Low Birthweight and Short Gestation (GBD 2019)
 
 5.1.4 Risk Effects Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Low Birthweight and Short Gestation Risk Effects (GBD 2019)
+* :ref:`Low Birthweight and Short Gestation Risk Effects (GBD 2019) <2019_risk_effect_lbwsg>`
 
 5.1.5 Intervention Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Treatment and management for acute malnutrition
+* :ref:`Treatment and management for acute malnutrition <intervention_wasting_treatment>`
 
 .. _5.2:
 


### PR DESCRIPTION
There's some superfluous whitespace changes, but the main thing is I added subsections under the concept model diagram that link out to the pages for the model components.

Note: I left out vitamin A deficiency because @Ninicorn said she's going to remove that.