### PR TITLE
Remove depth from PRL concept model

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -58,7 +58,6 @@ Vivarium Census PRL Simulated Data
 
 .. contents::
   :local:
-  :depth: 3
 
 +----------------------------------------------------+
 | List of abbreviations                              |


### PR DESCRIPTION
It was very annoying trying to find specific sections without having them listed and linked in the contents, so I removed the depth limit in order to display every subsection at the top of the file.