### PR TITLE
Lognormal parameter uncertainty for SQLNS effect sizes & SAM K parameter

### DIFF
--- a/docs/source/intervention_models/lipid_based_nutrient_supplements/index.rst
+++ b/docs/source/intervention_models/lipid_based_nutrient_supplements/index.rst
@@ -218,6 +218,15 @@ We will apply the relative risk ratio on the propensity of stunting starting fro
     - 0.85 (95% CI 0.74 to 0.98)
     - We apply this to the probability
 
+.. attention::
+
+  For all three effect sizes in the above table, we will use a **lognormal
+  distribution** to model parameter uncertainty, assuming the central value
+  represents the geometric mean (equivalently median) of the distribution. See
+  the :ref:`algorithm for fitting a lognormal distribution
+  <lognorm_from_median_lower_upper_code_block>` to a specified median and
+  confidence interval on the :ref:`Statistical Distributions of Uncertainty
+  <vivarium_best_practices_statistical_distributions>` page.
 
 .. list-table:: Affected Outcome Restrictions
   :widths: 15 15 15

--- a/docs/source/intervention_models/lipid_based_nutrient_supplements/index.rst
+++ b/docs/source/intervention_models/lipid_based_nutrient_supplements/index.rst
@@ -53,11 +53,11 @@ Ideally, infants are breastfed for two years or longer, with complementary food 
     - Note
   * - LNS
     - lipid-based nutrient supplements
-    - 
+    -
   * - SQ
     - small quantity
-    - 
-  * - FBF 
+    -
+  * - FBF
     - fortified blended foods
     -
   * - CSB ++
@@ -65,7 +65,7 @@ Ideally, infants are breastfed for two years or longer, with complementary food 
     -
   * - MNP
     - Multiple micronutrient powders
-    - 
+    -
 
 .. todo::
 
@@ -82,7 +82,7 @@ interventions advocated to address malnutrition among children is **lipid-based 
 products designed to deliver nutrients to vulnerable people. They are considered 'lipid-based' because most of the energy provided
 by these products is from lipids (fats). All LNS provide a range of vitamins and minerals, but unlike most other micronutrient supplements,
 LNS also provide *energy, protein and essential fatty acids*. LNS recipes can include a variety of ingredients, but typically have included vegetable fat, peanut or groundnut paste, milk powder and sugar. Based on the energy content, LNS can be small quantity (SQ LNS) providing ˜ 110 to 120 kcal/day (20 g dose), medium quantity (MQ LNS) providing ˜ 250 to 500 kcal/day (45 g to 90 g dose) or large-quantity (LQ LNS) providing
-more than 280 kcal/day (> 90 g dose).LNS are nutrient dense, require no cooking before use, and can be stored for months even in warm conditions. 
+more than 280 kcal/day (> 90 g dose).LNS are nutrient dense, require no cooking before use, and can be stored for months even in warm conditions.
 [DAS_Cochrane_Review_2019]_
 
 :underline:`Alternative recipes and formulations, other than LNS`
@@ -98,18 +98,18 @@ school or any other point of use. [DAS_Cochrane_Review_2019]_
 
 :underline:`Description of intervention`
 
-The intervention is the supplementation of children from aged **6 months to 23 months** with **LNS + complementary feeding** (intervention) compared with no intervention (control). The setting of the intervention is the community. 
+The intervention is the supplementation of children from aged **6 months to 23 months** with **LNS + complementary feeding** (intervention) compared with no intervention (control). The setting of the intervention is the community.
 
 .. note::
 
-  - Most studies included children aged six months to 18 months (Adu- Afarwuah 2007; Adu-Afarwuah 2016; Ashorn 2015; Bisimwa 2012; Christian 2015; Hess 2015; Iannotti 2014; Kumwenda 2014; Mangani 2015; Matias 2017; Phuka 2008; Siega-Riz 2014). 
-  - Four studies included children aged six to 24 months (Dewey 2017; Olney 2018; Luby   2018; Null 2018) and 
-  - one study included children aged six to 36 months (Huybregts 2012). 
+  - Most studies included children aged six months to 18 months (Adu- Afarwuah 2007; Adu-Afarwuah 2016; Ashorn 2015; Bisimwa 2012; Christian 2015; Hess 2015; Iannotti 2014; Kumwenda 2014; Mangani 2015; Matias 2017; Phuka 2008; Siega-Riz 2014).
+  - Four studies included children aged six to 24 months (Dewey 2017; Olney 2018; Luby   2018; Null 2018) and
+  - one study included children aged six to 36 months (Huybregts 2012).
   - Four included studies enrolled pregnant women and provided lipid-based nutrient supplements (LNS) plus complementary feeding during pregnancy and post-partum, followed by infant supplementation at six months of age (Adu-Afarwuah 2016; Ashorn 2015; Dewey 2017; Olney 2018). However, Dewey 2017 had an intervention arm in which only children were supplemented, hence we only used the data from that arm in the analysis in this review. The other studies provided LNS plus complementary feeding to children after six months of age. * The review conducted a sensitivity analysis by removing trials that also supplemented pregnant women with LNS in addition to children (Adu-Afarwuah 2016; Ashorn 2015), and found no significant difference in the outcome (Analysis 1.3; Analysis 1.4 in Das DAS_Cochrane_Review_2019).
 
 
 Please see this memo for a summary of the studies and the effect sizes :download:`SQ-LNS interventions memo<sqlns_memo_das2019.docx>`
-  
+
 .. list-table:: Affected Outcomes by intervention
   :widths: 15 15 15 15
   :header-rows: 1
@@ -158,26 +158,26 @@ For the outcome moderate wasting, the review compared prevalence of **moderate w
 
 We will apply the relative risk ratio as a relative rate ratio on the incidence of MAM from MILD (i2) starting from the age-start of the intervention starts (6 months). This is because we assume that the intervention does not affect the duration of disease and hence:
 
-| Prevalence_intervention 
-| = 0.82 x (prevalence_baseline_6mo) 
+| Prevalence_intervention
+| = 0.82 x (prevalence_baseline_6mo)
 | = 0.82 x (incidence_baseline_6mo) x Duration_baseline
 
 .. important::
 
-  Note that when we apply this incidence reduction to the incidence of MAM from Mild, we will inadvertently reduce SAM prevalence. This is because less people will be transitioning into SAM. Although the Das 2019 Cochrane Review says the intervention has no effect on SAM (in fact, it seems like it may increase SAM prevalence based on the mean prevalence RR!), we are assuming 'an absence of evidence is not evidence of absence' - quote Abie. Logically, it should reduce SAM prevalence. We should discuss this in our methods in the manuscript and see how much of SAM prevalence is decreased. 
+  Note that when we apply this incidence reduction to the incidence of MAM from Mild, we will inadvertently reduce SAM prevalence. This is because less people will be transitioning into SAM. Although the Das 2019 Cochrane Review says the intervention has no effect on SAM (in fact, it seems like it may increase SAM prevalence based on the mean prevalence RR!), we are assuming 'an absence of evidence is not evidence of absence' - quote Abie. Logically, it should reduce SAM prevalence. We should discuss this in our methods in the manuscript and see how much of SAM prevalence is decreased.
 
 .. todo::
