### PR TITLE
Don't copy within household for SSN in W2 dataset

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -3169,7 +3169,7 @@ for all column based noise include:
     - Taxes (both), SSA
     - 0.01
     - 0.1
-    - "Borrowed" SSN, missing data, copy from within household, numeric miswriting, OCR, typographic
+    - "Borrowed" SSN (W2 observer only), missing data, copy from within household (**not** on W2 observer), numeric miswriting, OCR, typographic
     - Note that not all types of noise apply to all observers, details below
   * - ITIN
     - Taxes 1040


### PR DESCRIPTION
As discussed:

- The combination of "borrowed" SSN and copy-within-household noise types both happening one after the other leads to some confusing scenarios
- Someone (who actually has an SSN) accidentally using the SSN of someone else in their household on a W2 does not seem like a very likely form of noise anyway

This will need to be reflected in pseudopeople docs as well; those don't exist yet.