### PR TITLE
Remove decennial census from PO box observers

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -3047,7 +3047,7 @@ for all column based noise include:
     - Missing data, numeric miswriting, OCR, typographic
     - Noise for all types of addresses will work in the same way 
   * - PO Box for Mailing Address 
-    - Census, Household Surveys, WIC, Taxes (both) 
+    - Household Surveys, WIC, Taxes (both) 
     - 1%
     - 0.1 
     - N/A


### PR DESCRIPTION
As pointed out by @stevebachmeier, the decennial Census does not record mailing address so there is no PO box in that observer.