### PR TITLE
make risk exposure and risk effects page for x-factor

### DIFF
--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -281,6 +281,8 @@ Scale-up of vicious cycle interventions (breast-feeding) from baseline coverage 
 
 * :ref:`Maternal Body Mass Index <2019_risk_exposure_maternal_bmi>`
 
+* :ref:`Wasting X-Factor Risk Exposure <2019_risk_exposure_x_factor>`
+
 5.1.4 Risk Effects Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -293,6 +295,8 @@ Scale-up of vicious cycle interventions (breast-feeding) from baseline coverage 
 * Child Wasting Risk Effects
 
 * :ref:`Low Birthweight and Short Gestation Risk Effects (GBD 2019) <2019_risk_effect_lbwsg>`
+
+* :ref:`Wasting X-Factor Risk Effects <2019_risk_effect_x_factor>`
 
 5.1.5 Risk-Risk Correlation Models
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -363,8 +367,6 @@ For correlated risks that affect the same outcomes in our simulation (just wasti
 5.2.2 Population of interest
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-
-
 .. _5.3:
 
 5.3 Models
@@ -403,91 +405,11 @@ For correlated risks that affect the same outcomes in our simulation (just wasti
 5.4 X-Factor
 ------------
 
-The x-factor is a risk exposure that tries to capture the differential risk experienced by some children who may experience more relapses of wasting. We believe this is an important component of wasting epidemiology to capture [see Brain Trust notes with Chris Murray for discussion of adding this component to the model]. There are many risk factors that have been described in the literature that pre-dispose children to wasting including maternal education, household food insecurity, family size, water and sanitation. However, we have not found any conclusive evidence yet of a single x-factor is or its effect size.
-
-.. note::
-
-  See Nicole's zotero library folder 'Relapse' and 'Determinants' to see studies on this topic.
-
-**Risk exposure**
-
-As we do not have a precise definition of the x-factor risk exposure, we will model the exposure to be equal to the :ref:`maternal BMI risk exposure <2019_risk_exposure_maternal_bmi>`. We are using maternal undernutrition as a **proxy** for household food insecurity and other factors that have been suggested determinants of child malnutrition. [Na_2020]_ [Mohammed_2018]_ 
-
-Additionally, we will correlate the x-factor risk exposure with the maternal BMI risk exposure according to :ref:`this document <2019_risk_correlation_maternal_bmi_x_factor>`. NOTE: we chose to model a high (but not perfect) degree of correlation between the x-factor and maternal BMI risk exposures to demonstrate that these are indeed distinct concepts in our simulation. Revisiting this approach after discussion with domain experts may be desired!
-
-**Risk effect**
-
-We do not have direct evidence or data for the risk effect of the x-factor *proxied by maternal undernutrition* on wasting incidence (from the previous source state). From the [Na_2020]_, table 4 shows the odds of infant malnutrition (wasting, stunting and underweight) at 6 months of age in infants from food-insecure households as compared with infants from food-secure households (reference group). For rare outcomes, the prevalence risk ratio, incidence rate ratio and prevalence odds ratios approximate each other which is likely to be true for SAM (<5% prevalence), but not true for MAM and MILD wasting. Hence we model a range of risk effects as a sensitivity analysis with the scale of the effect informed by [Na_2020]_. Below table is a suggested range of risk-effect values to model.
-
-.. csv-table:: X-factor risk effect sensitivity analysis
-   :file: x_factor_risk_effect.csv
-   :widths: 30, 10, 10, 10, 10
-   :header-rows: 1
-
-.. note::
-
-  For model runs following validation of model #4.5, use x-factor risk effect = 1.3 until consensus is reached on x-factor effect magnitude or the model is ready for simulation results for the full range of sensitivity analysis values.
+As noted on the :ref:`wasting x-factor risk effects page <2019_risk_effect_x_factor>`, the risk effect value of 1.3 should be used for simulation model runs until consensus is reached on x-factor effect magnitude or the model is ready for simulation results for the full range of sensitivity analysis values.
 
 .. todo::
 
   Perform data-driven calibration of the x-factor effect size according to this strategy: (1) identify one or more measurable quantities that vary when effect size varies (e.g. average number of SAM treatments per unique children with SAM during a single year period); (2) compare measurements of quantity/quantities to value(s) estimated by simulation for a grid of x-factor effect size values; and choose effect size that makes simulation produce quantity/quantities most similar to empirical measurement(s).
-
-The risk effect (relative rate ratio) of incidence would be applied as such (breaking out the exposed vs non-exposed incidence from the exposure weighted overall incidence):
-
- - :math:`i_{x1} = i_{wasting|markov} (1-PAF) \times rr_{x_{factor}}`
- - :math:`i_{x0} = i_{wasting|markov} \times (1-PAF)`
-
- where :math:`i_{wasting|markov}` are the wasting transition incidences from the Markov calibration (with vicious cycle in the final model). And the PAF is calculated as
-
- PAF = :math:`\frac{(\sum_{x\_factor_{cat_i} prevalence * rr_{x_{factor\_cat_i}}})-1}{\sum_{x\_factor_{cat_i} prevalence * rr_{x_{factor\_cat_i}}}}`
-
- - where x_factor_cati_prevalence is the x-factor exposure category prevalence for exposed (i = 1) or unexposed (i = 0)
- - rr_x_factor_cati is the relative rate ratio for exposed (i = 1) or unexposed (i = 0).
- - Note that there are 4 wasting states so there should be a PAF between every wasting state transition where the susceptible population is the source wasting state, the exposure is the 'x-factor' and the outcome is the sink wasting state.
-
-- Note diarrhea (vicious cycle) cycle have effects on wasting incidences. Hence the x-factor should be broken out for the incidences with/without diarrhea calibrated from the Markov matrix. In our final model, we should end up with 4 sets (2 diarrhea states x 2 x-factor states) of 3 incidences (i1-3) for a total of 12 incidence rates.
-- Note also that SQ-LNS affects wasting transition incidence from mild to mam. The protective effects of SQ-LNS (if covered) would be applied to the incidences from mild to mam corresponding to diarrhea and x-factor exposure.
-- Let us assume that the 'x-factor' does not have differential effects on treatment recovery rates.
-
-.. todo::
-
-  Investigate potential effect of x-factor on recovery rates.
-
-.. note::
-
-  **Risk initialization**
-
-  For simulants initialized into the simulation at the simulation start date on 1/1/2022, we assume that the year of simulation run time prior to the implementation of intervention coverage on 1/1/2023 is a sufficient "burn-in" period to reflect the greater wasting exposure among simulants exposed to the x-factor than those unexposed to the x-factor. One year is assumed to be adequate given that the average time to recovery of MAM/SAM is near 60 days (:ref:`Treatment and management for acute malnutrition <intervention_wasting_treatment>`), indicating that simulants who were initialized into wasted exposure states will have transitioned out of those states and the simulants who occupy the wasted exposure states at the time of intervention implementation will have transitioned into those states according to their wasting incidence rates that are affected by the x-factor.
-
-  For simulants born into the simulation, while we do not initialize their wasting exposure state according to their x-factor exposure state explicitly, we assume that the correlation between these two risks through their individual correlations with birthweight will be adequate.
-
-**Validation criteria**
-
-- Exposure distribution should match :ref:`maternal BMI risk exposure <2019_risk_exposure_maternal_bmi>` 
-- Decrease in exposure distribution over time should be small (given that the x-factor risk exposure is assigned once at initialization or birth and that x-factor risk exposure is associated with a higher mortality rate, the x-factor exposure will decrease slightly over time/with age in our simulation)
-- The ratio between wasting incidence rates among those exposed and unexposed to the x-factor should match the given x-factor effect size
-- There should be no difference in wasting state remission rates by x-factor exposure status
-- Wasting exposure should be greater among those exposed to the x-factor than those unexposed
-
-.. todo::
-
-  - A more thorough literature review and support for use of this proxy should be done to strengthen our argument.
-  - We have decided not to model the effect of x-factor on stunting for now. We will look more thoroughly on its effect on stunting and whether to model a direct effect of wasting on stunting as we do more research.
-  - may be helpful to put this in the concept model diagram to keep track of how different factors affect incidence rates
-
-      mam_incidence_i = mam_incidence_given_diarrheal_state_i * (1 - PAF_xfactor) * RR_xfactor_i * SQLNS_treatment_RR_i
-
-      sam_incidence_i = sam_incidence_given_diarrheal_state_i * (1 - PAF_xfactor) * RR_xfactor_i
-
-  - note that SQ-LNS only affects MILD to MAM incidence.
-
-.. todo::
-
-  Be careful of what the 'x-factor' effect size represents. While being proxied by m undernourishment exposure, it is **not** the only causal effect of m undernourishment on wasting. That's why we are using a series of RR to test out this effect since we can't find it directly in the literature. (although the Na paper has the ORs). We might need to think through how to appropriately use proxies, especially since we are also modelling m undernourishment as a risk exposure as well. So m undernourishment is acting as a risk exposure for itself AND also proxy for other risks. Perhaps we need to be specific and say the x-factor effect is all the 'other-stuff' without m undernourishment and we model m nourishment effect in addition to x-factor?
-
-  We would need to think through carefully this web of relationships that includes x-factor, m undernourishment (m undernourishment and x-factor will be perfectly correlated), lbwsg, wasting and stunting. We need to be specific and careful about when we are referring to m undernourishment as risk exposure for itself or m nourishment as proxy for other risks (the x-factor) and use the appropriate effect sizes.
-
-  Nathaniel asked if we should have a causal arrow from mm undernourishment to wasting. My thinking is that we need to think through what we are capturing through an indirect effect (through mediator), a direct effect and what the total effect is. For example, we are capturing this mediated effect through lbwsg [mm undernourishment (a)--> lbwsg (b)--> wasting]. So if we also have a direct effect, [mm undernourishment (c)--> wasting], we will end up with [Total effect of mm undernourishment on wasting = ab + c].  Not sure if the literature will have sufficient information for us to figure out all these effect pathways. So maybe we just use the effect of (a) and (b)?
 
 
 .. _5.5:
@@ -552,20 +474,3 @@ Final outputs to report in manuscript
 
 .. _`Ackatia-Armah et al 2015`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/25733649/
 
-
-.. [Na_2020]
-
-  View `Na 2020`_
-
-    Maternal nutritional status mediates the linkage between household food insecurity and mid-infancy size in rural Bangladesh
-
-.. _`Na 2020`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/32102702/
-
-
-.. [Mohammed_2018]
-
-  View `Mohammed 2018`_
-
-    Bayesian Gaussian regression analysis of malnutrition for children under five years of age in Ethiopia, EMDHS 2014
-
-.. _`Mohammed 2018`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/29636912/

--- a/docs/source/concept_models/vivarium_ciff_sam/x_factor_risk_effect.csv
+++ b/docs/source/concept_models/vivarium_ciff_sam/x_factor_risk_effect.csv
@@ -1,6 +1,0 @@
-Incidence rate ratio,TMREL,Mild wasting,Moderate wasting,Severe wasting 
-sensitivity analysis 1,1,1.1,1.1,1.1
-sensitivity analysis 2,1,1.2,1.2,1.2
-sensitivity analysis 3,1,1.3,1.3,1.3
-sensitivity analysis 4,1,1.4,1.4,1.4
-sensitivity analysis 5,1,1.5,1.5,1.5

--- a/docs/source/gbd2019_models/risk_effects/x_factor/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/x_factor/index.rst
@@ -1,0 +1,130 @@
+.. _2019_risk_effect_x_factor:
+
+..
+  Section title decorators for this document:
+
+  ==============
+  Document Title
+  ==============
+
+  Section Level 1
+  ---------------
+
+  Section Level 2
+  +++++++++++++++
+
+  Section Level 3
+  ^^^^^^^^^^^^^^^
+
+  Section Level 4
+  ~~~~~~~~~~~~~~~
+
+  Section Level 5
+  '''''''''''''''
+
+  The depth of each section level is determined by the order in which each
+  decorator is encountered below. If you need an even deeper section level, just
+  choose a new decorator symbol from the list here:
+  https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
+  And then add it to the list of decorators above.
+
+===========================
+Wasting X-Factor
+===========================
+
+.. contents::
+   :local:
+   :depth: 2
+
+Risk Overview
+-------------
+
+The x-factor is a risk exposure that tries to capture the differential risk experienced by some children who may experience more relapses of wasting. We believe this is an important component of wasting epidemiology to capture [see Brain Trust notes with Chris Murray for discussion of adding this component to the model]. There are many risk factors that have been described in the literature that pre-dispose children to wasting including maternal education, household food insecurity, family size, water and sanitation. However, we have not found any conclusive evidence yet of a single x-factor is or its effect size.
+
+.. note::
+
+  See Nicole's zotero library folder 'Relapse' and 'Determinants' to see studies on this topic.
+
+
+.. todo::
+
+  - A more thorough literature review and support for use of this proxy should be done to strengthen our argument.
+  - We have decided not to model the effect of x-factor on stunting for now. We will look more thoroughly on its effect on stunting and whether to model a direct effect of wasting on stunting as we do more research.
+  - may be helpful to put this in the concept model diagram to keep track of how different factors affect incidence rates
+
+      mam_incidence_i = mam_incidence_given_diarrheal_state_i * (1 - PAF_xfactor) * RR_xfactor_i * SQLNS_treatment_RR_i
+
+      sam_incidence_i = sam_incidence_given_diarrheal_state_i * (1 - PAF_xfactor) * RR_xfactor_i
+
+  - note that SQ-LNS only affects MILD to MAM incidence.
+
+.. todo::
+
+  Be careful of what the 'x-factor' effect size represents. While being proxied by m undernourishment exposure, it is **not** the only causal effect of m undernourishment on wasting. That's why we are using a series of RR to test out this effect since we can't find it directly in the literature. (although the Na paper has the ORs). We might need to think through how to appropriately use proxies, especially since we are also modelling m undernourishment as a risk exposure as well. So m undernourishment is acting as a risk exposure for itself AND also proxy for other risks. Perhaps we need to be specific and say the x-factor effect is all the 'other-stuff' without m undernourishment and we model m nourishment effect in addition to x-factor?
+
+  We would need to think through carefully this web of relationships that includes x-factor, m undernourishment (m undernourishment and x-factor will be perfectly correlated), lbwsg, wasting and stunting. We need to be specific and careful about when we are referring to m undernourishment as risk exposure for itself or m nourishment as proxy for other risks (the x-factor) and use the appropriate effect sizes.
+
+  Nathaniel asked if we should have a causal arrow from mm undernourishment to wasting. My thinking is that we need to think through what we are capturing through an indirect effect (through mediator), a direct effect and what the total effect is. For example, we are capturing this mediated effect through lbwsg [mm undernourishment (a)--> lbwsg (b)--> wasting]. So if we also have a direct effect, [mm undernourishment (c)--> wasting], we will end up with [Total effect of mm undernourishment on wasting = ab + c].  Not sure if the literature will have sufficient information for us to figure out all these effect pathways. So maybe we just use the effect of (a) and (b)?
+
+Vivarium Modeling Strategy
+--------------------------
+
+Wasting Incidence Rates
+++++++++++++++++++++++++
+
+We do not have direct evidence or data for the risk effect of the x-factor *proxied by maternal undernutrition* on wasting incidence (from the previous source state). From the [Na_2020-x-factor-risk-effect]_, table 4 shows the odds of infant malnutrition (wasting, stunting and underweight) at 6 months of age in infants from food-insecure households as compared with infants from food-secure households (reference group). For rare outcomes, the prevalence risk ratio, incidence rate ratio and prevalence odds ratios approximate each other which is likely to be true for SAM (<5% prevalence), but not true for MAM and MILD wasting. Hence we model a range of risk effects as a sensitivity analysis with the scale of the effect informed by [Na_2020-x-factor-risk-effect]_. Below table is a suggested range of risk-effect values to model.
+
+.. csv-table:: X-factor risk effect sensitivity analysis
+   :file: x_factor_risk_effect.csv
+   :widths: 30, 10, 10, 10, 10
+   :header-rows: 1
+
+.. note::
+
+  For model runs following validation of model #4.5, use x-factor risk effect = 1.3 until consensus is reached on x-factor effect magnitude or the model is ready for simulation results for the full range of sensitivity analysis values.
+
+The risk effect (relative rate ratio) of incidence would be applied as such (breaking out the exposed vs non-exposed incidence from the exposure weighted overall incidence):
+
+ - :math:`i_{x1} = i_{wasting|markov} (1-PAF) \times rr_{x_{factor}}`
+ - :math:`i_{x0} = i_{wasting|markov} \times (1-PAF)`
+
+ where :math:`i_{wasting|markov}` are the wasting transition incidences from the Markov calibration (with vicious cycle in the final model). And the PAF is calculated as
+
+ PAF = :math:`\frac{(\sum_{x\_factor_{cat_i} prevalence * rr_{x_{factor\_cat_i}}})-1}{\sum_{x\_factor_{cat_i} prevalence * rr_{x_{factor\_cat_i}}}}`
+
+ - where x_factor_cati_prevalence is the x-factor exposure category prevalence for exposed (i = 1) or unexposed (i = 0)
+ - rr_x_factor_cati is the relative rate ratio for exposed (i = 1) or unexposed (i = 0).
+ - Note that there are 4 wasting states so there should be a PAF between every wasting state transition where the susceptible population is the source wasting state, the exposure is the 'x-factor' and the outcome is the sink wasting state.
+
+- Note diarrhea (vicious cycle) cycle have effects on wasting incidences. Hence the x-factor should be broken out for the incidences with/without diarrhea calibrated from the Markov matrix. In our final model, we should end up with 4 sets (2 diarrhea states x 2 x-factor states) of 3 incidences (i1-3) for a total of 12 incidence rates.
+- Note also that SQ-LNS affects wasting transition incidence from mild to mam. The protective effects of SQ-LNS (if covered) would be applied to the incidences from mild to mam corresponding to diarrhea and x-factor exposure.
+- Let us assume that the 'x-factor' does not have differential effects on treatment recovery rates.
+
+.. todo::
+
+  Investigate potential effect of x-factor on recovery rates.
+
+Validation and Verification Criteria
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- The ratio between wasting incidence rates among those exposed and unexposed to the x-factor should match the given x-factor effect size
+- There should be no difference in wasting state remission rates by x-factor exposure status
+- Wasting exposure should be greater among those exposed to the x-factor than those unexposed
+
+Assumptions and Limitations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. todo::
+
+   Detail assumptions and limitations related to the x-factor risk effect 
+
+References
+----------
+
+.. [Na_2020-x-factor-risk-effect]
+
+  View `Na 2020`_
+
+    Maternal nutritional status mediates the linkage between household food insecurity and mid-infancy size in rural Bangladesh
+
+.. _`Na 2020`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/32102702/

--- a/docs/source/gbd2019_models/risk_effects/x_factor/x_factor_risk_effect.csv
+++ b/docs/source/gbd2019_models/risk_effects/x_factor/x_factor_risk_effect.csv
@@ -1,0 +1,6 @@
+Incidence rate ratio,TMREL,Mild wasting,Moderate wasting,Severe wasting 
+sensitivity analysis 1,1,1.1,1.1,1.1
+sensitivity analysis 2,1,1.2,1.2,1.2
+sensitivity analysis 3,1,1.3,1.3,1.3
+sensitivity analysis 4,1,1.4,1.4,1.4
+sensitivity analysis 5,1,1.5,1.5,1.5

--- a/docs/source/gbd2019_models/risk_exposures/x_factor/index.rst
+++ b/docs/source/gbd2019_models/risk_exposures/x_factor/index.rst
@@ -1,0 +1,84 @@
+.. _2019_risk_exposure_x_factor:
+
+======================================
+Wasting X-Factor
+======================================
+
+Risk Exposure Overview
+----------------------
+
+The x-factor is a risk exposure that tries to capture the differential risk experienced by some children who may experience more relapses of wasting. We believe this is an important component of wasting epidemiology to capture [see Brain Trust notes with Chris Murray for discussion of adding this component to the model]. There are many risk factors that have been described in the literature that pre-dispose children to wasting including maternal education, household food insecurity, family size, water and sanitation. However, we have not found any conclusive evidence yet of a single x-factor is or its effect size.
+
+.. note::
+
+  See Nicole's zotero library folder 'Relapse' and 'Determinants' to see studies on this topic.
+
+Vivarium Modeling Strategy
+--------------------------
+
+As we do not have a precise definition of the x-factor risk exposure, we will model the exposure to be equal to the :ref:`maternal BMI risk exposure <2019_risk_exposure_maternal_bmi>`. We are using maternal undernutrition as a **proxy** for household food insecurity and other factors that have been suggested determinants of child malnutrition. [Na_2020-x-factor-risk-exposure]_ [Mohammed_2018-x-factor-risk-exposure]_ 
+
+Additionally, we will correlate the x-factor risk exposure with the maternal BMI risk exposure according to :ref:`this document <2019_risk_correlation_maternal_bmi_x_factor>`. NOTE: we chose to model a high (but not perfect) degree of correlation between the x-factor and maternal BMI risk exposures to demonstrate that these are indeed distinct concepts in our simulation. Revisiting this approach after discussion with domain experts may be desired!
+
+.. note::
+
+  **Risk initialization**
+
+  For simulants initialized into the simulation at the simulation start date on 1/1/2022, we assume that the year of simulation run time prior to the implementation of intervention coverage on 1/1/2023 is a sufficient "burn-in" period to reflect the greater wasting exposure among simulants exposed to the x-factor than those unexposed to the x-factor. One year is assumed to be adequate given that the average time to recovery of MAM/SAM is near 60 days (:ref:`Treatment and management for acute malnutrition <intervention_wasting_treatment>`), indicating that simulants who were initialized into wasted exposure states will have transitioned out of those states and the simulants who occupy the wasted exposure states at the time of intervention implementation will have transitioned into those states according to their wasting incidence rates that are affected by the x-factor.
+
+  For simulants born into the simulation, while we do not initialize their wasting exposure state according to their x-factor exposure state explicitly, we assume that the correlation between these two risks through their individual correlations with birthweight will be adequate.
+
+Restrictions
+++++++++++++
+
+.. list-table:: GBD 2019 Risk Exposure Restrictions
+   :widths: 15 15 20
+   :header-rows: 1
+
+   * - Restriction Type
+     - Value
+     - Notes
+   * - Male only
+     - False
+     -
+   * - Female only
+     - False
+     -
+   * - Age group start
+     - 164 (birth)
+     -
+   * - Age group end
+     - 5 years of age
+     -
+
+Assumptions and Limitations
++++++++++++++++++++++++++++
+
+.. todo::
+
+   Detail assumptions and limitations related to the x-factor risk exposure
+
+Validation Criteria
++++++++++++++++++++
+
+- Exposure distribution should match :ref:`maternal BMI risk exposure <2019_risk_exposure_maternal_bmi>` 
+- Decrease in exposure distribution over time should be small (given that the x-factor risk exposure is assigned once at initialization or birth and that x-factor risk exposure is associated with a higher mortality rate, the x-factor exposure will decrease slightly over time/with age in our simulation)
+
+References
+----------
+
+.. [Mohammed_2018-x-factor-risk-exposure]
+
+  View `Mohammed 2018`_
+
+    Bayesian Gaussian regression analysis of malnutrition for children under five years of age in Ethiopia, EMDHS 2014
+
+.. _`Mohammed 2018`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/29636912/
+
+.. [Na_2020-x-factor-risk-exposure]
+
+  View `Na 2020`_
+
+    Maternal nutritional status mediates the linkage between household food insecurity and mid-infancy size in rural Bangladesh
+
+.. _`Na 2020`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/32102702/

--- a/docs/source/gbd2019_models/risk_risk_correlation/maternal_bmi_x_factor/index.rst
+++ b/docs/source/gbd2019_models/risk_risk_correlation/maternal_bmi_x_factor/index.rst
@@ -35,7 +35,7 @@ Maternal BMI and X-factor Risk Exposure Correlation
 Risk Exposures Overview
 ------------------------
 
-In the :ref:`acute malnutrition simulation model <2019_concept_model_vivarium_ciff_sam>`, a "x-factor" risk factor to represent an increased trajectory for wasting incidence was developed. In the absence of a well-defined risk expousre for this parameter, we are using the :ref:`maternal BMI risk exposure <2019_risk_exposure_maternal_bmi>` as a proxy exposure value (described in the :ref:`acute malnutrition concept model document <2019_concept_model_vivarium_ciff_sam>`).
+In the :ref:`acute malnutrition simulation model <2019_concept_model_vivarium_ciff_sam>`, an "x-factor" risk factor to represent an increased trajectory for wasting incidence was developed (see the :ref:`wasting x-factor risk effects page <2019_risk_effect_x_factor>`). In the absence of a well-defined risk expousre for this parameter, we are using the :ref:`maternal BMI risk exposure <2019_risk_exposure_maternal_bmi>` as a proxy exposure value for the :ref:`wasting x-factor risk exposure <2019_risk_exposure_x_factor>`.
 
 We are choosing to model the x-factor and maternal BMI risk exposures as highly, but not perfectly, correlated in this simulation. We will not model a causal relationship between these two factors. 
 
@@ -48,7 +48,7 @@ When simulants are initialized or born into the the simulation, they should be a
 
 2. Assign the simulant a x-factor propensity that is correlated to their maternal BMI propensity according to the spearman correlation coefficient of :math:`0.9`. This should be done according to the methodology described in the :ref:`risk-risk correlation proposal page <2017_risk_models>`
 
-3. Assign the simulant an x-factor risk exposure value based on their assigned x-factor propensity and the x-factor risk exposure distribution (equal to the :ref:`maternal BMI risk exposure distribution <2019_risk_exposure_maternal_bmi>`)
+3. Assign the simulant an x-factor risk exposure value based on their assigned x-factor propensity and the :ref:`x-factor risk exposure distribution<2019_risk_exposure_x_factor>`
 
 .. note::
 


### PR DESCRIPTION
I made individual pages for the x-factor risk exposure and risk effects documentation instead of having them in the concept model because I think it was getting cluttered. This PR doesn't add/change any information, just moves it around.