### PR TITLE
Maternal disorders cause model validation updates

### DIFF
--- a/docs/source/concept_models/vivarium_iv_iron/maternal_model/concept_model.rst
+++ b/docs/source/concept_models/vivarium_iv_iron/maternal_model/concept_model.rst
@@ -516,7 +516,7 @@ Probability of sampling from a given country's hemoglobin distribution using the
      - `Validation notebook can be found here <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/maternal/model1/sim_v_and_v.ipynb>`_. [1] ASFR covariate has negative values in the youngest age group for some draws... perhaps should update to truncated normal distribution. [2] duration of postpartum period appears to be too long... closer to 7 weeks than 6. [3] Request to have pregnancy person time stratified by pregnancy outcome in order to evaluate approximate differential duration of pregnancy. [4] Request to have all pregnancy transition counts rather than just np->p.
    * - I.2
      - Maternal disorders
-     - `Validation notebooks are available here <https://github.com/ihmeuw/vivarium_research_iv_iron/tree/main/validation/maternal/model2%2C%20maternal%20disorders>`_. [1] mortality rate due to other causes overestimated by a factor of approximately 50 (this is a new problem that was not present in model I.1). [2] rates (among women of reproductive age) AND ratios (per pregnancy) for both maternal disorders incidence AND mortality all overestimated. [3] Ratio of fatal to incident maternal disorders cases looks off for Sub-Saharan Africa, but is underestimated for South Asia. [4] previous issues appear to remain unresolved.
+     - `Validation notebooks are available here <https://github.com/ihmeuw/vivarium_research_iv_iron/tree/main/validation/maternal/model2%2C%20maternal%20disorders>`_. [1] mortality rate due to other causes overestimated by a factor of approximately 50 (this is a new problem that was not present in model I.1). [2] seeing age trend in maternal disorders burden attributable to differences bewteen rate of conception and rate of birth within each age group. [3] Underestimating maternal disorders burden relative to GBD overall [4] previous issues appear to remain unresolved.
 
 .. todo::
 
@@ -542,17 +542,18 @@ Probability of sampling from a given country's hemoglobin distribution using the
     - SWEs to implement
     - Soon (ticket MIC-2910)
   * - Mortality due to other causes overestimated
-    - Unknown
-    - SWEs to investigate (part of ticket  MIC-2944)
-    - Soon
-  * - Maternal disorder incidence and mortality rates and ratios overestimated
-    - Unknown
-    - SWEs to investigate (part of ticket  MIC-2944), Ali to be available to chat
-    - Soon
+    - Issue between weekly and annual rates
+    - SWEs addressed, Ali to validate implementation in next results
+    - For next model run
   * - Age group issues (underestimation of births in young ages and overestimation in older ages)
     - Related to start versus end of pregnancy timing
     - Ali to think through if we need to do anything about this
     - Soon
+  * - Underestimation of maternal disorders burden
+    - Perhaps a result of the `equation error that was fixed in this PR <https://github.com/ihmeuw/vivarium_research/pull/818/files>`_
+    - SWEs to update maternal disorders incidence and mortality equations, Ali to validate implementation and come up with next steps if necessary
+    - For next model run
+
 
 .. _ivironWRA4.4:
 


### PR DESCRIPTION
Matt and Jim caught an error in my plots that I was comparing maternal disorders burden to maternal hemorrhage burden, erroneously making it look like we were overestimating maternal disorders burden. Here are the updated conclusions now that that's been fixed