### PR TITLE
CIFF intervention coverage parameter docs single source of truth

### DIFF
--- a/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam/concept_model.rst
@@ -153,58 +153,50 @@ Historically, prevention research has primarily focused on stunting, and, as a r
     Intervention parameters should then be held constant at the alternative scenario values from 1/1/2026 until the end of the simulation on 12/31/2026.
 
 **Baseline**
-The baseline scenario will project GBD 2019 demographic and disease trends and GBD 2020 exposure trends out from 2022 to 2027 and coverage rates for all preventive and therapeutic interventions will be held constant across the 5 years of the microsimulation to simulate a business-as-usual treatment scenario.
+The baseline scenario will project GBD 2019 demographic and disease trends and GBD 2020 exposure trends out from 2022 to 2027 and coverage rates for all preventive and therapeutic interventions will be held constant across the 5 years of the microsimulation to simulate a business-as-usual treatment scenario. Baseline coverage/efficacy values for each of the modeled interventions can be found in the following locations:
+
+- :ref:`Acute malnutrition treatment and management baseline parameters <wasting-treatment-baseline-parameters>`: see the :math:`C_{SAM}`, :math:`C_{MAM}`, :math:`E_{SAM}`, and :math:`E_{MAM}` parameters
+
+- :ref:`Small quantity lipid based nutrient supplements (SQ-LNS) baseline parameters <sqlns-baseline-parameters>`
+
+- :ref:`Maternal Supplementation baseline parameters <maternal-supplementation-baseline-parameters>`: see the value for the proportion of the pregnant population who took *any* antenatal iron in Ethiopia.
+
+- :ref:`Insecticide treated nets baseline parameters <itn-baseline-parameters>`
+
+- :ref:`Intermittent malaria preventive therapy for pregnant women baseline parameters <iptp-baseline-parameters>`: PENDING DECISION TO INCLUDE IN SIMULATION
+
+- Kangaroo care for preterm and low birthweight infants baseline parameters
+
+- Breastfeeding promotion baseline parameters
+
+- Preventive and therapeutic zinc baseline parameters
 
 **Alternative scenario 1**
-Scale up of the 'effective-coverage' of GAM treatment from baseline level of effective-coverage to scenario level of effective-coverage. Those who are 'effectively covered' have a shorter duration of SAM and MAM episodes. In this first alternative scenario, a larger proportion of simulants will be effectivey covered than baseline. Keeping incidence of MAM (i2) and SAM (i1) the same as baseline, we expect the prevalence of SAM and MAM to decrease with a shorter duration (prevalence ~ incidence x duration).
+Scale up the :ref:`acute malnutrition treatment and management baseline parameters <wasting-treatment-baseline-parameters>` (:math:`C_{SAM}`, :math:`C_{MAM}`, :math:`E_{SAM}`, and :math:`E_{MAM}`) to the alternative scenario values in the table below. Note that intervention efficacy may *decrease* in the alternative scenario relative to the baseline scenario for some draws -- however, this may be a realistic effect of a dramatic increase in intervention coverage and *effctive* coverage (:math:`E \times C`) should be greater for all draws in the alterative scenario. See the :ref:`treatment and management for acute malnutrition document<intervention_wasting_treatment>` for more information.
 
-| Effective coverage = treatment coverage x treatment efficacy
-| Not effectively covered = 1 - (treatment coverage x treatment efficacy)
+.. _`wasting-treatment-alterative-scenario-values`:
 
-See linked documentation for more information :ref:`Treatment and management for acute malnutrition <intervention_wasting_treatment>`
-
-.. list-table:: Effective coverage of GAM treatment program
-  :widths: 10 10 10 15 15 15 20
+.. list-table:: Wasting treatment and management alterative scenario intervention parameter values
   :header-rows: 1
 
-  * - Exposure
-    - Treatment coverage (C)
-    - Treatment efficacy (E)
-    - Effectivey covered
-    - Not effectively covered
-    - Reference
+  * - Parameter
+    - Alternative scenario value
     - Note