-  
-  Try this out in the nano-sim to see how the intervention affects moderate wasting prevalence when RR applied to i2. 
+
+  Try this out in the nano-sim to see how the intervention affects moderate wasting prevalence when RR applied to i2.
 
 .. todo::
-  
-  Think about whether we want to apply the full reduction in incidence at 6 months or we have a gradual reduction in incidence, reaching full reduction at 18 months? 
-  Answer: we will start simple and apply immediately to 6 months (no gradual ramp-up). We can add complexity later. 
+
+  Think about whether we want to apply the full reduction in incidence at 6 months or we have a gradual reduction in incidence, reaching full reduction at 18 months?
+  Answer: we will start simple and apply immediately to 6 months (no gradual ramp-up). We can add complexity later.
 
 :underline:`Outcome #2 and #3: moderate and severe stunting`
 
-LNS plus complementary feeding reduced the prevalence of **moderate stunting** by 7% (risk ratio (RR) 0.93, 95% confidence interval (CI) 0.88 to 0.98; nine studies, 13,372 participants; moderate-quality evidence), **severe stunting** by 15% (RR 0.85, 95% CI 0.74 to 0.98; five studies, 6151 participants; moderate-quality evidence), 
+LNS plus complementary feeding reduced the prevalence of **moderate stunting** by 7% (risk ratio (RR) 0.93, 95% confidence interval (CI) 0.88 to 0.98; nine studies, 13,372 participants; moderate-quality evidence), **severe stunting** by 15% (RR 0.85, 95% CI 0.74 to 0.98; five studies, 6151 participants; moderate-quality evidence),
 
 We will apply the relative risk ratio on the propensity of stunting starting from the age-start of the intervention starts (6 months). See below example for male, age 6mo-11mo, 2020 stunting prevalence.
 
@@ -228,23 +228,23 @@ We will apply the relative risk ratio on the propensity of stunting starting fro
     - Note
   * - Male only
     - No
-    - 
+    -
   * - Female only
     - No
-    - 
+    -
   * - Age group start
     - 389 (6-11mo)
-    - intervention starts at 6 months 
+    - intervention starts at 6 months
   * - Age group end
     - 34 (2-4yr)
     - intervention effect size measured at 18mo | 24 mo
   * - Other
-    - 
-    - 
+    -
+    -
 
 .. note::
- 
-  We apply the effect size according to the outcome restictions in the above table. This means that the intervention starts at 6 months and the effect is sustained throughout until they are 5 years old if covered. They are still covered even during episodes of SAM or MAM. However, for the costing, we will restrict supplementation from 6 months to 2 years old (add reference for this claim). I will add more research to the costing model. 
+
+  We apply the effect size according to the outcome restictions in the above table. This means that the intervention starts at 6 months and the effect is sustained throughout until they are 5 years old if covered. They are still covered even during episodes of SAM or MAM. However, for the costing, we will restrict supplementation from 6 months to 2 years old (add reference for this claim). I will add more research to the costing model.
 
 
 .. todo::
@@ -265,11 +265,11 @@ Validation and Verification Criteria
 - verification: coverage of SQ-LNS as a function of time in baseline and intervention scenario
 - verification: prevalence of stunting in supplemented vs non-supplemented group
 - verification: incidence of moderate wasting from mild in supplemented vs non-supplemented group
-- validation: check that the prevalence of moderate wasting in supplemented vs non-supplemented group agrees with the prevalence RR that we applied to the incidence instead. 
-- validation: check to see how much of SAM prevalence decreases from reduction in MAM incidence from MILD. 
+- validation: check that the prevalence of moderate wasting in supplemented vs non-supplemented group agrees with the prevalence RR that we applied to the incidence instead.
+- validation: check to see how much of SAM prevalence decreases from reduction in MAM incidence from MILD.
 
 .. todo::
-  
+
   Did we say we can ramp up coverage to 100% in our scenarios and then we can look between 100% covered in scenario vs. 100% uncovered in baseline? Rather than within the scenario of 90% covered vs 10% uncovered?
 
 .. csv-table:: SQ-LNS intervention output table shell for v & v (Ethiopia)
@@ -281,8 +281,8 @@ Validation and Verification Criteria
 References
 ~~~~~~~~~~
 
-.. [DAS_Cochrane_Review_2019] 
-  
+.. [DAS_Cochrane_Review_2019]
+
   View `DAS Cochrane Review 2019`_
 
     Preventive lipid‐based nutrient supplements given with complementary foods to infants and young children 6 to 23 months of age for health, nutrition, and developmental outcomes

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -497,7 +497,10 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
 
 .. note::
 
-  To define an appropriate lognormal distribution for the uncertainty in :math:`k`, we will assume that the distribution has geometric mean 6.7 with a central 95% confidence interval approximately equal to (5.3, 8.4). This is a reasonable assumption since
+  To define an appropriate lognormal distribution for the uncertainty in
+  :math:`k`, we will assume that the distribution has geometric mean 6.7 with a
+  central 95% confidence interval approximately equal to (5.3, 8.4). This is a
+  reasonable assumption since
 
   .. math::
     \sqrt{5.3 \times 8.4} = 6.672330927044911... \approx 6.7,

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -495,6 +495,22 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - :ref:`defined on the wasting documentation <2020_risk_exposure_wasting_state_exposure>`
     - GBD
 
+.. note::
+
+  To define an appropriate lognormal distribution for the uncertainty in :math:`k`, we will assume that the distribution has geometric mean 6.7 with a central 95% confidence interval approximately equal to (5.3, 8.4). This is a reasonable assumption since
+
+  .. math::
+    \sqrt{5.3 \times 8.4} = 6.672330927044911... \approx 6.7,
+
+  whereas :math:`(5.3+8.4)/2 = 6.85>6.7`, so the confidence interval is
+  asymmetric, with 6.7 being closer to the geometric mean of the endpoints than
+  to the arithmetic mean. To create an appropriate lognormal distribution, see
+  the :ref:`algorithm for fitting a lognormal distribution
+  <lognorm_from_median_lower_upper_code_block>` to a specified median and
+  confidence interval on the :ref:`Statistical Distributions of Uncertainty
+  <vivarium_best_practices_statistical_distributions>` page (note that the
+  median of a lognormal distribution equals its geometric mean).
+
 .. todo::
 
     Confirm validity of uncertainty distribution assumptions.

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -32,7 +32,7 @@
 .. _intervention_wasting_treatment:
 
 ===============================================
-Treatment and management for acute malnutrition 
+Treatment and management for acute malnutrition
 ===============================================
 
 .. contents::
@@ -49,7 +49,7 @@ Treatment and management for acute malnutrition
   * - FMOH
     - Federal ministry of health
   * - SAM
-    - severe acute malnutrition 
+    - severe acute malnutrition
   * - MAM
     - moderate acute malnutrition
   * - DHS
@@ -63,28 +63,28 @@ Treatment and management for acute malnutrition
   * - HDG
     - Health Development Group
   * - HP
