### PR TITLE
Switch from ssh to https in contributing instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ install this repository.  As always, you should do this in a clean environment.
 
    $> conda create -y --name=vivarium_research python=3.8
    $> conda activate vivarium_research
-   (vivarium_research) $> git clone git@github.com:ihmeuw/vivarium_research.git
+   (vivarium_research) $> git clone https://github.com/ihmeuw/vivarium_research.git
    (vivarium_research) $> cd vivarium_research
    (vivarium_research) $> pip install -r requirements.txt
 


### PR DESCRIPTION
Edit instructions in `README.rst` to suggest cloning the repo using `https` rather than `ssh`, as that's GitHub's recommended method and doesn't require the user to set up an SSH key.