### PR TITLE
Update docs to show that employer_id remains unnoised

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -2583,7 +2583,7 @@ W2 and 1099 Forms
   * - Mailing Address ZIP Code
   * - Social Security Number
   * - Wages (income from this job)
-  * - Employer ID
+  * - Employer ID (for PRL tracking)
   * - Employer Name
   * - Employer Address
   * - Employer ZIP Code
@@ -3177,12 +3177,6 @@ for all column based noise include:
     - 0.1
     - Missing data, numeric miswriting, OCR, typographic
     - Note that wages and income are on separate tax forms and noise is applied to each separately
-  * - Employer ID
-    - Taxes (both)
-    - 0.01
-    - 0.1
-    - Missing data, numeric miswriting, OCR, typographic
-    -
   * - Employer Name
     - Taxes (both)
     - 0.01


### PR DESCRIPTION
JIRA ticket: https://jira.ihme.washington.edu/browse/SSCI-1425 
Please lmk if instead of 'for PRL tracking', I should be more clear and say 'employer_id is an un-noised truth-deck column' or something! Or if I misunderstood this ticket - thanks! 

Related SE PR: https://github.com/ihmeuw/pseudopeople/pull/159 