### PR TITLE
update child v and v table

### DIFF
--- a/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
+++ b/docs/source/concept_models/vivarium_iv_iron/child_model/concept_model.rst
@@ -351,7 +351,7 @@ Details on how to calculate weighted averages for specific simulation parameters
      - [1] Still have the `overstimation of mortality rates of our causes <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/model_2/model_2.1.0_cause_model_validation.ipynb>`_. [2] `Wasting risk exposure and PEM prevalence looks good <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/model_2/model_2.1.0_cause_model_validation.ipynb>`_. [3] `Wasting risk effects on incidence rates look good <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/model_2/wasting_validation_model_2.1.0.ipynb>`_. [4] No deaths due to PEM in deaths count data... also wasn't expecting outputs of PEM transition counts. **Keep stratification by wasting for now until we finish validating PEM deaths**
    * - 2.1.1
      - Experimental fixes to the excess mortality issue
-     - [1] `Overestimation of EMR fixed! <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/model_2/model_2.1.1_cause_model_validation.ipynb>`_ For both locations. [2] PEM CSMR is underestimated relative to artifact, although YLDs/YLLs/DALYs are validating to GBD, so seems to be ok. **Can remove wasting stratification moving forward**
+     - [1] `Overestimation of EMR fixed! <https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/model_2/model_2.1.1_cause_model_validation.ipynb>`_ For both locations. [2] PEM model looks good. **Can remove wasting stratification moving forward**
 
 
 .. list-table:: Outstanding model verification and validation issues
@@ -366,7 +366,7 @@ Details on how to calculate weighted averages for specific simulation parameters
     - Researchers to investigate solutions
     - TBD
   * - Underestimation of LRI burden in neonatal age groups and other issues for diarrheal diseases
-    - Appears to be a result of incompatible incidence, remission, and prevalence as estimated by GBD. There was birth prevalence of LRI in GBD 2017 that was removed for GBD 2019. Including a birth prevalence in our model would allow us to validate to GBD metrics, but would be inconsistent with GBD assumptions.
+    - Unknown
     - Researchers to determine which validation targets are most important to hit and strategize how to achieve that.
     - TBD
 


### PR DESCRIPTION
I had a comment about underestimating the PEM CSMR, but it was really because I was misunderstanding the definition of the severity-specific PEM CSMR in the artifact, which was actually for all PEM not severity-specific. Plots are now updated to reflect that here: https://github.com/ihmeuw/vivarium_research_iv_iron/blob/main/validation/child/model_2/model_2.1.1_cause_model_validation.ipynb