-    - Health post 
+    - Health post
   * - OTP
     - Outpatient Therapeutic Programme
   * - TSFP
-    - Targeted Supplementary Feeding Programme 
+    - Targeted Supplementary Feeding Programme
   * - SC
     - Stablisation Centre
   * - PSNP
     - Productive Safety Net Programme
-  * - TSFP 
+  * - TSFP
     - Targeted Supplementary Feeding Programme
   * - BSFP
     - Blanket Supplementary Feeding Programme
   * - IYCF
     - Infant and young child feeding
-  * - WFL 
+  * - WFL
     - weight-for-length z-score (used in EMOH guideline)
-  * - WFH 
+  * - WFH
     - weight-for-height z-score (used in EMOH guideline)
-  * - WLZ 
+  * - WLZ
     - weight-for-length z-score (used in GBD)
-  * - WHZ 
+  * - WHZ
     - weight-for-height z-score (used in GBD)
   * - SQUEAC
     - Simplified Lot Quality Assurance Sampling Evaluation of Access and Coverage
@@ -92,11 +92,11 @@ Treatment and management for acute malnutrition
     - Treated or treatment
   * - utx
     - Not treated
-  * - EPI 
+  * - EPI
     - Expanded programme on immunization
   * - CMAM
     - Community-based management of acute malnutrition
-  * - CTC 
+  * - CTC
     - Community-based therapeutic care
 
 This documentation focuses on treatment and management of acute malnutrition in Ethiopia based on 2019 National Guideline for the Management of Acute Malnutrition. [EMOH]_
@@ -115,7 +115,7 @@ Intervention Overview
 ---------------------
 
 This flow chart summarizes the core aspects of the care and treatment for SAM and MAM, and integration into the
-routine health system. 
+routine health system.
 
 .. image:: flow_chart_management_of_acute_malnutrition.svg
    :alt: Flow chart of management of acute malnutrition
@@ -132,7 +132,7 @@ Health system delivery
 Interventions for wasting treatment are delivered through different levels of the health system.
 
 :underline:`Community and household level`
- 
+
  Community outreach ensures early identification of SAM and MAM cases. Community outreach also aims to empower communities and families to understand the causes of malnutrition, and prevent and manage acute malnutrition in their communities. Health Extension Workers (HEWs) collaborate with the community-based structures such as health committees and engage with the Health Development Army (HDA)/Health Development Group (HDG) to screen and refer cases to the appropriate service for treatment.
 
 :underline:`Health post level`
@@ -157,9 +157,9 @@ which are based on the 2013 WHO guidelines on management of SAM in children and 
 
 :download:`2019 guidelines<guidelines_2019.pdf>`
 
-.. note:: 
-  
-    - In GBD, SAM and MAM are classified as using WHZ score. In reality, GBD-MAM kids with oedema are treated as SAM kids. The proportion (sequelae) of GBD-MAM kids with oedema is approximately 2%. In our model these will be classified as MAM. 
+.. note::
+
+    - In GBD, SAM and MAM are classified as using WHZ score. In reality, GBD-MAM kids with oedema are treated as SAM kids. The proportion (sequelae) of GBD-MAM kids with oedema is approximately 2%. In our model these will be classified as MAM.
 
 
 Severe acute malnutrition (SAM)
@@ -171,7 +171,7 @@ SAM in infants (0-6 months)
 :underline:`Classify SAM in infants`
 
 * Any grade of bilateral pitting oedema (+, ++ or +++) OR
-* WHZ < -3 zscore 
+* WHZ < -3 zscore
 
 Treatment of infants with SAM in the SC
 
@@ -181,14 +181,14 @@ NOTE: All infants 0-6 months of age with SAM with or without medical complicatio
 SAM in children (>6 months)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Since 2007, a new model of care called community-based therapetic care (CTC) or community-based management of acute malnutrition (CMAM) has been endorsed for the treatment of acute malnutrition which addresses the limitations of previous inpatient therapeutic feeding programmes. Patients with severe malnutrition, with good appetite and without medical complications are treated in the outpatient therapeutic programme (OTP) that provides ready-to-use therapeutic food (RUTF) and medicines to treat simple conditions. The food and medicines are taken home and patient attends OTP site weekly for monitoring and resupply. 
+Since 2007, a new model of care called community-based therapetic care (CTC) or community-based management of acute malnutrition (CMAM) has been endorsed for the treatment of acute malnutrition which addresses the limitations of previous inpatient therapeutic feeding programmes. Patients with severe malnutrition, with good appetite and without medical complications are treated in the outpatient therapeutic programme (OTP) that provides ready-to-use therapeutic food (RUTF) and medicines to treat simple conditions. The food and medicines are taken home and patient attends OTP site weekly for monitoring and resupply.
 
-Severely malnourished persons with medical complications and/or anorexia are treated in an inpatient stabilization center (SC) where they receive standard World Health Organization (WHO)- recommended initial care until they have enough appetite and are well enough to continue with outpatient care. Approximately 10-15% of children in CMAM programmes require inpatient care at the stabilisation centers and the average length-of-stay at an SC is 14 days before they are transferred out to an OTP. [Scott_2020]_ [Tekeste_2012]_ 
+Severely malnourished persons with medical complications and/or anorexia are treated in an inpatient stabilization center (SC) where they receive standard World Health Organization (WHO)- recommended initial care until they have enough appetite and are well enough to continue with outpatient care. Approximately 10-15% of children in CMAM programmes require inpatient care at the stabilisation centers and the average length-of-stay at an SC is 14 days before they are transferred out to an OTP. [Scott_2020]_ [Tekeste_2012]_
 
 :underline:`Classify SAM without medical complications`
 
-* Bilateral pitting oedema + or ++ OR 
-* WHZ <-3 z-scores AND 
+* Bilateral pitting oedema + or ++ OR
+* WHZ <-3 z-scores AND
 * Appetite test passed
 * No medical complications
 * Clinically well and alert
@@ -196,12 +196,12 @@ Severely malnourished persons with medical complications and/or anorexia are tre
 Treatment of children with SAM in OTP
 
 - Admit in OTP (outpatient) programme
-- Treatment and care are provided at home with weekly follow-up visits at a nearby health facility. 
+- Treatment and care are provided at home with weekly follow-up visits at a nearby health facility.
 - Give routine medications.
 
 :underline:`Classify SAM with medical complications`
 
-* Any grade of bilateral pitting oedema (+, ++, +++) OR 
+* Any grade of bilateral pitting oedema (+, ++, +++) OR
 * WHZ < -3 zscore OR
 * Presence of any medical complications (see guideline for full list)
 
@@ -215,11 +215,11 @@ Treatment of children with SAM in SC
 
 Discharge criteria
 
- - Cured = Has reached discharge criteria for SAM treatment: WHZ ≥ -2 z-scores, no bilateral pitting oedema, clinically alert and well. 
+ - Cured = Has reached discharge criteria for SAM treatment: WHZ ≥ -2 z-scores, no bilateral pitting oedema, clinically alert and well.
  - Died = Dies while receiving treatment in the OTP.
  - Defaulted = Absent for two consecutive visits.
  - Non-responder = Does not reach the SAM discharge criteria after 16 weeks (4 months) in treatment.
