### PR TITLE
Maternal disorders YLD equation fix

### DIFF
--- a/docs/source/models/causes/maternal_disorders/gbd_2019/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2019/index.rst
@@ -321,7 +321,7 @@ Simulants who experience an incident case of maternal disorders and occupy the p
     \text{YLDs per non-fatal maternal disorders case} = 
     
 
-    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
+    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - \text{csmr}_\text{c366}}
 
   This equation has been updated for the :ref:`2021 maternal disorders cause model document <2021_cause_maternal_disorders>` and will be implemented in the nutrition optimization simulation. The erroneous equation implemented in IV iron is kept below for reference. Note that the impact of this discepency will be quite small given the small magnitude of the ACMR parameter.
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2019/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2019/index.rst
@@ -312,6 +312,19 @@ Years lived with disability
 
 Simulants who experience an incident case of maternal disorders and occupy the post-maternal disorders state following the incident case and will remain there for a single timestep. The disability weight for the post-maternal disorders time-step long state will then be the number of YLDs per case (defined below) divided by :math:`\text{time step duration in days} / 365`, such that the disability weight multiplied by the duration spent accruing disability is equal to the total YLDs per case (defined below). Notably, for simulations that evaluate disability due to anemia through the :ref:`hemoglobin/anemia model <2019_hemoglobin_anemia_and_iron_deficiency>` such as the :ref:`IV iron simulation <2019_concept_model_vivarium_iv_iron>`, the disability due to anemia sequelae should not be counted as part of YLDs due to maternal disorders as they will be tracked separately as YLDs due to anemia (this is reflected in the equation below).
 
+.. note::
+
+  The equation shown below is inconsistent with the approach we implemented of accumulating all maternal disorders YLDs in a single timestep rather than over the course of 1 year. With maternal disorders YLDs accumulated in a single timestep, the equation should be: 
+
+  .. math::
+
+    \text{YLDs per non-fatal maternal disorders case} = 
+    
+
+    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
+
+  This equation has been updated for the :ref:`2021 maternal disorders cause model document <>` and will be implemented in the nutrition optimization simulation. The erroneous equation implemented in IV iron is kept below for reference. Note that the impact of this discepency will be quite small given the small magnitude of the ACMR parameter.
+
 .. math::
 
   \text{YLDs per non-fatal maternal disorders case} = 

--- a/docs/source/models/causes/maternal_disorders/gbd_2019/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2019/index.rst
@@ -323,7 +323,7 @@ Simulants who experience an incident case of maternal disorders and occupy the p
 
     \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
 
-  This equation has been updated for the :ref:`2021 maternal disorders cause model document <>` and will be implemented in the nutrition optimization simulation. The erroneous equation implemented in IV iron is kept below for reference. Note that the impact of this discepency will be quite small given the small magnitude of the ACMR parameter.
+  This equation has been updated for the :ref:`2021 maternal disorders cause model document <2021_cause_maternal_disorders>` and will be implemented in the nutrition optimization simulation. The erroneous equation implemented in IV iron is kept below for reference. Note that the impact of this discepency will be quite small given the small magnitude of the ACMR parameter.
 
 .. math::
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
@@ -341,7 +341,7 @@ Simulants who experience an incident case of maternal disorders and occupy the p
   \text{YLDs per non-fatal maternal disorders case} = 
   
 
-  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
+  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - \text{csmr}_\text{c366}}
 
 .. _YLDUpdateNote:
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021/index.rst
@@ -6,7 +6,7 @@ Maternal disorders: GBD 2021
 
 .. note::
 
-  This page is an update from the previously developed :ref:`GBD 2019 maternal disorders cause model document <2019_cause_maternal_disorders>`. There were no major updates from the 2019 to 2021 version.
+  This page is an update from the previously developed :ref:`GBD 2019 maternal disorders cause model document <2019_cause_maternal_disorders>`. The only update was a change to the YLD equation, as noted in the YLDUpdateNote_.
 
 .. contents::
    :local:
@@ -320,7 +320,6 @@ The following table defines the parameters used in the calculation of maternal d
      - como; decomp_step='iterative'
      - Use the :ref:`total population incidence rate <total population incidence rate>` directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
 
-     
 .. _AgeGroupNote:
 
 .. note::
@@ -342,23 +341,21 @@ Simulants who experience an incident case of maternal disorders and occupy the p
   \text{YLDs per non-fatal maternal disorders case} = 
   
 
-  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366}) * \text{incidence_rate}_\text{c366} - csmr_\text{c366}}
+  \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - csmr_\text{c366}}
 
-.. warning::
+.. _YLDUpdateNote:
 
-  A previous version of the above equation yielded a negative value in initial attempts. We've implementated the following placeholder (which may result in an underestimation of maternal disorder YLDs):
+.. note::
 
-  .. math::
-
-    \text{YLDs per non-fatal maternal disorders case} = \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366}}
-
-  The equation may eventually be updated to the resolved version in the main section above, although it is approximately 98-99% of the temporary fix, so it is a low priority for implementation.
-
-  For reference, the previous version of the equation that yielded a negative rate was as follows:
+  This equation was updated from the previous (erroneous) implementation in IV iron (shown below):
 
   .. math::
 
-    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366} + csmr_\text{c366} / \text{incidence_rate}_\text{c366})}
+    \text{YLDs per non-fatal maternal disorders case} = 
+    
+
+    \frac{\text{ylds}_{c366} - \text{ylds}_\text{s182,s183,s184}}{\text{incidence_rate}_{c366} - (ACMR - csmr_\text{c366}) * \text{incidence_rate}_\text{c366} - csmr_\text{c366}}
+
 
 .. todo::
 


### PR DESCRIPTION
Found a small error in our YLD equation for maternal disorders from the IV iron implementation. Updated the equation in the 2021 document (and noted the updated from the prior implementation) and called out that the implemented equation in the 2019 document is incorrect but kept it there for reference.