-  * - SAM baseline
-    - 48.8% (95% CI: 37.4, 60.4)
-    - 70% (95% CI: 64, 76)
-    - 0.488 x 0.7 = 0.34
-    - 1 - 0.34 = 0.66
-    - coverage: [Isanaka_etal_2021]_ , efficacy: [Zw_2020]_
-    - This is for SAM-OTP which is ~98% of SAM.
-  * - SAM alternative
-    - 70%
-    - 75%
-    - 0.7 x 0.75 = 0.53
-    - 1 - 0.53 = 0.47
-    - Sphere standards for efficacy; discussion with CIFF/UNICEF for coverage
-    - 
-  * - MAM baseline
-    - 15% (95% CI: 10, 20)
-    - 73.1% (95% CI:58.5-87.7) for RUSF
-    - 0.15 x 0.731 = 0.11
-    - 1 - 0.11 = 0.89
-    - Efficacy: [Ackatia_Armah_2015]_, Coverage: assumption from CIFF/UNICEF
-    - Efficacy comes from trial and may be too optimistic
-  * - MAM alternative
-    - 70%
-    - 75% for RUSF
-    - 0.7 x 0.75 = 0.53
-    - 1 - 0.53 = 0.47
-    - Sphere standards for efficacy; discussion with CIFF/UNICEF for coverage
-    - 
+  * - :math:`C_{MAM}`
+    - 0.7
+    - Informed by discussion with CIFF/UNICEF
+  * - :math:`C_{SAM}`
+    - 0.7
+    - Informed by discussion with CIFF/UNICEF
+  * - :math:`E_{MAM}`
+    - 0.75
+    - Informed by Sphere standards
+  * - :math:`E_{SAM}`
+    - 0.75
+    - Informed by Sphere standards
 
 **Alternative scenario 2**
-Scale up the SQ-LNS for 6 month+ from 0% at baseline to 90% in addition to the intervention coverage in alternative scenario 1. The SQ-LNS intervention will decrease the **incidence rate of MAM** (i2), without affecting duration (assumption). This is expected to further decrease the prevalence of MAM and SAM.
+Scale up the SQ-LNS for 6 month+ from the baseline coverage to **90%** in addition to the intervention coverage in alternative scenario 1. 
 
 .. todo::
 
@@ -215,10 +207,26 @@ Scale up the SQ-LNS for 6 month+ from 0% at baseline to 90% in addition to the i
   Consider if 90% intervention coverage is too aspirational
 
 **Alternative scenario 3**
-Scale up of LBWSG interventions from baseline coverage % (TBD) to 90% in addition to the intervention coverage in alternative scenario 2.
+Scale up of LBWSG intervention parameters (see table below) from baseline coverage to **90%** in addition to the intervention coverage in alternative scenario 2.
+
+.. list-table:: Alternative scenario 3 intervention coverage values
+  :header-rows: 1
+
+  * - Intervention
+    - Coverage value
+    - Note
+  * - :ref:`maternal supplementation <maternal_supplementation_intervention>`
+    - 0.9
+    - Applies to joint coverage of MMS/BEP
+  * - :ref:`insecticide treated nets <insecticide_treated_nets>`
+    - :math:`C_\text{malarious areas} = 0.9`
+    - Overall ITN intervention coverage (:math:`C_\text{overall}`) calculated as :math:`C_\text{malarious areas} \times p_\text{malarious areas}`
+  * - :ref:`intermittent malaria preventive therapy for pregnant women <maternal_malaria_prevention_therapy>`
+    - 0.9
+    - Pending decision to include intervention in simulation
 
 **Alternative scenario 4**
-Scale-up of vicious cycle interventions (breast-feeding) from baseline coverage % (TBD) to 90% in addition to the intervention coverage in alternative scenario 3.
+Scale-up of vicious cycle interventions (kangaroo care, breastfeeding promotion, and preventive and therapeutic zinc) from baseline coverage to 90% in addition to the intervention coverage in alternative scenario 3.
 
 .. note::
 
@@ -227,6 +235,8 @@ Scale-up of vicious cycle interventions (breast-feeding) from baseline coverage 
 .. note::
 
     In the BEP paper reviewer comments, this 90% was deemed to be too optimistic and we are asked to do some sensitivity analysis around this. Hence, we could model a few coverages eg. 50%, 75%, 90%.
+
+    Consider 70% target for all interventions.
 
 .. _ciff_sam_intervention_timing:
 
@@ -505,29 +515,4 @@ Final outputs to report in manuscript
 
 8.0 References
 +++++++++++++++
-
-.. [Isanaka_etal_2021]
-
-  View `Isanaka 2021`_
-
-    Improving estimates of the burden of severe wasting: analysis of secondary prevalence and incidence data from 352 sites
-
-.. _`Isanaka 2021`: https://gh.bmj.com/content/6/3/e004342
-
-
-.. [Zw_2020]
-
-  View `Zw et al 2020`_
-
-    Treatment outcomes of severe acute malnutrition and predictors of recovery in under-five children treated within outpatient therapeutic programs in Ethiopia: a systematic review and metaanalysis
-
-.. _`Zw et al 2020`: https://bmcpediatr.biomedcentral.com/articles/10.1186/s12887-020-02188-5
-
-.. [Ackatia_Armah_2015]
-
-  View `Ackatia-Armah et al 2015`_
-
-    Malian children with moderate acute malnutrition who are treated with lipid-based dietary supplements have greater weight gains and recovery rates than those treated with locally produced cereal-legume products: a community-based, cluster-randomized trial
-
-.. _`Ackatia-Armah et al 2015`: https://pubmed-ncbi-nlm-nih-gov.offcampus.lib.washington.edu/25733649/
 