- - Transferred out = Condition has deteriorated or not responding to treatment according to action protocol and referred for treatment 
+ - Transferred out = Condition has deteriorated or not responding to treatment according to action protocol and referred for treatment
    in the SC, or moved out to receive OTP in another facility
 
 
@@ -229,8 +229,8 @@ MAM in infants (0-6 months)
 :underline:`Classify MAM in infants`
 
 * MUAC of lactatating mother of infant 0-6 months <23.0 cm
-* WHZ ≥-3 to <-2 AND 
-* No bilateral pitting oedema AND 
+* WHZ ≥-3 to <-2 AND
+* No bilateral pitting oedema AND
 * No medical complications
 * Clinically well and alert
 
@@ -245,7 +245,7 @@ MAM in children >6 months
 :underline:`Classify MAM in children`
 
 * WHZ ≥ -3 to <-2 z scores AND
-* No bilateral pitting oedema 
+* No bilateral pitting oedema
 * No medical complications
 * Clinically well and alert
 
@@ -270,20 +270,20 @@ No acute malnutrition
 
 :underline:`Classify no acute malnutrition in infants`
 
-* WHZ ≥-2 zscores AND 
+* WHZ ≥-2 zscores AND
 * No bilateral pitting oedema
 
-**Treatment** 
+**Treatment**
 
 Congratulate and counsel the mother on appropriate IYCF practices.
 
 .. todo::
     What about MAM with oedema? Are they treated as SAM or MAM?
-    Answer: they are treated as MAM in GBD, but in reality, probably SAM. MAM with oedema is approximately 2% of MAM. 
+    Answer: they are treated as MAM in GBD, but in reality, probably SAM. MAM with oedema is approximately 2% of MAM.
 
 :underline:`Classify no acute malnutritionin children`
 
-* WHZ ≥ -2 z score AND 
+* WHZ ≥ -2 z score AND
 * No bilateral pitting oedema
 
 **Treatment**
@@ -303,7 +303,7 @@ Congratulate and counsel the mother on appropriate IYCF practices.
     - Modeled?
     - Note (ex: is this relationship direct or mediated?)
   * - Time-to-recovery
-    - Decreases 
+    - Decreases
     - Yes
     - Direct relationship
   * - Death rate
@@ -331,11 +331,11 @@ The aim and priority in community-based services for the management of acute mal
 
   Treatment coverage = :math:`\frac{\text{Children with MAM/SAM recieving treatment}}{\text{Total number of MAM/SAM kids}}`
 
-Treatment coverage should not be confused with geographical coverage. 
+Treatment coverage should not be confused with geographical coverage.
 
   Geographical coverage (GC) = :math:`\frac{\text{Healthcare facilities/communities delivering MAM/SAM treatments}}{\text{Total number of facilities/communities}}`
 
-Geographic coverage attempts to measure the *availability* of services which does not equate with the *service access* and *uptake*. 
+Geographic coverage attempts to measure the *availability* of services which does not equate with the *service access* and *uptake*.
 
 **Effectively covered** is the product of the treatment coverage and the treatment efficacy (proportion of the treated who were cured or 'cure-rate').
 
@@ -346,12 +346,12 @@ Geographic coverage attempts to measure the *availability* of services which doe
 .. image:: effective_coverage_figure.svg
 
 | SAM programme treatment coverage: 48.8% (37.4-60.4) (this is a point coverage; assumes programmes are not good at case finding) [Isanaka_2021]_
-| MAM programme treatment coverage: same as SAM for now until this website is updated https://acutemalnutrition.org/en/countries 
+| MAM programme treatment coverage: same as SAM for now until this website is updated https://acutemalnutrition.org/en/countries
 
 .. todo::
 
-  Discuss how coverage is estimated (SQUEAC surveys). Discuss difference in point-coverage and period-coverage. 
- 
+  Discuss how coverage is estimated (SQUEAC surveys). Discuss difference in point-coverage and period-coverage.
+
 See the `parameter values table`_ for coverage and effictiveness values for use in the model.
 
 .. note::
@@ -367,14 +367,14 @@ Vivarium Modeling Strategy
 .. image:: treatment_diagram.svg
    :alt: Compartmental diagram with treatment
 
-So, 
+So,
 
- - :math:`r2_{ux} = r_{SAM,ux} = \frac{t}{\text{median time-to-recovery (days) of utx SAM}}` 
- - :math:`t1_{sam} = r_{SAM,tx} = \frac{t}{\text{median time-to-recovery (days) of tx SAM}}` 
- - :math:`r3_{ux} = r_{MAM,ux} = \frac{t}{\text{median time-to-recovery (days) of utx MAM}}` 
- - :math:`t2_{mam} = r_{MAM,tx} = \frac{t}{\text{median time-to-recovery (days) of tx MAM}}` 
+ - :math:`r2_{ux} = r_{SAM,ux} = \frac{t}{\text{median time-to-recovery (days) of utx SAM}}`
+ - :math:`t1_{sam} = r_{SAM,tx} = \frac{t}{\text{median time-to-recovery (days) of tx SAM}}`
+ - :math:`r3_{ux} = r_{MAM,ux} = \frac{t}{\text{median time-to-recovery (days) of utx MAM}}`
+ - :math:`t2_{mam} = r_{MAM,tx} = \frac{t}{\text{median time-to-recovery (days) of tx MAM}}`
 
-where t is the period for which transition the is estimated (a year) eg. 365 days using days as the unit and the duration of time-to-recovery is age-specific and "treated" refers to *effective* treatment. 
+where t is the period for which transition the is estimated (a year) eg. 365 days using days as the unit and the duration of time-to-recovery is age-specific and "treated" refers to *effective* treatment.
 
 .. todo::
 
@@ -383,8 +383,8 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
 .. important::
 
    For model 2 (wasting exposure only with baseline coverage of treatment but treatment-not-tracked),the above reciprocal of durations were weighted by the baseline treatment coverage of 0.488 (C). Also note that the recovery durations we used for model 2 were slightly different than what we have here in model 4. In model 2, we used:
-  
-   - r2_ux (sam untreated) = (1-C) x 1/60.5 days 
+
+   - r2_ux (sam untreated) = (1-C) x 1/60.5 days
    - t1_sam = C x 1/48.3 days
    - r3_ux (mam untreated) = (1-C) x 1/63 days
    - t2_mam = C x 1/41.3 days
@@ -392,7 +392,7 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
 
    Additionally, for the recovery rate from MAM, we used r3 which was = r3_ux(1-C) + t2_mam(C). (See wasting exposure 2020 documentation for the use of these rates).
 
-   Note also that we used the same recovery duration for 0-6 months as 6-59 months in model 2. We have now updated the recovery durations for effectively treated population to be specific for 0-6 months in this model 4. 
+   Note also that we used the same recovery duration for 0-6 months as 6-59 months in model 2. We have now updated the recovery durations for effectively treated population to be specific for 0-6 months in this model 4.
 
 .. list-table:: Annual recovery rate equations
   :header-rows: 1
