### PR TITLE
Risk effects: LBWSG 2019 PAF

### DIFF
--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -857,7 +857,7 @@ As always, the formula for the PAF is
   = 1 - \frac{1}{\int \mathit{RR}\, d\rho},
 
 where :math:`\textit{RR}` is the relative risk function, :math:`\rho` is the
-risk exposure distribution, and :math:`E` is expectation with respect to the
+risk exposure distribution, and :math:`E` is expectation_ with respect to the
 probability measure :math:`\rho`. Thus the PAF computation comes down to
 computing an integral representing the average relative risk in the population.
 In our case the relevant integral is
@@ -904,8 +904,8 @@ simple version of Monte Carlo integration by leveraging the Vivarium
 microsimulation framework. Namely, we can initialize a population of simulants
 according to the LBWSG risk exposure distribution :math:`\rho`, then compute the
 average relative risk and the PAF for the simulated population. Here is Python
-(pseudo-)code to achieve this, using the relative risk interpolation code from
-above:
+(pseudo-)code to achieve this, continuing from the relative risk interpolation
+code above:
 
 .. code-block:: Python
 
@@ -989,6 +989,22 @@ simulants gets larger.
   sufficiently large population size for a desired level of precision if we deem
   that the original population size was insufficient.
 
+.. todo::
+
+  Describe a strategy for choosing a large enouth population size for the Monte
+  Carlo calculation.
+
+.. todo::
+
+  Determine if any alternative sampling strategies for the Monte Carlo
+  calculation may be more efficient.
+
+.. todo::
+
+  Try using SciPy's integration tools to compute the PAF as an alernative to the
+  Monte Carlo approach.
+
+.. _expectation: https://en.wikipedia.org/wiki/Expected_value
 .. _Monte Carlo integration: https://en.wikipedia.org/wiki/Monte_Carlo_integration
 .. _standard error: https://en.wikipedia.org/wiki/Standard_error
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -871,7 +871,12 @@ In our case the relevant integral is
 where :math:`\mathrm{GA} = [0,42\text{wk}]` and :math:`\mathrm{BW} =
 [0,4500\text{g}]`, :math:`\mathit{RR}(x,y)` is the interpolated relative
 risk at gestational age :math:`x \in \mathrm{GA}` and birthweight :math:`y \in
-\mathrm{BW}`, and :math:`d\rho(x,y) / dx\,dy` is the probability density of the point :math:`(x,y)\in \mathrm{GA}\times \mathrm{BW}`. That is,
+\mathrm{BW}`, and :math:`\rho` is the LBWSG exposure distribution.
+
+Note that the above formula employs the notation ":math:`d\rho`" from measure
+theory. To compute the integral, we can rewrite :math:`d\rho(x,y)` in terms of
+the probability density function for the LBWSG exposure distribution
+:math:`\rho`:
 
 .. math::
 
@@ -879,7 +884,9 @@ risk at gestational age :math:`x \in \mathrm{GA}` and birthweight :math:`y \in
   = \frac{d\rho(x,y)}{dx\, dy}\, dx\, dy
   = p(x,y)\, dx\, dy,
 
-where :math:`p(x,y) = d\rho(x,y) / dx\,dy` is the probability density function for the LBWSG exposure distribution :math:`\rho`.
+where :math:`p(x,y) = d\rho(x,y) / dx\,dy` is the probability density of the
+point :math:`(x,y)\in \mathrm{GA}\times \mathrm{BW}`, according to the LBWSG
+exposure distibution from GBD.
 
 Computing the PAF via Monte Carlo Integration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -991,13 +991,22 @@ simulants gets larger.
 
 .. todo::
 
-  Describe a strategy for choosing a large enouth population size for the Monte
-  Carlo calculation.
+  Describe a strategy for choosing a large enough population size for the Monte
+  Carlo calculation. See this `post in Slack
+  <https://ihme.slack.com/archives/C018BLX2JKT/p1639696957071600?thread_ts=1639685855.069100&cid=C018BLX2JKT>`_.
+
+.. todo::
+
+  Add link to Nathaniel's nanosim for LSFF as an example of working code that
+  performs the Monte Carlo PAF calculation.
 
 .. todo::
 
   Determine if any alternative sampling strategies for the Monte Carlo
-  calculation may be more efficient.
+  calculation may be more efficient. For example, rather than sampling the
+  continuous LBWSG distribution directly, it may be better to estimate the mean
+  RR in each category separately, then take a weighted average of the mean RR in
+  each category, weighting by the category prevalences.
 
 .. todo::
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -965,24 +965,32 @@ above:
 As the number of simulants gets larger, the Law of Large Numbers implies that
 the mean RR of the simulated population will converge to the mean RR of a
 population with LBWSG exposure distribution :math:`\rho` (represented by the
-``lbwsg_exposure`` DataFrame in the above code). Therefore, the PAF computed by the above
-code will converge to the true PAF of the population as the number of simulants
-gets larger.
+``lbwsg_exposure`` DataFrame in the above code). Therefore, the PAF computed by
+the above code will converge to the true PAF of the population as the number of
+simulants gets larger.
 
