### PR TITLE
PRL: Add middle name and event ID to SSA columns

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -3107,7 +3107,13 @@ for all column based noise include:
     - Missing data, nicknames, fake names, phonetic, OCR, typographic
     -
   * - Middle Initial
-    - Census, Household Surveys, WIC, Taxes (both), SSA
+    - Census, Household Surveys, WIC, Taxes (both)
+    - 0.01
+    - 0.1
+    - Missing data, phonetic, OCR, typographic
+    -
+  * - Middle Name
+    - SSA
     - 0.01
     - 0.1
     - Missing data, phonetic, OCR, typographic

--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -2956,13 +2956,14 @@ added later (not in the minimum viable model), if desired.
 
   * - Unique simulant ID (for PRL tracking)
   * - First name
-  * - Middle initial
+  * - Middle name
   * - Last name
   * - DOB (stored as a string in YYYYMMDD format, as indicated by [CARRA_SSA]_ Table 1)
   * - Sex (binary; "Male" or "Female")
   * - Social Security Number
   * - Type of event
   * - Date of event (stored as a string in YYYYMMDD format, as indicated by [CARRA_SSA]_ Table 1)
+  * - Event ID (unique integer identifier for each row in the SSA dataset, representing a ground-truth identifier for the event recorded in that row; unaffected by noise functions; to be used for comparing noised and unnoised data)
 
 .. note::
   Unlike the other observers, there is no ground-truth unique household ID for PRL tracking in this observer.

--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -3116,8 +3116,8 @@ for all column based noise include:
     - SSA
     - 0.01
     - 0.1
-    - Missing data, phonetic, OCR, typographic
-    -
+    - Missing data, nicknames, fake names, phonetic, OCR, typographic
+    - Use the list of fake first names for middle names as well
   * - Last Name
     - Census, Household Surveys, WIC, Taxes (both), SSA
     - 0.01


### PR DESCRIPTION
JIRA tickets: [SSCI-1464](https://jira.ihme.washington.edu/browse/SSCI-1464), [SSCI-1395](https://jira.ihme.washington.edu/browse/SSCI-1395)

Makes some changes to the Social Security observer:
- Change middle initial to middle name
- Add an event ID column for comparing noised to unnoised data
- Edit noise table to reflect the change from middle initial to middle name in SSA dataset

The change from middle initial to middle name is based on these [archival NUMIDENT files from NARA](https://aad.archives.gov/aad/series-description.jsp?s=5057).

I haven't yet added these changes to the pseudopeople docs since I don't know whether they'll be included in the yellow release.