@@ -438,13 +438,13 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - 0-6 months old
     - mean: 13.3, sd: 6.9
     - normal
-    - 
+    -
     - [Vygen_2013]_; Niger
   * - :math:`duration_\text{treated SAM}`
     - 6-59 months old
     - 48.3
     - point value
-    - 
+    -
     - [Zw_2020tx]_; Ethiopia
   * - :math:`duration_\text{untreated MAM}`
     - 0-59 months old
@@ -456,13 +456,13 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - 0-6 months old
     - 20.8
     - point value
-    - 
+    -
     - [Woeltje_2020]_; Malawi
   * - :math:`duration_\text{treated MAM}`
     - 6-59 months old
     - 41.3 (95% CI: 34.4, 49)
     - normal
-    - 
+    -
     - [Ackatia_Armah_2015tx]_; Mali
   * - :math:`C`
     - 0-59 months old
@@ -486,7 +486,7 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - 0-59 months old
     - 6.7(95% CI: 5.3-8.4)
     - lognormal
-    - 
+    -
     - [Isanaka_2021]_
   * - :math:`mortality_{SAM|a,s,l,y}`
     - GBD demographic group
@@ -499,7 +499,7 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
 
     Confirm validity of uncertainty distribution assumptions.
 
-    Try to update the weighted time-to-recovery for SAM children admitted to OTP. There are 7 studies from the Zw 2020 paper that reports median (IQR) time to recovery in table 1. The 48.3 days currently in the table is just a weighted average. It would be better to find a way to get the summary value (random effects?) with the uncertainty distribution. Nathanial might have a way to do this. 
+    Try to update the weighted time-to-recovery for SAM children admitted to OTP. There are 7 studies from the Zw 2020 paper that reports median (IQR) time to recovery in table 1. The 48.3 days currently in the table is just a weighted average. It would be better to find a way to get the summary value (random effects?) with the uncertainty distribution. Nathanial might have a way to do this.
 
 Deriving :math:`r_{SAM,ux}` using the following three equations:
 
@@ -519,18 +519,18 @@ So...
 
 .. note::
 
-  A note on the incidence correction factor, :math:`k`: 
+  A note on the incidence correction factor, :math:`k`:
 
 
-    The incidence correction factor :math:`k` is = :math:`\frac{t}{\text{average duration of disease}}`, where :math:`t` is the period for which incidence is estimated (a year) eg. 365 days using days as the unit 
+    The incidence correction factor :math:`k` is = :math:`\frac{t}{\text{average duration of disease}}`, where :math:`t` is the period for which incidence is estimated (a year) eg. 365 days using days as the unit
 
-    k = :math:`\frac{\text{number of incident cases}}{\text{number of prevalent cases}}` see [Isanaka_2021]_ for full proof and equations. 
+    k = :math:`\frac{\text{number of incident cases}}{\text{number of prevalent cases}}` see [Isanaka_2021]_ for full proof and equations.
 
     Number of incident cases = :math:`\frac{\text{annual programme admissions}}{\text{treatment coverage}}`
 
 .. important::
 
-  In this first run that Rajan is building (August-18-21), we are not modelling treatment in the first 28 days of life. If we do model treatment in this first 28 days, the prevalence of wasting by the time they reach post-neonatal age groups in the scale-up scenario will be different (reduced). We should think through the relationship between wasting and LBWSG in the neonatal age groups and see if we want to add treatment back into the first month of life. 
+  In this first run that Rajan is building (August-18-21), we are not modelling treatment in the first 28 days of life. If we do model treatment in this first 28 days, the prevalence of wasting by the time they reach post-neonatal age groups in the scale-up scenario will be different (reduced). We should think through the relationship between wasting and LBWSG in the neonatal age groups and see if we want to add treatment back into the first month of life.
 
 .. todo::
 
@@ -538,24 +538,24 @@ So...
 
 .. note::
 
-  How the value r2_ux was derived for model 2 (note we did use an efficacy (E) in model 2): 
+  How the value r2_ux was derived for model 2 (note we did use an efficacy (E) in model 2):
 
-  1) From Isanaka 2021, the incidence correction factor K = 6.7 for a population SAM coverage of 48.8% 
+  1) From Isanaka 2021, the incidence correction factor K = 6.7 for a population SAM coverage of 48.8%
   2) K = 1 year/duration of SAM (in years) = 6.7
   3) Duration of SAM in years = 1/6.7 = 0.149253 years = 54.5 days
-  4) 365/(r2_ux + t1_sam + d1) = 54.5 
+  4) 365/(r2_ux + t1_sam + d1) = 54.5
   5) 365/(r2_ux + [0.488 x 365/48.3] + [yearly rate of death]) = 54.5; using d1 = 0.015 for age_group 4 and sex 2
   6) r2_ux = 2.9945
   7) r2_ux = (1-Csam) X 365/Dsam_utx (1-Csam = 0.512)
   8) Dsam_utx ~ 62 days (will need to recalculate by age and sex; this is sightly higher than model 4)
 
-  Note that 
+  Note that
 
   r2_ux = untreated% x 365/Dsam_utx
   t1_sam = treated% x 365/Dsam_tx
 
   Also note that Dsam_tx < Dsam_utx (time to recovery of tx SAM is shorter than time to recovery of untreated SAM)
-  
+
   *We did not calculate a specific r2_ux value for each age and sex in model 2*
 
 Affected Outcomes
@@ -563,7 +563,7 @@ Affected Outcomes
 
 The Vivarium modeling strategy above details how to solve for the transition rates among the covered uncovered populations. However, the wasting treatment intervention will be implemented as a variable that affects the relative risk of certain transition rates between wasting states in the :ref:`dynamic wasting model <2020_risk_exposure_wasting_state_exposure>`. The following table details the relative risks for each dynamic wasting model transition rate that is affected by wasting treatment based on a given treatment category.
 
-.. list-table:: Wasting transition rate relative risks for wasting treatment 
+.. list-table:: Wasting transition rate relative risks for wasting treatment
   :header-rows: 1
 
   * - Transition
@@ -573,7 +573,7 @@ The Vivarium modeling strategy above details how to solve for the transition rat
   * - r3
     - Untreated/uncovered by :math:`C`
     - :math:`\frac{r_{MAM,ux}}{r_{MAM,tx} * E_{MAM} + r_{MAM,ux} * (1 - E_{MAM})}`
-    - 
+    -
   * - t1
     - Untreated/uncovered by :math:`C`
     - 0
@@ -585,15 +585,15 @@ The Vivarium modeling strategy above details how to solve for the transition rat
   * - r3
     - Treated/covered by :math:`C`
     - 1
-    - 
+    -
   * - t1
     - Treated/covered by :math:`C`
     - 1
-    - 
+    -
   * - r2
     - Treated/covered by :math:`C`
     - 1
-    - 
+    -
 
 **How to apply treatment effects at the simulant level**
 
@@ -630,7 +630,7 @@ Scenarios
   * - :math:`C`
     - 0.488 (95% CI:0.374-0.604)
     - 0.9
-    - 
+    -
   * - :math:`E_{SAM}`
     - 0.731 (95% CI:0.585-0.877), normal
     - 0.75
