### PR TITLE
CIFF wasting treatment coverage updates

### DIFF
--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -185,8 +185,8 @@ See linked documentation for more information :ref:`Treatment and management for
     - 73.1% (95% CI:58.5-87.7) for RUSF
     - 15 x 0.731 = 0.11
     - 1 - 0.11 = 0.89
-    - [Ackatia_Armah_2015]_
-    - Baseline coverage of MAM needs to be updated, efficacy comes from trial and may be too optimistic
+    - Efficacy: [Ackatia_Armah_2015]_, Coverage: assumption from CIFF/UNICEF
+    - Efficacy comes from trial and may be too optimistic
   * - MAM alternative
     - 70%
     - 75% for RUSF

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -171,15 +171,15 @@ See linked documentation for more information :ref:`Treatment and management for
     - 70% (95% CI: 64, 76)
     - 0.488 x 0.7 = 0.34
     - 1 - 0.34 = 0.66
-    - [Isanaka_etal_2021]_ , [Zw_2020]_
+    - coverage: [Isanaka_etal_2021]_ , efficacy: [Zw_2020]_
     - This is for SAM-OTP which is ~98% of SAM.
   * - SAM alternative
     - 70%
     - 75%
     - 0.7 x 0.75 = 0.53
     - 1 - 0.53 = 0.47
-    - Sphere standards
-    - Sphere guideline for efficacy only
+    - Sphere standards for efficacy; discussion with CIFF/UNICEF for coverage
+    - 
   * - MAM baseline
     - 15% (95% CI: 10, 20)
     - 73.1% (95% CI:58.5-87.7) for RUSF
@@ -192,8 +192,8 @@ See linked documentation for more information :ref:`Treatment and management for
     - 75% for RUSF
     - 0.7 x 0.75 = 0.53
     - 1 - 0.53 = 0.47
-    - Sphere standards
-    - Sphere guideline for efficacy only
+    - Sphere standards for efficacy; discussion with CIFF/UNICEF for coverage
+    - 
 
 **Alternative scenario 2**
 Scale up the SQ-LNS for 6 month+ from 0% at baseline to 90% in addition to the intervention coverage in alternative scenario 1. The SQ-LNS intervention will decrease the **incidence rate of MAM** (i2), without affecting duration (assumption). This is expected to further decrease the prevalence of MAM and SAM.

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -183,7 +183,7 @@ See linked documentation for more information :ref:`Treatment and management for
   * - MAM baseline
     - 15% (95% CI: 10, 20)
     - 73.1% (95% CI:58.5-87.7) for RUSF
-    - 15 x 0.731 = 0.11
+    - 0.15 x 0.731 = 0.11
     - 1 - 0.11 = 0.89
     - Efficacy: [Ackatia_Armah_2015]_, Coverage: assumption from CIFF/UNICEF
     - Efficacy comes from trial and may be too optimistic

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -190,7 +190,7 @@ See linked documentation for more information :ref:`Treatment and management for
   * - MAM alternative
     - 70%
     - 75% for RUSF
-    - 0.9 x 0.75 = 0.53
+    - 0.7 x 0.75 = 0.53
     - 1 - 0.53 = 0.47
     - Sphere standards
     - Sphere guideline for efficacy only

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -160,7 +160,7 @@ See linked documentation for more information :ref:`Treatment and management for
   :header-rows: 1
 
   * - Exposure
-    - Treatment coverage (c)
+    - Treatment coverage (C)
     - Treatment efficacy (E)
     - Effectivey covered
     - Not effectively covered
