### PR TITLE
Wasting model baseline scenario run time update

### DIFF
--- a/docs/source/concept_models/vivarium_ciff_sam_2/concept_model.rst
+++ b/docs/source/concept_models/vivarium_ciff_sam_2/concept_model.rst
@@ -420,7 +420,8 @@ For scenarios that feature a scale-up of one of the above interventions, interve
   * - 1.0 Baseline concept model updates
     - Includes relevant model components, updated outputs, updated model specs.
     - 1
-    - Default (20 draws, 100,000 population size)
+    - * Simulation end date: 2023-12-31 (modified from 2026-12-31)
+      * Otherwise, default specs (20 draws, 100,000 population size)
     - Stratify cause state person time and cause transition counts by wasting and stunting state person time (for V&V of risk effects)
     - No x-factor component. V&V baseline model before moving on (cause models, risk effects, MAM/SAM treatment effects)
   * - 2.0 SQ-LNS updates


### PR DESCRIPTION
I realized we could get away with a shorter run time here, so updating this parameter to decrease our cluster load. Tagging as SE required to make sure this update is caught.