@@ -644,24 +644,24 @@ Scenarios
 
   Changing the :math:`E_{SAM}` and :math:`E_{MAM}` rates between the baseline and alternative scenarios will change the rate of simulants covered by MAM/SAM treatment that transition through the treated and untreated pathways (the treated pathway transition rate will be greater and the untreated pathway transition rate will be lower in the alternative scenario relative to the the baseline scenario). This should be reflected in the implementation of the treatment model.
 
-  Also, :math:`E_{SAM}` and :math:`E_{MAM}` fractions may depend on diarrheal status in later model builds. 
+  Also, :math:`E_{SAM}` and :math:`E_{MAM}` fractions may depend on diarrheal status in later model builds.
 
 Restrictions
 ++++++++++++
 
-For treatment of SAM and MAM, we model treatment starting in the post-neonatal age groups (after the first 28 days of life). This is true for both baseline and treatment scale-up scenarios. This is because in GBD, the burden (death, disability) in the neonatal age groups are all attributable to LBWSG. Hence, it is not very meaningful to 'treat' wasting in this age group as the treatment will not impove DALYs. 
+For treatment of SAM and MAM, we model treatment starting in the post-neonatal age groups (after the first 28 days of life). This is true for both baseline and treatment scale-up scenarios. This is because in GBD, the burden (death, disability) in the neonatal age groups are all attributable to LBWSG. Hence, it is not very meaningful to 'treat' wasting in this age group as the treatment will not impove DALYs.
 
-Note that for the exposure, we model a 'birth prevalence' which is the prevalence of wasting of the post-neontal age group extrapolated to the neonatal age groups. This is to ensure our post-neonatal age groups initialize at the correct prevalences to start the wasting transitions. 
+Note that for the exposure, we model a 'birth prevalence' which is the prevalence of wasting of the post-neontal age group extrapolated to the neonatal age groups. This is to ensure our post-neonatal age groups initialize at the correct prevalences to start the wasting transitions.
 
-Also note that since wasting and LBWSG are correlated, those with more severe wasting will have higher likelihood to die in the first month as those with lower birthweights have higher risk of death. This might lead to a bias in our wasting exposures at the post-neonatal age groups to favour healthier babies. 
+Also note that since wasting and LBWSG are correlated, those with more severe wasting will have higher likelihood to die in the first month as those with lower birthweights have higher risk of death. This might lead to a bias in our wasting exposures at the post-neonatal age groups to favour healthier babies.
 
 .. list-table:: Affected outcomes restrictions
   :widths: 20 20 20
   :header-rows: 1
 
   * - Restriction
-    - Value 
-    - Note 
+    - Value
+    - Note
   * - Male only
     - False
     -
@@ -673,7 +673,7 @@ Also note that since wasting and LBWSG are correlated, those with more severe wa
     - 1m-5m = 388 GBD 2020; 1m-12m = 4 GBD 2019
   * - Age group end
     - 2 - 4 years age_group_id = 34
-    - 2y-4y = 34 GBD 2020; 1y-5y = 5 GBD 2019 
+    - 2y-4y = 34 GBD 2020; 1y-5y = 5 GBD 2019
   * - Other
     -
     -
@@ -685,8 +685,8 @@ Assumptions and Limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 #. We are not applying a differential death rate to those effectively covered vs not effectively covered
-#. We are generalizing across the whole country. There is likely to be a lot of heterogeneity within the country. 
-#. We do not have the durations of untreated SAM and MAM for 0-6 age groups hence we are using the durations from 6-59 age groups. 
+#. We are generalizing across the whole country. There is likely to be a lot of heterogeneity within the country.
+#. We do not have the durations of untreated SAM and MAM for 0-6 age groups hence we are using the durations from 6-59 age groups.
 #. We assume that MAM treatment coverage is equal to SAM treatment coverage. Given that SAM treatment is more intensive than MAM treatment, we may underestimate MAM treatment coverage as a result of this assumption.
 #. We assume that MAM and SAM treatment effectivenesses are independent from one another.
 #. We assume that individual simulant's propensity to respond to wasting treatment is independent of their previous response/non-response to treatment. According to [Zw_2020tx]_, SAM treatment response rates are associated with diarrhea, oedema, and use of antibiotics in the treament course in Ethiopia. Additionally, vitamin A supplementation and distance from the treatment center may be associated with SAM treatment response rates, although direct evidence was not provided [Zw_2020tx]_. We chose to make this assumption given the non-deterministic nature of these factors.
@@ -706,13 +706,13 @@ Validation and Verification Criteria
 References
 ----------
 
-.. [EMOH] Government of Ethiopia, Federal Ministry of Health. 2019. 
+.. [EMOH] Government of Ethiopia, Federal Ministry of Health. 2019.
    National Guideline for the Management of Acute
    Malnutrition. Addis Ababa: FMOH.
 
 
-.. [WHO_2013_SAM_guidelines] 
-  
+.. [WHO_2013_SAM_guidelines]
+
   View `WHO 2013 SAM guidelines`_
 
     Updates on the management of severe acute malnutrition in infants and children
@@ -731,7 +731,7 @@ References
 
 .. [CMAM_Forum_coverage]
 
