### PR TITLE
Pregnancy model fix wrong covariate ID

### DIFF
--- a/docs/source/other_models/pregnancy/index.rst
+++ b/docs/source/other_models/pregnancy/index.rst
@@ -178,7 +178,7 @@ We will model pregnancy as a characteristic of women of reproductive age in our 
     - Assume normal distribution of uncertainty. Regional-level estimates available.
   * - SBR
     - Covariate
-    - 1106
+    - 2267
     - get_covariate_estimates: decomp_step='step4' or 'iterative' for GBD 2019, 'step3' or 'iterative' for GBD 2020
     - No uncertainty in this estimate: use mean_value as point value for this parameter. Regional-level estimates not available.
   * - incidence_c995


### PR DESCRIPTION
I accidentally recorded the covariate ID for live births by sex instead of the still birth ratio. I'd be surprised if this was included in the model since the correct ID for SBR is included in other places and the SBR is less than 1 and live births by sex is in the many thousands, so I think we would have noticed, but just FYI!