### PR TITLE
Misc. pregnancy model updates from rt/se

### DIFF
--- a/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
@@ -6,7 +6,7 @@ Maternal disorders: GBD 2021
 
 .. note::
 
-  This page is an update from the previously developed :ref:`GBD 2019 maternal disorders cause model document <2019_cause_maternal_disorders>`. There were no major updates from the 2019 to 2021 version.
+  This page is an update from the previously developed :ref:`GBD 2019 maternal disorders cause model document <2019_cause_maternal_disorders>`. The only update was a change to the YLD equation, as noted in the YLDUpdateNote_.
 
 .. contents::
    :local:
@@ -239,11 +239,11 @@ Ratios of maternal disorder mortality and incidence are defined in the table bel
      - Value
      - Note
    * - Maternal disorder deaths
-     - csmr_c366 / (incidence_p * prevalence_np)
-     - 
+     - csmr_c366 / preg_rate
+     - Terms defined in table below
    * - Incident maternal disorders
-     - incidence_rate_c366 / (incidence_p * prevalence_np)
-     - **Post-maternal disorder state persists for one timestep** (one week, as implemented).
+     - incidence_rate_c366 / preg_rate
+     - **Post-maternal disorder state persists for one timestep** (one week, as implemented). Terms defined in table below.
 
 
 .. note::
@@ -299,15 +299,27 @@ The following table defines the parameters used in the calculation of maternal d
      - Annual rate of YLDs attributable to anemia due to maternal hemorrhage among WRA
      - como, decomp_step='iterative'
      - 
-   * - incidence_p
+   * - preg_rate
      - Pregnancy incidence rate
-     - :math:`\frac{ASFR + ASFR * SBR + incidence_\text{c995} + incidence_\text{c374}}{prevalence_\text{np}}`
-     - Do NOT use the value on the closed cohort pregnancy model document, but can find ASFR/SBR/incidence data definitions there.
-   * - prevalence_np
-     - Prevalence of the non-pregnant state
-     - 1 - [(ASFR + ASFR * SBR) * 46 / 52 + (incidence_c995 + incidence_c374) * 21 /52] 
-     - Do NOT use the value on the closed cohort pregnancy model document, but can find ASFR/SBR/incidence data definitions there.
-     
+     - :math:`ASFR + ASFR * SBR + incidence_\text{c995} + incidence_\text{c374}`
+     - 
+   * - ASFR
+     - Age-specific fertility rate
+     - get_covariate_estimates: coviarate_id=13, decomp_step='iterative'
+     - Assume lognormal distribution of uncertainty.
+   * - SBR
+     - Still to live birth ratio
+     - get_covariate_estimates: covariate_id=2267, decomp_step='iterative' for GBD 2021
+     - Parameter is not age specific and has no draw-level uncertainty. Use mean_value as location-specific point parameter.
+   * - incidence_c995
+     - Incidence rate of abortion and miscarriage cause
+     - como; decomp_step='iterative'
+     - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
+   * - incidence_c374
+     - Incidence rate of ectopic pregnancy
+     - como; decomp_step='iterative'
+     - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
+
 .. _AgeGroupNote:
 
 .. note::
@@ -329,23 +341,21 @@ Simulants who experience an incident case of maternal disorders and occupy the p
   \text{YLDs per non-fatal maternal disorders case} = 
   
 
+  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
+
+.. _YLDUpdateNote:
+
+.. note::
+
+  This equation was updated from the previous implementation (shown below):
+
+  .. math::
+
+  \text{YLDs per non-fatal maternal disorders case} = 
+  
+
   \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366}) * \text{incidence_rate}_\text{c366} - csmr_\text{c366}}
 