-In order to get an idea of how large of a population we need to get a mean RR
-and PAF close enough to the right value, we can estimate the standard error of
-the mean RR from the simulated population, and use it to compute the population
-size for a desired tolerance as follows:
+.. important::
 
-.. code-block:: Python
+  In order to get an idea of how large of a population we need to get a mean RR
+  and PAF close enough to the right value, we should do the Monte Carlo PAF
+  calculation for several small population sizes (e.g., 10, 100, 1000, 10,000),
+  and record some descriptive statistics for each calculation. Namely, it will
+  be useful to record the **mean RR**, the **sample standard deviation of the
+  RRs**, and the `standard error`_ **of the mean RR** for each simulation:
 
-  def standard_error_of_the_mean(values: pd.Series)->float:
-    """Returns sample esimate of the standard error of the mean for a Series of sample values."""
-    return np.sqrt(values.var()/len(values))
+  .. code-block:: Python
 
-  enn_female_standard_error = standard_error_of_the_mean(enn_female_lbwsg_rrs)
+    enn_female_rr_mean = enn_female_lbwsg_rrs.mean()
+    enn_female_rr_std_dev = np.sqrt(enn_female_lbwsg_rrs.var())
+    enn_female_rr_standard_error = enn_female_rr_std_dev / np.sqrt(len(enn_female_lbwsg_rrs))
+
+  These statisics will help us evaluate whether the PAF we get for a given
+  simulation is likely to be close to the true PAF, and will help us choose a
+  sufficiently large population size for a desired level of precision if we deem
+  that the original population size was insufficient.
 
 .. _Monte Carlo integration: https://en.wikipedia.org/wiki/Monte_Carlo_integration
+.. _standard error: https://en.wikipedia.org/wiki/Standard_error
 
 Affected Outcomes in Vivarium
 +++++++++++++++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -837,6 +837,36 @@ using ``get_draws``:
 PAF Calculation for Interpolated Relative Risks
 +++++++++++++++++++++++++++++++++++++++++++++++
 
+Since the interpolated relative risk function is different from the piecewise
+constant relative risk function used by GBD, we will need to compute our own
+population attributable fraction (PAF) for the interpolated relative risks
+rather than using the PAF calculated by GBD. As always, the formula for the PAF
+is
+
+.. math::
+
+  \mathrm{PAF}
+  = \frac{E(\mathit{RR}) - 1}{E(\mathit{RR})}
+  = 1 - \frac{1}{E(\mathit{RR})}
+  = 1 - \frac{1}{\int \mathit{RR}\, d\rho},
+
+where :math:`\textit{RR}` is the relative risk function, :math:`\rho` is the
+risk exposure distribution, and :math:`E` is expectation with respect to the
+probability measure :math:`\rho`. Thus the PAF computation comes down to
+computing an integral representing the average relative risk in the population.
+In our case the relevant integral is
+
+.. math::
+
+  \int \mathit{RR}\, d\rho
+  = \int_{\mathrm{GA}\times \mathrm{BW}}
+    \mathit{RR}(x,y)\, d\rho(x,y),
+
+where :math:`\mathrm{GA} = [0,42\text{wk}]` and :math:`\mathrm{BW} =
+[0,4500\text{g}]`, and :math:`\mathit{RR}(x,y)` is the interpolated relative
+risk at gestational age :math:`x \in \mathrm{GA}` and birthweight :math:`y \in
+\mathrm{BW}`.
+
 Affected Outcomes in Vivarium
 +++++++++++++++++++++++++++++
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -834,6 +834,9 @@ using ``get_draws``:
 .. _Notebook comparing 2-step interpolations: https://github.com/ihmeuw/vivarium_data_analysis/blob/main/pre_processing/lbwsg/2021_03_16a_lbwsg_compare_two_step_interpolation_plots.ipynb
 .. _LBWSGRiskEffectRBVSpline class: https://github.com/ihmeuw/vivarium_research_lsff/blob/main/nanosim_models/lbwsg.py#L722
 
+PAF Calculation for Interpolated Relative Risks
++++++++++++++++++++++++++++++++++++++++++++++++
+
 Affected Outcomes in Vivarium
 +++++++++++++++++++++++++++++
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -333,6 +333,8 @@ Vivarium Modeling Strategy
    :ref:`Low Birthweight and Short Gestation (GBD 2019)
    <2019_risk_exposure_lbwsg>` page.
 
