### PR TITLE
Roll back sphinx-rtd-theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==4.0.2
-sphinx_rtd_theme=0.5.4
+sphinx_rtd_theme==0.5.4
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==4.0.2
-sphinx_rtd_theme==0.5.4
+sphinx_rtd_theme==0.5.2
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==4.0.2
-sphinx_rtd_theme>=0.5.2
+sphinx_rtd_theme=0.5.4
 matplotlib


### PR DESCRIPTION
`sphinx-rtd-theme` updated to 1.0 and seems to have some issues related to custom css themes.  See: https://github.com/readthedocs/sphinx_rtd_theme/issues/1236.  Pinning the version for now, which should fix things.