-.. warning::
-
-  A previous version of the above equation yielded a negative value in initial attempts. We've implementated the following placeholder (which may result in an underestimation of maternal disorder YLDs):
-
-  .. math::
-
-    \text{YLDs per non-fatal maternal disorders case} = \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366}}
-
-  The equation may eventually be updated to the resolved version in the main section above, although it is approximately 98-99% of the temporary fix, so it is a low priority for implementation.
-
-  For reference, the previous version of the equation that yielded a negative rate was as follows:
-
-  .. math::
-
-    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366} + csmr_\text{c366} / \text{incidence_rate}_\text{c366})}
 
 .. todo::
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
@@ -286,7 +286,7 @@ The following table defines the parameters used in the calculation of maternal d
    * - incidence_rate_c366
      - incidence rate of maternal disorders
      - como, decomp_step='iterative'
-     - 
+     - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
    * - ylds_non_fatal_maternal_disorder_case
      - Number of YLDs attributable to a single non-fatal maternal disorder case
      - See `Years lived with disability`_ section

--- a/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
@@ -6,7 +6,7 @@ Maternal disorders: GBD 2021
 
 .. note::
 
-  This page is an update from the previously developed :ref:`GBD 2019 maternal disorders cause model document <2019_cause_maternal_disorders>`. The only update was a change to the YLD equation, as noted in the YLDUpdateNote_.
+  This page is an update from the previously developed :ref:`GBD 2019 maternal disorders cause model document <2019_cause_maternal_disorders>`. There were no major updates from the 2019 to 2021 version.
 
 .. contents::
    :local:
@@ -320,6 +320,7 @@ The following table defines the parameters used in the calculation of maternal d
      - como; decomp_step='iterative'
      - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
 
+     
 .. _AgeGroupNote:
 
 .. note::
@@ -341,21 +342,23 @@ Simulants who experience an incident case of maternal disorders and occupy the p
   \text{YLDs per non-fatal maternal disorders case} = 
   
 
-  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
+  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366}) * \text{incidence_rate}_\text{c366} - csmr_\text{c366}}
 
-.. _YLDUpdateNote:
+.. warning::
 
-.. note::
-
-  This equation was updated from the previous implementation (shown below):
+  A previous version of the above equation yielded a negative value in initial attempts. We've implementated the following placeholder (which may result in an underestimation of maternal disorder YLDs):
 
   .. math::
 
-  \text{YLDs per non-fatal maternal disorders case} = 
-  
+    \text{YLDs per non-fatal maternal disorders case} = \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366}}
 
-  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366}) * \text{incidence_rate}_\text{c366} - csmr_\text{c366}}
+  The equation may eventually be updated to the resolved version in the main section above, although it is approximately 98-99% of the temporary fix, so it is a low priority for implementation.
 
+  For reference, the previous version of the equation that yielded a negative rate was as follows:
+
+  .. math::
+
+    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366} + csmr_\text{c366} / \text{incidence_rate}_\text{c366})}
 
 .. todo::
 

