### PR TITLE
IV iron timeframe (including burn in period) and intervention scale-up

### DIFF
--- a/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
+++ b/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
@@ -94,17 +94,45 @@ Vivarium Intravenous Iron - Children under five
 3.2 Simulation timeframe and intervention start dates
 ------------------------------------------------------
 
-* Date of simulation start: January 1, 2022
+**Throughout model development and verification/validation:**
 
-* Date of intervention scale-up: N/A (simulation coverage modeled in WRA simulation)
+.. list-table:: Developmental model child simulation timeframe and intervention dates
+  :header-rows: 1
 
-* Date of simulation end: December 31, 2024
+  * - Parameter
+    - Value
+  * - Date of simulation burn-in period start
+    - N/A: no burn-in period
+  * - Date of simulation observation period start
+    - January 1, 2022 (only model births that occur on or after this date)
+  * - Date of intervention scale-up start
+    - N/A: defined for maternal simulation
+  * - Date of simulation end
+    - December 31, 2026 (run beyond end of maternal simulation so we can see impact of older children covered by intervention)
+  * - Simulation time step
+    - 0.5 days
+  * - Intervention scale-up rate
+    - N/A: defined for maternal simulation
 
-* Simulation time step: 0.5 days
+**For final model results:**
 
-.. note::
+.. list-table:: Final model child simulation timeframe and intervention dates
+  :header-rows: 1
 
-  We will likely increase the duration of simulation run time for final results of this model, but a shorter timeframe should be used throughout model development and validation.
+  * - Parameter
+    - Value
+  * - Date of simulation burn-in period start
+    - January 1, 2019 (so that we have children aged 5 years by the time of intervention start date)
+  * - Date of simulation observation period start
+    - N/A: defined for maternal simulation
+  * - Date of intervention scale-up start
+    -  N/A: defined for maternal simulation
+  * - Date of simulation end
+    - December 31, 2040
+  * - Simulation time step
+    - 0.5 days
+  * - Intervention scale-up rate
+    - N/A: defined for maternal simulation
 
 .. _ivironU54.0:
 

--- a/docs/source/concept_models/vivarium_iv_iron/maternal_model/concept_model.rst
+++ b/docs/source/concept_models/vivarium_iv_iron/maternal_model/concept_model.rst
@@ -96,19 +96,79 @@ Vivarium Intravenous Iron - Women of reproductive age
 3.2 Simulation timeframe and intervention start dates
 ------------------------------------------------------
 
-We will model an *immediate* scale-up of intervention coverage from the baseline level to the target level rather than a gradual scale-up over time.
+**Throughout model development and verification/validation:**
 
-* Date of simulation start: January 1, 2022
+.. list-table:: Developmental model maternal simulation timeframe and intervention dates
+  :header-rows: 1
 
-* Date of intervention scale-up: Janary 1, 2023
+  * - Parameter
+    - Value
+  * - Date of simulation burn-in period start
+    - January 1, 2020 (two years to accomodate ~1 year of pregnancy duration and 1 year post-birth disability)
+  * - Date of simulation observation period start
+    - January 1, 2022
+  * - Date of intervention scale-up start
+    - Janary 1, 2023
+  * - Date of simulation end
+    - December 31, 2024
+  * - Simulation time step
+    - 1 week
+  * - Intervention scale-up rate
+    - Immediate jump to target coverage level
 
-* Date of simulation end: December 31, 2024
+**For final model results:**
 
-* Simulation time step: 1 week
+.. list-table:: Final model maternal simulation timeframe and intervention dates
+  :header-rows: 1
+
+  * - Parameter
+    - Value
+  * - Date of simulation burn-in period start
+    - January 1, 2019 (so that we have children aged 5 years by the time of intervention start date)
+  * - Date of simulation observation period start
+    - January 1, 2025
+  * - Date of intervention scale-up start
+    - Janary 1, 2025
+  * - Date of simulation end
+    - December 31, 2040
+  * - Simulation time step
+    - 1 week
+  * - Intervention scale-up rate
+    - See table below
+
+.. list-table:: Intervention scale-up for final model results
+  :header-rows: 1
+
+  * - Year
+    - Percent of target coverage reached on January 1
+  * - 2025
+    - 0%
+  * - 2026
+    - 2%
+  * - 2027
+    - 5%
+  * - 2028
+    - 10%
+  * - 2029
+    - 20%
+  * - 2030
+    - 36%
+  * - 2031
+    - 55%
+  * - 2032
+    - 73%
+  * - 2033
+    - 86%
+  * - 2034
+    - 93%
+  * - 2035
+    - 97%
+  * - 2036+
+    - 100%
 
 .. note::
-
-  The BMGF is interested in modeling a scale-up of intervention coverage over time. However, we will plan to model an immediate intervention scale-up throughout model development and validation and implement the scale-up at the end of model development prior to results finalization.
+  
+  This scale-up curve comes from BMGF's internal product analytics group that develop these curves based on market dynamics and product characteristics compared to other like products on the market.
 
 .. _ivironWRA4.0:
 

--- a/docs/source/other_models/pregnancy/index.rst
+++ b/docs/source/other_models/pregnancy/index.rst
@@ -135,7 +135,7 @@ We will model pregnancy as a characteristic of women of reproductive age in our 
     - Note
   * - np
     - 1 - prevalence_p - prevalence_pp
-    - 
+    - If using a burn-in strategy, initialize all simulants to np state
   * - p
     - :math:`(ASFR + ASFR * SBR + incidence_\text{c995} + incidence_\text{c374}) * 40 / 52`
     - Consider updating to reflect average gestational age for location of interest rather than 40 weeks
@@ -278,7 +278,7 @@ For pregnancies that result in abortion/miscarriage/ectopic pregnancy, assign a 
 
 For pregnancies that result in live births or stillbirths, duration of pregnancy should be determined by gestational age exposure, which should be assigned according to the process for assigning LBWSG exposures described in the :ref:`risk correlation document between maternal BMI, maternal hemoglobin, and infant LBWSG exposure <2019_risk_correlation_maternal_bmi_hgb_birthweight>`. The LBWSG exposure distribution used to assign gestational age exposures should be specific to the sex of the infant for a given pregnancy (discussed in the above section). Note that the gestational age distribution is measured in weeks and will need to be converted to the equivalent simulation time measure.
 
-For simulants who are initialized into the pregnancy state at the start of the simulation:
+For simulants who are initialized into the pregnancy state at the start of the simulation (NOTE: this is not necessary if using a burn-in strategy instead):
 
    Assign the simulant a duration of pregnancy/gestational age value and then sample a random value from a uniform distribution between zero and the assigned gestational age value. The randomly sampled value will represent the current gestational duration of that pregnancy. The simulant should remain in the pregnancy state prior to transitioning to the postpartum state for the duration equal to the assigned gestational age value *minus* the randomly sampled value.
 


### PR DESCRIPTION
I know we said that we only needed a one year burn-in for the pregnancy model when we discussed it earlier today, but I think we will need to run for two years otherwise we will underestimate YLDs due to maternal disorders for the first year of the simulation, so I upped it to two years. Happy to discuss this PR as a group in our check-in meeting tomorrow.