@@ -174,27 +174,26 @@ See linked documentation for more information :ref:`Treatment and management for
     - [Isanaka_etal_2021]_ , [Zw_2020]_
     - This is for SAM-OTP which is ~98% of SAM.
   * - SAM alternative
-    - 90%
+    - 70%
     - 75%
-    - 0.9 x 0.75 = 0.675
-    - 1 - 0.675 = 0.325
+    - 0.7 x 0.75 = 0.53
+    - 1 - 0.53 = 0.47
     - Sphere standards
     - Sphere guideline for efficacy only
   * - MAM baseline
-    - 48.8% (95% CI: 37.4, 60.4)
+    - 15% (95% CI: 10, 20)
     - 73.1% (95% CI:58.5-87.7) for RUSF
-    - 0.488 x 0.731 = 0.34
-    - 1 - 0.34 = 0.66
+    - 15 x 0.731 = 0.11
+    - 1 - 0.11 = 0.89
     - [Ackatia_Armah_2015]_
     - Baseline coverage of MAM needs to be updated, efficacy comes from trial and may be too optimistic
   * - MAM alternative
-    - 90%
+    - 70%
     - 75% for RUSF
-    - 0.9 x 0.75 = 0.675
-    - 1 - 0.675 = 0.325
+    - 0.9 x 0.75 = 0.53
+    - 1 - 0.53 = 0.47
     - Sphere standards
     - Sphere guideline for efficacy only
-
 
 **Alternative scenario 2**
 Scale up the SQ-LNS for 6 month+ from 0% at baseline to 90% in addition to the intervention coverage in alternative scenario 1. The SQ-LNS intervention will decrease the **incidence rate of MAM** (i2), without affecting duration (assumption). This is expected to further decrease the prevalence of MAM and SAM.
@@ -202,6 +201,10 @@ Scale up the SQ-LNS for 6 month+ from 0% at baseline to 90% in addition to the i
 .. todo::
 
   Consider targeting SQ-LNS coverage to simulants in SAM treatment.
+
+.. todo::
+
+  Consider if 90% intervention coverage is too aspirational
 
 **Alternative scenario 3**
 Scale up of LBWSG interventions from baseline coverage % (TBD) to 90% in addition to the intervention coverage in alternative scenario 2.

--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -153,6 +153,10 @@ Scale up (immediate, not temporal) the 'effective-coverage' of GAM treatment fro
 
 Note: we apply an immediate scale-up rather than a temporal scale-up for now.
 
+.. todo::
+
+  Update to reflect linear scale-up over three years.
+
 See linked documentation for more information :ref:`Treatment and management for acute malnutrition <intervention_wasting_treatment>`
 
 .. list-table:: Effective coverage of GAM treatment program

--- a/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
+++ b/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
@@ -661,7 +661,7 @@ in terms of the following variables:
    * - :math:`time_to_sam_ux_recovery`
      - Without treatment or death, average days spent in SAM before recovery
      - :math:`365 / r_{SAM,ux}`
-     - :math:`r_{SAM,ux}` defined in the "Annual recovery rate equations" table in the :ref:`wasting treatment intervention document <intervention_wasting_treatment>`
+     - :math:`r_{SAM,ux}` defined in the :ref:`untreated-sam-time-to-recovery-reference-label` table in the :ref:`wasting treatment intervention document <intervention_wasting_treatment>` 
    * - :math:`time_to_sam_tx_recovery`
      - With treatment and without death, average days spent in SAM before recovery
      - 48.3

--- a/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
+++ b/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
@@ -660,8 +660,8 @@ in terms of the following variables:
      - 
    * - :math:`time_to_sam_ux_recovery`
      - Without treatment or death, average days spent in SAM before recovery
-     - See the definition on the :ref:`wasting treatment intervention document <intervention_wasting_treatment>`
-     - 
+     - :math:`365 / r_{SAM,ux}`
+     - :math:`r_{SAM,ux}` defined in the "Annual recovery rate equations" table in the :ref:`wasting treatment intervention document <intervention_wasting_treatment>`
    * - :math:`time_to_sam_tx_recovery`
      - With treatment and without death, average days spent in SAM before recovery
      - 48.3

--- a/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
+++ b/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
@@ -593,7 +593,7 @@ that follows we will detail how to calculate all the variables used
    * - r4
      - 0.001
      - Daily probability of remission from cat 3 into cat 4
-     - Assumed to be small
+     - TO BE UPDATED FOLLOWING MODEL CALIBRATION
    * - t1
      - 1 - e^(-sam_tx_coverage * (1/time_to_sam_tx_recovery))
      - Daily probability of remission into cat 3 from cat 1 (treated)
@@ -644,34 +644,32 @@ in terms of the following variables:
      - All category "prevalences" are scaled down, such that the prevalence of cat 0 (the reincarnation pool) and the prevalences of the wasting categories sum to 1
    * - :math:`mam_tx_coverage`
      - Proportion of MAM (CAT 2) cases that have treatment coverage
-     - 0.488
+     - 0.15 (95% CI: 0.1, 0.2)
      - Potentially to be updated
    * - :math:`sam_tx_coverage`
      - Proportion of SAM (CAT 1) cases that have treatment coverage
-     - 0.488
+     - 0.488 (95% CI: 0.374, 0.604)
      - Potentially to be updated
    * - :math:`time_to_mam_ux_recovery`
      - Without treatment or death, average days spent in MAM before recovery
      - 63
-     - Potentially to be updated
+     - 
    * - :math:`time_to_mam_tx_recovery`
      - With treatment and without death, average days spent in MAM before recovery
-     - 41.3
-     - Potentially to be updated
+     - 41.3 (95% CI: 34.4, 49)
+     - 
    * - :math:`time_to_sam_ux_recovery`
      - Without treatment or death, average days spent in SAM before recovery
-     - 60.5
-     - Potentially to be updated
+     - See the definition on the :ref:`wasting treatment intervention document <intervention_wasting_treatment>`
+     - 
    * - :math:`time_to_sam_tx_recovery`
      - With treatment and without death, average days spent in SAM before recovery
      - 48.3
-     - Potentially to be updated
+     - 
    * - :math:`time_step`
      - Scalar time step conversion to days
      - 1
      -
-
-
 
 .. list-table:: Calculations for variables in transition equations
    :widths: 6 10 10

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -346,7 +346,7 @@ Geographic coverage attempts to measure the *availability* of services which doe
 .. image:: effective_coverage_figure.svg
 
 | SAM programme treatment coverage: 48.8% (37.4-60.4) (this is a point coverage; assumes programmes are not good at case finding) [Isanaka_2021]_
-| MAM programme treatment coverage: same as SAM for now until this website is updated https://acutemalnutrition.org/en/countries
+| MAM programme treatment coverage: Per discussion with CIFF/UNICEF, there is not reliable data avilable for this parameter, but it may be between 10 and 20 percent and often scales-up in response to emergencies. Note: this website tracks measures related to SAM coverage: https://acutemalnutrition.org/en/countries
 
 .. todo::
 
@@ -393,7 +393,7 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - Value
     - Note
   * - :math:`r_{SAM,ux}`
-    - :math:`\frac{k - r_{SAM,tx} * C * E_{SAM} - mortality_{SAM|a,s,l,y}}{1 - C * E_{SAM}}`
+    - :math:`\frac{k - r_{SAM,tx} * C_{SAM} * E_{SAM} - mortality_{SAM|a,s,l,y}}{1 - C_{SAM} * E_{SAM}}`
     - See constant values in table below and equation derivation below table. Ali to confirm and potentially update this equation. Previously referred to as :math:`r2_{ux}`
   * - :math:`r_{SAM,tx}`
     - :math:`365 / \text{time to recovery}_\text{effectively treated SAM}`
@@ -434,12 +434,16 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - normal
     - Censored participants who did not recover in estimation of median time to recovery.
     - [Ackatia_Armah_2015tx]_; Mali
-  * - :math:`C`
+  * - :math:`C_{SAM}`
     - 6-59 months old
     - 0.488 (95% CI:0.374-0.604)
     - normal
-    - Baseline scenario value. Assumed to be the same for SAM and MAM and across age groups at the draw level.
-    - Currently the same for SAM and MAM [Isanaka_2021]_
+    - Baseline scenario value ([Isanaka_2021]_); defined as the number in the program / number that should be in the program 
+  * - :math:`C_{MAM}`
+    - 6-59 months old
+    - 0.15 (95% CI: 0.1, 0.2)
+    - normal
+    - Baseline scenario value. Informed through discussion with CIFF/UNICEF that reported there is not reliable data on this parameter, but that this appeared to be a plausible range
   * - :math:`E_\text{SAM}`
     - 6-59 months old
     - 0.70 (95% CI:0.64-0.76)
@@ -508,7 +512,7 @@ Deriving :math:`r_{SAM,ux}` using the following equations:
 
 #. :math:`r_{SAM,tx} = 1 / \text{time to recovery}_\text{effectively treated SAM}`
 
-#. :math:`1 / \text{time to recovery}_\text{overall SAM} =  1 / \text{time to recovery}_\text{effectively treated SAM} * C * E_{SAM} + 1 / \text{time to recovery}_\text{untreated SAM} * (1 - C * E_{SAM})`
+#. :math:`1 / \text{time to recovery}_\text{overall SAM} =  1 / \text{time to recovery}_\text{effectively treated SAM} * C_{SAM} * E_{SAM} + 1 / \text{time to recovery}_\text{untreated SAM} * (1 - C_{SAM} * E_{SAM})`
 
 #. :math:`1 / duration_\text{overall SAM} = 1 / \text{time to recovery}_\text{overall SAM} + mortality_{SAM|a,s,l,y}`
 
@@ -516,15 +520,15 @@ Deriving :math:`r_{SAM,ux}` using the following equations:
 
 So...
 
-  :math:`1 / duration_\text{overall SAM} - mortality_{SAM|a,s,l,y} = r_{SAM,tx} * C * E_{SAM} + r_{SAM,ux} * (1 - C * E_{SAM})`
+  :math:`1 / duration_\text{overall SAM} - mortality_{SAM|a,s,l,y} = r_{SAM,tx} * C_{SAM} * E_{SAM} + r_{SAM,ux} * (1 - C_{SAM} * E_{SAM})`
 
   ...
 
-  :math:`k / 365 = r_{SAM,tx} * C * E_{SAM} + r_{SAM,ux} * (1 - C * E_{SAM}) + mortality_{SAM|a,s,l,y}`
+  :math:`k / 365 = r_{SAM,tx} * C_{SAM} * E_{SAM} + r_{SAM,ux} * (1 - C_{SAM} * E_{SAM}) + mortality_{SAM|a,s,l,y}`
 
   ...
 
-  :math:`r_{SAM,ux} = \frac{k/365 - r_{SAM,tx} * C * E_{SAM} - mortality_{SAM|a,s,l,y}}{1 - C * E_{SAM}}`
+  :math:`r_{SAM,ux} = \frac{k/365 - r_{SAM,tx} * C_{SAM} * E_{SAM} - mortality_{SAM|a,s,l,y}}{1 - C_{SAM} * E_{SAM}}`
 
 .. note::
 
@@ -568,27 +572,27 @@ The Vivarium modeling strategy above details how to solve for the transition rat
     - Value
     - Note
   * - r3
-    - Untreated/uncovered by :math:`C`
+    - Untreated/uncovered by :math:`C_{MAM}`
     - :math:`\frac{r_{MAM,ux}}{r_{MAM,tx} * E_{MAM} + r_{MAM,ux} * (1 - E_{MAM})}`
     -
   * - t1
-    - Untreated/uncovered by :math:`C`
+    - Untreated/uncovered by :math:`C_{SAM}`
     - 0
     - :math:`\frac{0 * r_{SAM,tx}}{E_{SAM} * r_{SAM,tx}}`
   * - r2
-    - Untreated/uncovered by :math:`C`
+    - Untreated/uncovered by :math:`C_{SAM}`
     - :math:`1 / (1 - E_{SAM})`
     - :math:`\frac{r_{SAM,ux} * 1}{r_{SAM,ux} * (1 - E_{SAM})}`
   * - r3
-    - Treated/covered by :math:`C`
+    - Treated/covered by :math:`C_{MAM}`
     - 1
     -
   * - t1
-    - Treated/covered by :math:`C`
+    - Treated/covered by :math:`C_{SAM}`
     - 1
     -
   * - r2
-    - Treated/covered by :math:`C`
+    - Treated/covered by :math:`C_{SAM}`
     - 1
     -
 
@@ -612,7 +616,7 @@ and
 
   \overline{RR_{r}} = C * RR_{r, treated} + (1 - C) * RR_{r, untreated}
 
-NOTE: Each simulant should have a single propensity value for :math:`C` for both MAM and SAM treatment (equally likely to be covered by SAM treatment as MAM treatment).
+NOTE: Each simulant should have a single propensity value for the :math:`C_{MAM}` and :math:`C_{SAM}` parameters (equally likely to be covered by SAM treatment as MAM treatment if they had the same coverage rates).
 
 Scenarios
 +++++++++++
@@ -624,9 +628,13 @@ Scenarios
     - Baseline value
     - Alternative Value
     - Note
-  * - :math:`C`
+  * - :math:`C_{MAM}`
+    - 0.15 (95% CI: 0.1, 0.2)
+    - 0.7
+    -
+  * - :math:`C_{SAM}`
     - 0.488 (95% CI:0.374-0.604)
-    - 0.9
+    - 0.7
     -
   * - :math:`E_{MAM}`
     - 0.731 (95% CI:0.585-0.877), normal

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -616,7 +616,16 @@ and
 
   \overline{RR_{r}} = C * RR_{r, treated} + (1 - C) * RR_{r, untreated}
 
-NOTE: Each simulant should have a single propensity value for the :math:`C_{MAM}` and :math:`C_{SAM}` parameters (equally likely to be covered by SAM treatment as MAM treatment if they had the same coverage rates).
+Coverage Propensities
+++++++++++++++++++++++
+
+.. todo::
+
+  Detail strategy for assigning :math:`C` and :math:`E` parameter propensity values to simulants so that:
+
+  1) coverage among the MAM and SAM states is equal to :math:`C_{MAM}` and :math:`C_{SAM}`
+
+  2) simulants who are treated for MAM or SAM once are likely to be treated again and vise versa.
 
 Scenarios
 +++++++++++

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -386,6 +386,8 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
 
   Update figure to new parameter names. Update was made to distinguish difference between these parameters (for wasting treatment model) and the related parameters for the wasting exposure model.
 
+.. _untreated-sam-time-to-recovery-reference-label:
+
 .. list-table:: Annual recovery rate equations
   :header-rows: 1
 

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -514,11 +514,19 @@ Deriving :math:`r_{SAM,ux}` using the following equations:
 
 #. :math:`r_{SAM,tx} = 1 / \text{time to recovery}_\text{effectively treated SAM}`
 
-#. :math:`1 / \text{time to recovery}_\text{overall SAM} =  1 / \text{time to recovery}_\text{effectively treated SAM} * C_{SAM} * E_{SAM} + 1 / \text{time to recovery}_\text{untreated SAM} * (1 - C_{SAM} * E_{SAM})`
+#. 
 
-#. :math:`1 / duration_\text{overall SAM} = 1 / \text{time to recovery}_\text{overall SAM} + mortality_{SAM|a,s,l,y}`
+.. math::
 
-#. :math:`duration_\text{overall SAM} = 365 / k`
+  1 / \text{time to recovery}_\text{overall SAM} =  
+
+  1 / \text{time to recovery}_\text{effectively treated SAM} * C_{SAM} * E_{SAM} 
+
+  + 1 / \text{time to recovery}_\text{untreated SAM} * (1 - C_{SAM} * E_{SAM})
+
+4. :math:`1 / duration_\text{overall SAM} = 1 / \text{time to recovery}_\text{overall SAM} + mortality_{SAM|a,s,l,y}`
+
+5. :math:`duration_\text{overall SAM} = 365 / k`
 
 So...
 

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -438,12 +438,14 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
     - 6-59 months old
     - 0.488 (95% CI:0.374-0.604)
     - normal
-    - Baseline scenario value ([Isanaka_2021]_); defined as the number in the program / number that should be in the program 
+    - Baseline scenario value; defined as the number in the program / number that should be in the program 
+    - [Isanaka_2021]_
   * - :math:`C_{MAM}`
     - 6-59 months old
     - 0.15 (95% CI: 0.1, 0.2)
     - normal
-    - Baseline scenario value. Informed through discussion with CIFF/UNICEF that reported there is not reliable data on this parameter, but that this appeared to be a plausible range
+    - Baseline scenario value. 
+    - Informed through discussion with CIFF/UNICEF that reported there is not reliable data on this parameter, but that this appeared to be a plausible range
   * - :math:`E_\text{SAM}`
     - 6-59 months old
     - 0.70 (95% CI:0.64-0.76)


### PR DESCRIPTION
These changes should not be implemented until after the calibration changes are made and reviewed

The coverage parameter (C) was split into C_MAM and C_SAM. Intervention scenario targets were updated. 

A strategy to account for the difference between coverage defined as percent of population vs. percent of population in need will need to be implemented but is not yet reflected in this PR.