-  View `CMAM Forum coverage`_ 
+  View `CMAM Forum coverage`_
 
     Assessment of Coverage of Community-based Management of Acute Malnutrition
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -64,6 +64,16 @@ if and only if its exponential :math:`X = \exp(Y)` satisfies :math:`X \sim
 Defining a log-normal distribution to simulate parameter uncertainty
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+A lognormal distribution may be an appropriate model of uncertainty for any
+positive, unbounded quantity :math:`X`. Rates and relative risks are common
+model parameters for which a lognormal distribution may be appropriate. If the
+literature reports a value :math:`v` for :math:`X` and a 95% confidence interval
+:math:`(a,b)` such that :math:`v` is close to the geometric mean of the
+endpoints (that is, :math:`v \approx \sqrt{ab}`, which is to the *left* of the
+interval's midpoint), this is a good indication that the uncertainty in
+:math:`X` can be modeled by a lognormal distribution with geometric mean
+:math:`v` and central 95% interval :math:`(a,b)`.
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -1,6 +1,6 @@
 ..
   Section title decorators for this document:
-  
+
   ==============
   Document Title
   ==============
@@ -48,6 +48,9 @@ Common Statistical Distributions
   - Ensemble
   - Etc.
 
+Log-normal distribution
++++++++++++++++++++++++
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 
@@ -62,7 +65,7 @@ Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 Other Considerations
 --------------------
 
-.. todo:: 
+.. todo::
 
   - How to handle very asymmetric confidence intervals
   - How to handle uncertainty in data source(s) rather than statistical uncertainty from a single high quality data source?

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -51,6 +51,16 @@ Common Statistical Distributions
 Log-normal distribution
 +++++++++++++++++++++++
 
+A random variable :math:`X` has a `log-normal distribution`_ with parameters
+:math:`\mu` and :math:`\sigma^2`, denoted :math:`X\sim \mathrm{Lognorm}(\mu,
+\sigma^2)`, if and only if its logarithm :math:`Y=\log(X)` has a normal
+distribution with mean :math:`\mu` and variance :math:`\sigma^2`. Equivalently,
+a random variable :math:`Y` satisfies :math:`Y\sim \mathcal{N}(\mu, \sigma^2)`
+if and only if its exponential :math:`X = \exp(Y)` satisfies :math:`X \sim
+\mathrm{Lognorm}(\mu, \sigma^2)`.
+
+.. _log-normal distribution: https://en.wikipedia.org/wiki/Log-normal_distribution
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -52,7 +52,7 @@ Log-normal distribution
 +++++++++++++++++++++++
 
 A random variable :math:`X` has a `log-normal distribution`_ with parameters
-:math:`\mu` and :math:`\sigma^2`, denoted :math:`X\sim \mathrm{Lognorm}(\mu,
+:math:`\mu` and :math:`\sigma`, denoted :math:`X\sim \mathrm{Lognorm}(\mu,
 \sigma^2)`, if and only if its logarithm :math:`Y=\log(X)` has a normal
 distribution with mean :math:`\mu` and variance :math:`\sigma^2`. Equivalently,
 a random variable :math:`Y` satisfies :math:`Y\sim \mathcal{N}(\mu, \sigma^2)`
@@ -73,6 +73,17 @@ endpoints (that is, :math:`v \approx \sqrt{ab}`, which is to the *left* of the
 interval's midpoint), this is a good indication that the uncertainty in
 :math:`X` can be modeled by a lognormal distribution with geometric mean
 :math:`v` and central 95% interval :math:`(a,b)`.
+
+A lognormal distribution with parameters :math:`\mu` and :math:`\sigma` has
+geometric mean :math:`e^\mu`, which is also equal to the median of the
+distribution. Below is Python code to construct a `scipy.stats lognormal
+distribution`_ with a specified geometric mean (median) :math:`e^\mu = v =`
+``median`` and approximate central 95% interval :math:`(a,b)` (where :math:`a =`
+``lower`` and :math:`b =` ``upper``). The interval :math:`(a,b)` will be exactly
+the central 95% interval of the distribution if and only if :math:`v =
+\sqrt{ab}`.
+
+.. _scipy.stats lognormal distribution: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html
 
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -48,6 +48,8 @@ Common Statistical Distributions
   - Ensemble
   - Etc.
 
+.. _lognormal_distribution_section:
+
 Log-normal distribution
 +++++++++++++++++++++++
 
@@ -60,6 +62,8 @@ if and only if its exponential :math:`X = \exp(Y)` satisfies :math:`X \sim
 \mathrm{Lognorm}(\mu, \sigma^2)`.
 
 .. _log-normal distribution: https://en.wikipedia.org/wiki/Log-normal_distribution
+
+.. _lognormal_parameter_uncertainty_section:
 
 Defining a log-normal distribution to simulate parameter uncertainty
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -85,6 +89,8 @@ the central 95% interval of the distribution if and only if :math:`v =
 
 .. _scipy.stats lognormal distribution: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html
 
+.. _lognorm_from_median_lower_upper_code_block:
+
 .. code-block:: Python
 
   import numpy as np
@@ -95,7 +101,9 @@ the central 95% interval of the distribution if and only if :math:`v =
     the values (lower, upper) are approximately equal to the quantiles with ranks
     (quantile_ranks[0], quantile_ranks[1]). More precisely, if q0 and q1 are
     the quantiles of the returned distribution with ranks quantile_ranks[0]
-    and quantile_ranks[1], respectively, then q1/q0 = upper/lower.
+    and quantile_ranks[1], respectively, then q1/q0 = upper/lower. If the
+    quantile ranks are symmetric about 0.5, lower and upper will coincide with
+    q0 and q1 precisely when median^2 = lower*upper.
     """
     # Let Y ~ Norm(mu, sigma^2) and X = exp(Y), where mu = log(median)
     # so X ~ Lognorm(s=sigma, scale=exp(mu)) in scipy's notation.

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -67,7 +67,7 @@ Defining a log-normal distribution to simulate parameter uncertainty
 A lognormal distribution may be an appropriate model of uncertainty for any
 positive, unbounded quantity :math:`X`. Rates and relative risks are common
 model parameters for which a lognormal distribution may be appropriate. If the
-literature reports a value :math:`v` for :math:`X` and a 95% confidence interval
+literature reports a value :math:`v` for :math:`X` and an asymmetric 95% confidence interval
 :math:`(a,b)` such that :math:`v` is close to the geometric mean of the
 endpoints (that is, :math:`v \approx \sqrt{ab}`, which is to the *left* of the
 interval's midpoint), this is a good indication that the uncertainty in
@@ -118,7 +118,19 @@ and :math:`\sigma`, specifying the distribution from the three parameters
 an overdetermined system if the specified median :math:`v` is not exactly equal
 to the geometric mean of :math:`a`, and :math:`b`. In ths case, the above code
 actually determines the distribution's two parameters from the median :math:`v`
-and the ratio :math:`b/a`.
+and the ratio :math:`b/a`, and the returned distribution's central 95% interval
+will only be approximately equal to :math:`(a,b)`.
+
+If the confidence interval :math:`(a,b)` was in fact generated from a log-normal
+distribution with the reported value :math:`v` being an estimate of the
+geometric mean :math:`e^\mu` of :math:`X`, then any discrepancy between
+:math:`v` and :math:`\sqrt{ab}` would be due to rounding errors. In this case,
+the above function incorporates all available data and generally results in a
+better fit than using only one of the two estimated quantiles :math:`a` or
+:math:`b`. See Nathaniel's `notebook investigating different lognormal
+distributions`_ for the :ref:`CIFF acute malnutrition project <2019_concept_model_vivarium_ciff_sam>`.
+
+.. _notebook investigating different lognormal distributions: https://github.com/ihmeuw/vivarium_research_ciff_sam/blob/main/wasting_transitions/uncertainty/2021_09_03c_lognormal_distributions_for_k_sam.ipynb
 
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -85,6 +85,33 @@ the central 95% interval of the distribution if and only if :math:`v =
 
 .. _scipy.stats lognormal distribution: https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html
 
+.. code-block:: Python
+
+  import numpy as np
+  from scipy import stats
+
+  def lognorm_from_median_lower_upper(median, lower, upper, quantile_ranks=(0.025,0.975)):
+    """Returns a frozen lognormal distribution with the specified median, such that
+    (lower, upper) are approximately equal to the quantiles with ranks
+    (quantile_ranks[0], quantile_ranks[1]).
+    """
+    # Let Y ~ Norm(mu, sigma^2) and X = exp(Y), where mu = log(median)
+    # so X ~ Lognorm(s=sigma, scale=exp(mu)) in scipy's notation.
+    # We will determine sigma from the two specified quantiles lower and upper.
+
+    # mean (and median) of the normal random variable Y = log(X)
+    mu = np.log(median)
+    # quantiles of the standard normal distribution corresponding to quantile_ranks
+    stdnorm_quantiles = stats.norm.ppf(quantile_ranks)
+    # quantiles of Y = log(X) corresponding to the quantiles (lower, upper) for X
+    norm_quantiles = np.log([lower, upper])
+    # standard deviation of Y = log(X) computed from the above quantiles for Y
+    # and the corresponding standard normal quantiles
+    sigma = (norm_quantiles[1] - norm_quantiles[0]) / (stdnorm_quantiles[1] - stdnorm_quantiles[0])
+    # Frozen lognormal distribution for X = exp(Y)
+    # (s=sigma is the shape parameter; the scale parameter is exp(mu), which equals the median)
+    return stats.lognorm(s=sigma, scale=median)
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -112,6 +112,14 @@ the central 95% interval of the distribution if and only if :math:`v =
     # (s=sigma is the shape parameter; the scale parameter is exp(mu), which equals the median)
     return stats.lognorm(s=sigma, scale=median)
 
+Note that since the log-normal distribution has only two parameters :math:`\mu`
+and :math:`\sigma`, specifying the distribution from the three parameters
+:math:`v=` ``median``, :math:`a=` ``lower``, and :math:`b=` ``upper`` results in
+an overdetermined system if the specified median :math:`v` is not exactly equal
+to the geometric mean of :math:`a`, and :math:`b`. In ths case, the above code
+actually determines the distribution's two parameters from the median :math:`v`
+and the ratio :math:`b/a`.
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -132,6 +132,12 @@ distributions`_ for the :ref:`CIFF acute malnutrition project <2019_concept_mode
 
 .. _notebook investigating different lognormal distributions: https://github.com/ihmeuw/vivarium_research_ciff_sam/blob/main/wasting_transitions/uncertainty/2021_09_03c_lognormal_distributions_for_k_sam.ipynb
 
+.. todo::
+
+  Investigate more fully what the above algorithm does when there is no
+  lognormal distribution matching the three parameters ``median``, ``lower`` and
+  ``upper`` for the specified quantile ranks.
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -92,8 +92,10 @@ the central 95% interval of the distribution if and only if :math:`v =
 
   def lognorm_from_median_lower_upper(median, lower, upper, quantile_ranks=(0.025,0.975)):
     """Returns a frozen lognormal distribution with the specified median, such that
-    (lower, upper) are approximately equal to the quantiles with ranks
-    (quantile_ranks[0], quantile_ranks[1]).
+    the values (lower, upper) are approximately equal to the quantiles with ranks
+    (quantile_ranks[0], quantile_ranks[1]). More precisely, if q0 and q1 are
+    the quantiles of the returned distribution with ranks quantile_ranks[0]
+    and quantile_ranks[1], respectively, then q1/q0 = upper/lower.
     """
     # Let Y ~ Norm(mu, sigma^2) and X = exp(Y), where mu = log(median)
     # so X ~ Lognorm(s=sigma, scale=exp(mu)) in scipy's notation.
@@ -137,6 +139,13 @@ distributions`_ for the :ref:`CIFF acute malnutrition project <2019_concept_mode
   Investigate more fully what the above algorithm does when there is no
   lognormal distribution matching the three parameters ``median``, ``lower`` and
   ``upper`` for the specified quantile ranks.
+
+  As noted in the docstring, here's a brief description of what the algorithm
+  does. Let :math:`v=` ``median``, :math:`a=` ``lower``, and :math:`b=`
+  ``upper``, and let :math:`(p_0, p_1) =` ``(quantile_ranks[0],
+  quantile_ranks[1])`` be the specified quantile ranks. Then the returned
+  lognormal distribution has median :math:`v` and quantiles :math:`a'` and
+  :math:`b'` of ranks :math:`p_0` and :math:`p_1` such that :math:`b'/a' = b/a`.
 
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -67,12 +67,12 @@ Defining a log-normal distribution to simulate parameter uncertainty
 A lognormal distribution may be an appropriate model of uncertainty for any
 positive, unbounded quantity :math:`X`. Rates and relative risks are common
 model parameters for which a lognormal distribution may be appropriate. If the
-literature reports a value :math:`v` for :math:`X` and an asymmetric 95% confidence interval
-:math:`(a,b)` such that :math:`v` is close to the geometric mean of the
-endpoints (that is, :math:`v \approx \sqrt{ab}`, which is to the *left* of the
-interval's midpoint), this is a good indication that the uncertainty in
-:math:`X` can be modeled by a lognormal distribution with geometric mean
-:math:`v` and central 95% interval :math:`(a,b)`.
+literature reports a value :math:`v` for :math:`X` and an asymmetric 95%
+confidence interval :math:`(a,b)` such that :math:`v` is close to the geometric
+mean of the endpoints (that is, :math:`v \approx \sqrt{ab}`, which is to the
+*left* of the interval's midpoint), this is a good indication that the
+uncertainty in :math:`X` can be modeled by a lognormal distribution with
+geometric mean :math:`v` and central 95% interval :math:`(a,b)`.
 
 A lognormal distribution with parameters :math:`\mu` and :math:`\sigma` has
 geometric mean :math:`e^\mu`, which is also equal to the median of the

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -61,6 +61,9 @@ if and only if its exponential :math:`X = \exp(Y)` satisfies :math:`X \sim
 
 .. _log-normal distribution: https://en.wikipedia.org/wiki/Log-normal_distribution
 
+Defining a log-normal distribution to simulate parameter uncertainty
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Common Model Parameters and Their Possible Appropriate Uncertainty Distributions
 --------------------------------------------------------------------------------
 

--- a/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
+++ b/docs/source/model_design/concept_model/statistical_distributions_uncertainty/index.rst
@@ -113,10 +113,10 @@ the central 95% interval of the distribution if and only if :math:`v =
     return stats.lognorm(s=sigma, scale=median)
 
 Note that since the log-normal distribution has only two parameters :math:`\mu`
-and :math:`\sigma`, specifying the distribution from the three parameters
-:math:`v=` ``median``, :math:`a=` ``lower``, and :math:`b=` ``upper`` results in
-an overdetermined system if the specified median :math:`v` is not exactly equal
-to the geometric mean of :math:`a`, and :math:`b`. In ths case, the above code
+and :math:`\sigma`, using three parameters :math:`v=` ``median``, :math:`a=`
+``lower``, and :math:`b=` ``upper`` to specify the distribution results in an
+overdetermined system if the specified median :math:`v` is not exactly equal to
+the geometric mean of :math:`a` and :math:`b`. In ths case, the above code
 actually determines the distribution's two parameters from the median :math:`v`
 and the ratio :math:`b/a`, and the returned distribution's central 95% interval
 will only be approximately equal to :math:`(a,b)`.


### PR DESCRIPTION
**Tip:** Hide whitespace changes to see my real changes (see screenshot below), since Atom automatically deletes whitespace when I save files.

I added a section to the "Statistical Distributions of Uncertainy" page in the Vivarium Model Design section to describe how to fit a lognormal distribution to a median and confidence interval, and I added links to the algorithm from the SQLNS and Wasting Treatment Intervention pages for the CIFF SAM project.

I believe @rmudambi already implemented these changes in model 4 based on Slack discussions, but this PR makes it official.