### PR TITLE
LBWSG 2019 exposure: Add links from other pages

### DIFF
--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -192,7 +192,7 @@ Scale up the coverage of treatment and prevention interventions to 90%.
 
 * :ref:`Child Stunting (GBD 2020) <2020_risk_exposure_child_stunting>`
 
-* Low Birthweight and Short Gestation (GBD 2019)
+* :ref:`Low Birthweight and Short Gestation (GBD 2019) <2019_risk_exposure_lbwsg>`
 
 5.1.4 Risk Effects Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -48,15 +48,9 @@ GBD 2019 Modeling Strategy
 
 .. note::
 
-   This section will describe the GBD modeling strategy for risk effects.
-   For a description of GBD modeling strategy for risk exposure, see the
-   {RISK_EXPOSURE_PAGE_LINK} page.
-
-.. todo::
-
-   Replace {RISK_EXPOSURE_PAGE_LINK} with a reference to the appropriate risk
-   exposure page in the above note.
-
+   This section will describe the GBD modeling strategy for risk effects. For a
+   description of GBD modeling strategy for risk exposure, see the :ref:`Low
+   Birthweight and Short Gestation (GBD 2019) <2019_risk_exposure_lbwsg>` page.
 
 **The available data for deriving relative risk was only for all-cause
 mortality.**

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -329,13 +329,9 @@ Vivarium Modeling Strategy
 .. note::
 
    This section will describe the Vivarium modeling strategy for risk effects.
-   For a description of Vivarium modeling strategy for risk exposure, see
-   the {RISK_EXPOSURE_PAGE_LINK} page.
-
-.. todo::
-
-   Replace {RISK_EXPOSURE_PAGE_LINK} with a reference to the appropriate risk
-   exposure page in the above note.
+   For a description of Vivarium modeling strategy for risk exposure, see the
+   :ref:`Low Birthweight and Short Gestation (GBD 2019)
+   <2019_risk_exposure_lbwsg>` page.
 
 Interpolation of LBWSG Relative Risks
 +++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
Sequel to https://github.com/ihmeuw/vivarium_research/pull/576

Add links to the LBWSG 2019 risk exposure page from the CIFF acute malnutrition concept model and from the LBWSG 2019 risk exposure pages.