### PR TITLE
iv iron child sim validation

### DIFF
--- a/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
+++ b/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
@@ -341,7 +341,7 @@ Details on how to calculate weighted averages for specific simulation parameters
      - Cause models (infectious diseases)
      - `Simulation validation notebook can be found here <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/cause_data_validation.ipynb>`_. [1] underestimation of diarrheal diseases and lower respiratory infections remission rates. [2] underestimation of lower respiratory infections burden in neonatal age groups. [3] GBD 2019 age groups (does not include new GBD 2020 age groups). NOTE: still need to validate DALYs, YLLs, YLDs once environment issue is solved.
 
-.. list-table:: Outstaning model verification and validation issues
+.. list-table:: Outstanding model verification and validation issues
   :header-rows: 1
 
   * - Issue

--- a/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
+++ b/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
@@ -337,9 +337,29 @@ Details on how to calculate weighted averages for specific simulation parameters
    * - Model
      - Description
      - V&V summary
-   * - II.0
-     - 
-     - 
+   * - II.1
+     - Cause models (infectious diseases)
+     - `Simulation validation notebook can be found here <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/cause_data_validation.ipynb>`_. [1] underestimation of diarrheal diseases and lower respiratory infections remission rates. [2] underestimation of lower respiratory infections burden in neonatal age groups. [3] GBD 2019 age groups (does not include new GBD 2020 age groups). NOTE: still need to validate DALYs, YLLs, YLDs once environment issue is solved.
+
+.. list-table:: Outstaning model verification and validation issues
+  :header-rows: 1
+
+  * - Issue
+    - Explanation
+    - Action plan
+    - Timeline
+  * - Underestimation of diarrheal diseases and LRI remission rates
+    - Potential timestep issue, as identified with CIFF
+    - Researchers to investigate solutions
+    - TBD
+  * - Underestimation of LRI burden in neonatal age groups
+    - Appears to be a result of incompatible incidence, remission, and prevalence as estimated by GBD. There was birth prevalence of LRI in GBD 2017 that was removed for GBD 2019. Including a birth prevalence in our model would allow us to validate to GBD metrics, but would be inconsistent with GBD assumptions.
+    - Researchers to determine which validation targets are most important to hit and strategize how to achieve that.
+    - TBD
+  * - GBD 2019 age groups
+    - Model is using GBD 2019 age groups rather than GBD 2020 age groups, which will be needed if we plan to use GBD 2020 CGF risk factors
+    - Researchers to determine if we would like to update to GBD 2020 or stick with GBD 2019
+    - TBD
 
 .. _ivironU54.4:
 

--- a/docs/source/gbd2019_models/risk_effects/maternal_hemorrhage/index.rst
+++ b/docs/source/gbd2019_models/risk_effects/maternal_hemorrhage/index.rst
@@ -51,11 +51,7 @@ GBD 2019 Modeling Strategy
 
 GBD does not explicitly model maternal hemorrhage as a risk factor. However, GBD models a hemoglobin shift associated with maternal hemorrhage in the :ref:`anemia causal attribution process <2019_anemia_impairment>`, which was derived from a meta-analysis performed for GBD 2019. 
 
-GBD assumes that a case of **maternal hemorrhage is associated with a decrease of 6.8 grams per liter hemoglobin concentration**, on average. There is no uncertainty interval around this value considered in the GBD anemia causal attribution process (this value is not published, but was obtained from the anemia modelers).
-
-.. todo::
-
-  Reach out to anemia modelers to see if there is an uncertainty interval from the systematic review that just isn't used in the causal attribution code.
+GBD assumes that a case of **maternal hemorrhage is associated with a decrease of 6.8 grams per liter hemoglobin concentration**, on average. There is no uncertainty interval around this value considered in the GBD anemia causal attribution process (this value is not published, but was obtained from the anemia modelers). Notably, according to Nick K., this shift is representative of the longer-term impact of hemorrhage on hemoglobin after some duration of follow-up on the scale of months.
 
 Vivarium Modeling Strategy
 --------------------------


### PR DESCRIPTION
It doesn't look like there are any software bugs in the child sim, but a few things to note:
- There are LRI and diarrheal diseases research validation issues to sort out. These mainly affect the neonatal age groups so we considered them ok for CIFF, but it will be more impactful for this project so we should try to get these resolved.
- We're using GBD 2019 rather than 2020 age groups, so we'll have to decide if we think it's worth updating this in order to use the GBD 2020 child growth failure risk factors. I think it would be acceptable to use 2019 exposures given the following:
    - From Ryan Fitzgerald: `Hi all, I'm Ryan, I model CGF and LBWSG exposure on GBD. I have been messaging with Nicole about your project and specifically about how the relative risks changed from GBD2019 - GBD2020. Michael Arndt is actually the one who lead that analysis. Briefly, because we got access to a very large longitudinal dataset, we were better able to understand the co-occurrence of stunting, wasting, and underweight and therefore parse out better relative risks for each CGF indicator. Those changed the RR's and attributable burdens of stunting, wasting, and underweight significantly - but since we basically just 're-distributed' the CGF burden within CGF, the attributable burden of CGF as a whole only slightly changed`. Since we don't have such a specific focus on wasting as for CIFF, this might be ok.
    - CGF is expected to have a small impact on our model given that it will only be affected by birthweight and we know that the association between them is small.
- I haven't yet validated YLD/YLL/DALYs given the environment issues (described in this thread: https://ihme.slack.com/archives/C014RDZA1GE/p1648238502235909)