--- a/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
+++ b/docs/source/gbd2020_models/risk_attributable_causes/wasting/index.rst
@@ -644,12 +644,12 @@ in terms of the following variables:
      - All category "prevalences" are scaled down, such that the prevalence of cat 0 (the reincarnation pool) and the prevalences of the wasting categories sum to 1
    * - :math:`mam_tx_coverage`
      - Proportion of MAM (CAT 2) cases that have treatment coverage
-     - 0.15 (95% CI: 0.1, 0.2)
-     - Potentially to be updated
+     - :ref:`defined here <wasting-treatment-baseline-parameters>` as :math:`C_{MAM}`
+     - 
    * - :math:`sam_tx_coverage`
      - Proportion of SAM (CAT 1) cases that have treatment coverage
-     - 0.488 (95% CI: 0.374, 0.604)
-     - Potentially to be updated
+     - :ref:`defined here <wasting-treatment-baseline-parameters>` as :math:`C_{SAM}`
+     - 
    * - :math:`time_to_mam_ux_recovery`
      - Without treatment or death, average days spent in MAM before recovery
      - 63

--- a/docs/source/intervention_models/insecticide_treated_nets/index.rst
+++ b/docs/source/intervention_models/insecticide_treated_nets/index.rst
@@ -59,6 +59,8 @@ Insecticide treated bed nets effectively reduce malaria incidence (and therefore
     - No
     - Statistically insignificant from [Gamble-et-al-2007]_. Effect entirely mediated through malaria incidence reduction.
 
+.. _`itn-baseline-parameters`:
+
 Baseline Coverage Data
 ++++++++++++++++++++++++
 
@@ -69,20 +71,15 @@ survey of coverage of key malaria control interventions, treatment-seeking behav
   :header-rows: 1
 
   * - Location
-    - Subpopulation
-    - Coverage parameter
-    - Value
+    - :math:`C_\text{malarious areas}`
+    - :math:`p_\text{malarious areas}`
+    - :math:`C_\text{overall}`
     - Note
   * - Ethiopia
-    - Pregnant women in malarious areas
-    - Proportion sleeping under ITNs
-    - 0.44 (SD: 0.021)
-    - Assume normal distribution of uncertainty. SD of uncertainty distribution calculated from :math:`SE = \sqrt{p * (1 - p) / n}`. Data from Ethiopia MIS 2015.
-  * - Ethiopia
-    - Pregnant women
-    - Proportion sleeping under ITNs
-    - 0.6 :math:`\times` the proportion of pregnant women in malarious areas sleeping under ITNs 
-    - Use this value for baseline intervention coverage among the general pregnant population. NOTE: this strategy requires a maximum target intervention coverage level of 60% of the general population of pregnant women.
+    - **0.44 (SD: 0.021), normal distribution of uncertainty.** (SD of uncertainty distribution calculated from :math:`SE = \sqrt{p * (1 - p) / n}`. Data from Ethiopia MIS 2015)
+    - **0.6** (data from Ethiopia MIS 2015)
+    - :math:`C_\text{malarious areas} \times p_\text{malarious areas}`
+    - Use :math:`C_\text{overall}` for simulation coverage proportion
 
 Vivarium Modeling Strategy
 --------------------------

--- a/docs/source/intervention_models/lipid_based_nutrient_supplements/index.rst
+++ b/docs/source/intervention_models/lipid_based_nutrient_supplements/index.rst
@@ -140,11 +140,12 @@ Please see this memo for a summary of the studies and the effect sizes :download
     - Direct
 
 
+.. _`sqlns-baseline-parameters`:
+
 Baseline Coverage Data
 ++++++++++++++++++++++++
 
-No baseline coverage of SQ-LNS
-
+No baseline coverage of SQ-LNS (0%)
 
 Vivarium Modeling Strategy
 --------------------------

--- a/docs/source/intervention_models/maternal_malaria_prevention_therapy/index.rst
+++ b/docs/source/intervention_models/maternal_malaria_prevention_therapy/index.rst
@@ -65,6 +65,8 @@ This is considered to be a strong recommendation based on high quality evidence.
     - Yes
     - [Radeva-Petrova-et-al-2014]_. Statistically insignificant reduction in preterm birth
 
+.. _`iptp-baseline-parameters`:
+
 Baseline Coverage Data
 ++++++++++++++++++++++++
 

--- a/docs/source/intervention_models/maternal_supplementation/index.rst
+++ b/docs/source/intervention_models/maternal_supplementation/index.rst
@@ -92,6 +92,8 @@ IFA is widely used as a prenatal supplement in most areas of the world and is re
     - Yes (hypothesized effect in the :ref:`BEP simulation <2017_concept_model_vivarium_gates_bep>`). Should not be modeled in simulations using conservative evidence
     - Possible mediation through birthweight/wasting. Low quality evidence.
 
+.. _`maternal-supplementation-baseline-parameters`:
+
 Baseline Coverage Data
 ++++++++++++++++++++++++
 

--- a/docs/source/intervention_models/wasting_treatment/index.rst
+++ b/docs/source/intervention_models/wasting_treatment/index.rst
@@ -409,6 +409,8 @@ where t is the period for which transition the is estimated (a year) eg. 365 day
 
 .. _`parameter values table`:
 
+.. _`wasting-treatment-baseline-parameters`:
+
 .. list-table:: Parameter Values
   :header-rows: 1
 
@@ -576,6 +578,12 @@ Affected Outcomes
 
 The Vivarium modeling strategy above details how to solve for the transition rates among the covered uncovered populations. However, the wasting treatment intervention will be implemented as a variable that affects the relative risk of certain transition rates between wasting states in the :ref:`dynamic wasting model <2020_risk_exposure_wasting_state_exposure>`. The following table details the relative risks for each dynamic wasting model transition rate that is affected by wasting treatment based on a given treatment category.
 
+.. warning::
+
+  The :math:`E_{SAM}` and :math:`E_{MAM}` parameters vary between baseline and alterantive scenarios for the :ref:`acute malnutrition simulation <2019_concept_model_vivarium_ciff_sam>` (see the :ref:`alternative scenario values here <wasting-treatment-alterative-scenario-values>`). This will cause the rate at which simulants covered by MAM/SAM treatment transition through the treated and untreated pathways to vary by scenario (the treated pathway transition rate will be greater and the untreated pathway transition rate will be lower in the alternative scenario relative to the the baseline scenario). This should be reflected in the implementation of the treatment model (such as separate intervention "risk factor" components for baseline and alternative treatments).
+
+  Also, :math:`E_{SAM}` and :math:`E_{MAM}` fractions may depend on diarrheal status in later model builds.
+
 .. list-table:: Wasting transition rate relative risks for wasting treatment
   :header-rows: 1
 
@@ -638,39 +646,6 @@ Coverage Propensities
   1) coverage among the MAM and SAM states is equal to :math:`C_{MAM}` and :math:`C_{SAM}`
 
   2) simulants who are treated for MAM or SAM once are likely to be treated again and vise versa.