--- a/docs/source/models/causes/maternal_hemorrhage_incidence/index.rst
+++ b/docs/source/models/causes/maternal_hemorrhage_incidence/index.rst
@@ -164,7 +164,7 @@ There should be no correlation between maternal hemorrhage events and :ref:`mate
      - 0
      - Captured in the :ref:`maternal disorders cause model <2019_cause_maternal_disorders>`
    * - Incident maternal hemorrhage cases
-     - (incidence_rate_c367 - csmr_c367) / (incidence_p * prevalence_np)
+     - (incidence_rate_c367 - csmr_c367) / preg_rate
      - 
 
 The following table defines the parameters used in the calculation of maternal disorder ratios per birth.
@@ -191,15 +191,27 @@ The following table defines the parameters used in the calculation of maternal d
    * - incidence_rate_c367
      - incidence rate of maternal hemorrhage
      - como, decomp_step='step5' for GBD 2019, 'iterative' for GBD 2021
-     - 
-   * - incidence_p
+     - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
+   * - preg_rate
      - Pregnancy incidence rate
-     - Defined on the :ref:`pregnancy model document <other_models_pregnancy>`
-     - Use equations from this linked document, not the closed cohort pregnancy page
-   * - prevalence_np
-     - Prevalence of non-pregnant state
-     - Defined on the :ref:`pregnancy model document <other_models_pregnancy>`
-     - Use equations from this linked document, not the closed cohort pregnancy page
+     - :math:`ASFR + ASFR * SBR + incidence_\text{c995} + incidence_\text{c374}`
+     -
+   * - ASFR
+     - Age-specific fertility rate
+     - get_covariate_estimates: coviarate_id=13, decomp_step='iterative'
+     - Assume lognormal distribution of uncertainty.
+   * - SBR
+     - Still to live birth ratio
+     - get_covariate_estimates: covariate_id=2267, decomp_step='iterative' for GBD 2021
+     - Parameter is not age specific and has no draw-level uncertainty. Use mean_value as location-specific point parameter.
+   * - incidence_c995
+     - Incidence rate of abortion and miscarriage cause
+     - como; decomp_step='iterative'
+     - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
+   * - incidence_c374
+     - Incidence rate of ectopic pregnancy
+     - como; decomp_step='iterative'
+     - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
 
 Disability adjusted life years
 """""""""""""""""""""""""""""""""""

--- a/docs/source/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.rst
@@ -112,6 +112,9 @@ Documents that contain information specific to the overall model and the child s
 |                     |:ref:`Background morbidity due to other    |Modeled causes: c366,|
 |                     |causes <other_causes>`                     |r192. Change from    |
 |                     |                                           |IV iron!             |
+|                     +-------------------------------------------+---------------------+
+|                     |Removal of background mortality due to     |Change from IV iron  |
+|                     |other causes                               |                     |
 +---------------------+-------------------------------------------+---------------------+
 |Interventions        |:ref:`Antenatal supplementation, including |Change from IV iron! |
 |                     |IFA, MMS, and BEP and their effects        |New effects on       |
@@ -286,6 +289,10 @@ Specific outputs for specific models are specified in the following section.
 
   Unless otherwise specified, all maternal outputs should be stratified by maternal age group
 
+.. todo::
+
+  Determine which model we will plan to remove mortality due to "other causes" and add to V&V plan
+
 .. list-table:: Model run requests
   :header-rows: 1
 
@@ -340,8 +347,8 @@ Specific outputs for specific models are specified in the following section.
     - None
     - * Deaths
       * YLLs
-      * Pregnancy state person-time, stratified by birth outcome
-      * Pregnancy transition counts, stratified by birth outcome
+      * Pregnancy state person-time, **stratified by birth outcome**
+      * Pregnancy transition counts, **stratified by birth outcome**
       * Counts of birth outcomes
     - Live and still births with maternal_ids and LBWSG exposures
     - 
@@ -375,9 +382,9 @@ Specific outputs for specific models are specified in the following section.
       * YLDs
       * Pregnancy state person-time
       * Pregnancy transition counts
-      * Anemia state person-time stratified by pregnancy state
-      * Incident maternal disorder counts stratified by anemia status at birth
-      * Incident maternal hemorrhage counts stratified by anemia status at birth
+      * Anemia state person-time **stratified by pregnancy state**
+      * Incident maternal disorder counts **stratified by anemia status at birth**
+      * Incident maternal hemorrhage counts **stratified by anemia status at birth**
     - N/A
     - Do NOT include risk effect of hemoglobin on birth outcomes (which was included in IV iron). Data block for GBD 2021 update as of 6/23.
   * - 5.0
@@ -480,7 +487,16 @@ Specific outputs for specific models are specified in the following section.
     - Looks great! Note that pregnancy duration skews when evaluated at age-specific level, but this is not a bug in implementation, rather in analysis. `Model 1.0 V&V notebook can be found here <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/pregnancy_model/model_1.0.ipynb>`_
   * - 1.1
     - Confirm that relative distribution of partial versus full term pregnancies is as expected, that partial term pregnancy duration implemented as expected, and that child data looks good