+.. _lbwsg_2019_rr_interpolation_section:
+
 Interpolation of LBWSG Relative Risks
 +++++++++++++++++++++++++++++++++++++
 
@@ -837,11 +839,14 @@ using ``get_draws``:
 PAF Calculation for Interpolated Relative Risks
 +++++++++++++++++++++++++++++++++++++++++++++++
 
-Since the interpolated relative risk function is different from the piecewise
-constant relative risk function used by GBD, we will need to compute our own
-population attributable fraction (PAF) for the interpolated relative risks
-rather than using the PAF calculated by GBD. As always, the formula for the PAF
-is
+The Population Attributable Fraction (PAF) is used to compute "risk-deleted"
+transiton rates in our simulations. In the present context, the deleted risk
+will be LBWSG, and the affected rate will be the simulants' mortality hazard.
+Since the interpolated relative risk function described :ref:`above
+<lbwsg_2019_rr_interpolation_section>` is different from the piecewise constant
+relative risk function used by GBD, we will need to compute our own PAF for the
+interpolated relative risks rather than using the PAF calculated by GBD. As
+always, the formula for the PAF is
 
 .. math::
 

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -845,8 +845,9 @@ will be LBWSG, and the affected rate will be the simulants' mortality hazard.
 Since the interpolated relative risk function described :ref:`above
 <lbwsg_2019_rr_interpolation_section>` is different from the piecewise constant
 relative risk function used by GBD, we will need to compute our own PAF for the
-interpolated relative risks rather than using the PAF calculated by GBD. As
-always, the formula for the PAF is
+interpolated relative risks rather than using the PAF calculated by GBD.
+
+As always, the formula for the PAF is
 
 .. math::
 
@@ -868,9 +869,20 @@ In our case the relevant integral is
     \mathit{RR}(x,y)\, d\rho(x,y),
 
 where :math:`\mathrm{GA} = [0,42\text{wk}]` and :math:`\mathrm{BW} =
-[0,4500\text{g}]`, and :math:`\mathit{RR}(x,y)` is the interpolated relative
+[0,4500\text{g}]`, :math:`\mathit{RR}(x,y)` is the interpolated relative
 risk at gestational age :math:`x \in \mathrm{GA}` and birthweight :math:`y \in
-\mathrm{BW}`.
+\mathrm{BW}`, and :math:`d\rho(x,y) / dx\,dy` is the probability density of the point :math:`(x,y)\in \mathrm{GA}\times \mathrm{BW}`. That is,
+
+.. math::
+
+  d\rho(x,y)
+  = \frac{d\rho(x,y)}{dx\, dy}\, dx\, dy
+  = p(x,y)\, dx\, dy,
+
+where :math:`p(x,y) = d\rho(x,y) / dx\,dy` is the probability density function for the LBWSG exposure distribution :math:`\rho`.
+
+Computing the PAF via Monte Carlo Integration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Affected Outcomes in Vivarium
 +++++++++++++++++++++++++++++

--- a/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/low_birthweight_short_gestation/index.rst
@@ -874,8 +874,11 @@ risk at gestational age :math:`x \in \mathrm{GA}` and birthweight :math:`y \in
 \mathrm{BW}`, and :math:`\rho` is the LBWSG exposure distribution.
 
 Note that the above formula employs the notation ":math:`d\rho`" from measure
-theory. To use more familiar notation, we can rewrite :math:`d\rho(x,y)` in
-terms of the probability density function for the LBWSG exposure distribution
+theory. If the exposure distribution :math:`\rho` is absolutely continuous with
+density function :math:`p` (e.g., if :math:`\rho` is defined by the piecewise
+constant density function described on the :ref:`GBD 2019 LBWSG exposure page
+<2019_risk_exposure_lbwsg>`), we can rewrite :math:`d\rho(x,y)` in terms of the
+probability density function :math:`p` for the LBWSG exposure distribution
 :math:`\rho`:
 
 .. math::
@@ -887,7 +890,10 @@ terms of the probability density function for the LBWSG exposure distribution
 where :math:`dx\, dy` represents two-dimensional Lebesgue measure, and the
 Radon-Nikodym derivative :math:`p(x,y) = d\rho(x,y) / dx\,dy` is the probability
 density function of the LBWSG exposure distibution at the point :math:`(x,y)\in
-\mathrm{GA}\times \mathrm{BW}`.
+\mathrm{GA}\times \mathrm{BW}`. On the other hand, if :math:`\rho` is a discrete
+distribution (e.g., the polytomous LBWSG distribution described by GBD), then
+the integral with respect to :math:`d\rho` is by definition a sum over the
+discrete exposure categories.
 
 Computing the PAF via Monte Carlo Integration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Adds a section to the GBD 2019 Low Birthweight and Short Gestation risk effects documentation to explain how to compute a PAF for the interpolated relative risks using Monte Carlo integration. 