-
-Scenarios
-+++++++++++
-
-.. list-table:: Scenario coverage data (Ethiopia)
-  :header-rows: 1
-
-  * - Parameter
-    - Baseline value
-    - Alternative Value
-    - Note
-  * - :math:`C_{MAM}`
-    - 0.15 (95% CI: 0.1, 0.2)
-    - 0.7
-    -
-  * - :math:`C_{SAM}`
-    - 0.488 (95% CI:0.374-0.604)
-    - 0.7
-    -
-  * - :math:`E_{MAM}`
-    - 0.731 (95% CI:0.585-0.877), normal
-    - 0.75
-    - Sphere standards
-  * - :math:`E_{SAM}`
-    - 0.70 (95% CI:0.64-0.76), normal
-    - 0.75
-    - Sphere standards
-
-.. note::
-
-  Changing the :math:`E_{SAM}` and :math:`E_{MAM}` rates between the baseline and alternative scenarios will change the rate of simulants covered by MAM/SAM treatment that transition through the treated and untreated pathways (the treated pathway transition rate will be greater and the untreated pathway transition rate will be lower in the alternative scenario relative to the the baseline scenario). This should be reflected in the implementation of the treatment model.
-
-  Also, :math:`E_{SAM}` and :math:`E_{MAM}` fractions may depend on diarrheal status in later model builds.
 
 Restrictions
 ++++++++++++


### PR DESCRIPTION
This PR does not change any modeling strategy or data values, but is intended to clarify scenario-specific values related to intervention coverage and avoid listing parameter values in multiple places in the documentation as requested by Rajan (a few additional PRs will be coming to do the same thing on other pages).