-    - Looks great! `Model 1.1 V&V notebook can be found here <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/pregnancy_model/model_1.1.ipynb>`
+    - Looks great! `Model 1.1 V&V notebook can be found here <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/pregnancy_model/model_1.1.ipynb>`_
+  * - 1.2
+    - * Check that average duration of "other" birth outcomes is 15 weeks in maternal outputs
+      * Check that average duration of live and still birth outcomes is close to 38-39 weeks or so in maternal outputs
+      * Check live birth to stillbirth ratio verifies to expected value
+      * Check that LBWSG exposure in child outputs verifies to GBD exposure distribution
+    - 
+  * - 2.0
+    - Verify incident and fatal maternal disorder and maternal hemorrhage (incident only) rates
+    - 
 
 .. list-table:: Outstanding V&V issues
   :header-rows: 1

--- a/docs/source/models/other_models/pregnancy/gbd_2021_closed_cohort/index.rst
+++ b/docs/source/models/other_models/pregnancy/gbd_2021_closed_cohort/index.rst
@@ -324,15 +324,15 @@ A duration of pregnancy value will need to be assigned to all pregnancies regard
 
 For partial term pregnancies (that result in abortion/miscarriage/ectopic pregnancy), assign a duration of pregnancy sampled from a uniform distribution beween 6 and 24 weeks (individual heterogeneity with no parameter uncertainty).
 
+For full term pregnancies (that result in live births or stillbirths), duration of pregnancy should be determined by gestational age exposure, which should be assigned according to the process for assigning LBWSG exposures described in the :ref:`risk correlation document between maternal BMI, maternal hemoglobin, and infant LBWSG exposure <2019_risk_correlation_maternal_bmi_hgb_birthweight>`. The LBWSG exposure distribution used to assign gestational age exposures should be specific to the sex of the infant for a given pregnancy (discussed in the above section) and may also be modified by :ref:`antenatal supplementation intervention coverage <maternal_supplementation_intervention>`. Note that the gestational age distribution is measured in weeks and will need to be converted to the equivalent simulation time measure.
+
+.. note::
+
+  The impact of :ref:`antenatal supplementation intervention coverage <maternal_supplementation_intervention>` on pregnancy duration (distinguished from its effect on infant LBWSG exposure here) will have a minimal impact on total DALYs modeled in the nutrition optimization simulation (will only affect anemia YLDs by extending for the duration of the gestational age shift). Therefore, it would be an acceptable limitation to ignore the impact of this intervention coverage on pregnancy duration if it is convenient for implementation as long as the intervention continues to impact infant LBWSG exposures.
+
 .. todo::
 
-  Update link to correlation doc
-
-For full term pregnancies (that result in live births or stillbirths), duration of pregnancy should be determined by gestational age exposure, which should be assigned according to the process for assigning LBWSG exposures described in the :ref:`risk correlation document between maternal BMI, maternal hemoglobin, and infant LBWSG exposure <2019_risk_correlation_maternal_bmi_hgb_birthweight>`. The LBWSG exposure distribution used to assign gestational age exposures should be specific to the sex of the infant for a given pregnancy (discussed in the above section). Note that the gestational age distribution is measured in weeks and will need to be converted to the equivalent simulation time measure.
-
-.. todo::
-
-  Describe how to handle intervention effects on gestational age here (remember, will make little difference for mothers... maybe ignore and only model impact on infants?)
+  Update the above note to reflect what is actually implemented.
 
 Pregnancy outcomes
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
1. Added V&V plans to the next 2models in case I am out when model results come in 
2. Added note that it would be an acceptable limitation for interventions to affect LBWSG exposure only and not pregnancy duration, with a todo note to update docs to whatever ends up being implemented
3. Added removal of background mortality to cause model section, with a todo note to figure out which model version to implement the removal
4. Bolded output stratification requests to make them more visible
5. Clarified the preg_rate parameter in the maternal disorders cause model doc (doesn't change the implementation, just tried to make parameter definition less confusing)