### PR TITLE
PRL: Reorder dataset columns

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -2639,6 +2639,8 @@ W2 and 1099 Forms
 
   * - Unique simulant ID (for PRL tracking)
   * - Unique household ID consistent between observers (for PRL tracking)
+  * - Employer ID (for PRL tracking)
+  * - Social Security Number
   * - First name
   * - Middle initial
   * - Last name
@@ -2649,9 +2651,7 @@ W2 and 1099 Forms
   * - Mailing Address City
   * - Mailing Address State
   * - Mailing Address ZIP Code
-  * - Social Security Number
   * - Wages (income from this job)
-  * - Employer ID (for PRL tracking)
   * - Employer Name
   * - Employer Address
   * - Employer ZIP Code
@@ -2784,6 +2784,8 @@ in January 2024.
     -
   * - Last name
     -
+  * - Social Security Number (if present)
+    - ITIN if no SSN present
   * - Mailing Address Street Number (blank for PO boxes)
     -
   * - Mailing Address Street Name (blank for PO boxes)
@@ -2798,8 +2800,6 @@ in January 2024.
     -
   * - Mailing Address ZIP Code
     -
-  * - Social Security Number (if present)
-    - ITIN if no SSN present
   * - Tracked Dependent(s) (for noise functions ONLY)
     -
   * - Tracked Dependent Address(es) (for noise functions ONLY)
@@ -2831,7 +2831,7 @@ in January 2024.
   * - Social Security Number (if present)
     - ITIN if no SSN present
   * - Tax year
-    - 
+    -
 
 .. note::
 
@@ -2990,12 +2990,12 @@ added later (not in the minimum viable model), if desired.
   :header-rows: 0
 
   * - Unique simulant ID (for PRL tracking)
+  * - Social Security Number
   * - First name
   * - Middle name
   * - Last name
   * - DOB (stored as a string in YYYYMMDD format, as indicated by [CARRA_SSA]_ Table 1)
   * - Sex (binary; "Male" or "Female")
-  * - Social Security Number
   * - Type of event
   * - Date of event (stored as a string in YYYYMMDD format, as indicated by [CARRA_SSA]_ Table 1)
   * - Event ID (unique integer identifier for each row in the SSA dataset, representing a ground-truth identifier for the event recorded in that row; unaffected by noise functions; to be used for comparing noised and unnoised data)

--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -2989,6 +2989,7 @@ added later (not in the minimum viable model), if desired.
   :widths: 20
   :header-rows: 0
 
+  * - Event ID (unique integer identifier for each row in the SSA dataset, representing a ground-truth identifier for the unique event recorded in that row; unaffected by noise functions; to be used for comparing noised and unnoised data)
   * - Unique simulant ID (for PRL tracking)
   * - Social Security Number
   * - First name
@@ -2998,7 +2999,6 @@ added later (not in the minimum viable model), if desired.
   * - Sex (binary; "Male" or "Female")
   * - Type of event
   * - Date of event (stored as a string in YYYYMMDD format, as indicated by [CARRA_SSA]_ Table 1)
-  * - Event ID (unique integer identifier for each row in the SSA dataset, representing a ground-truth identifier for the event recorded in that row; unaffected by noise functions; to be used for comparing noised and unnoised data)
 
 .. note::
   Unlike the other observers, there is no ground-truth unique household ID for PRL tracking in this observer.

--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -2641,6 +2641,10 @@ W2 and 1099 Forms
   * - Unique household ID consistent between observers (for PRL tracking)
   * - Employer ID (for PRL tracking)
   * - Social Security Number
+  * - Wages (income from this job)
+  * - Employer Name
+  * - Employer Address
+  * - Employer ZIP Code
   * - First name
   * - Middle initial
   * - Last name
@@ -2651,10 +2655,6 @@ W2 and 1099 Forms
   * - Mailing Address City
   * - Mailing Address State
   * - Mailing Address ZIP Code
-  * - Wages (income from this job)
-  * - Employer Name
-  * - Employer Address
-  * - Employer ZIP Code
   * - Type of Tax Form (W2 or 1099)
   * - Tax year
 


### PR DESCRIPTION
Re-orders some columns in the taxes W2 & 1099 dataset, taxes 1040 dataset, and social security dataset, in order to put ground-truth columns first and to more closely match the order of fields in the corresponding real versions:
- [W2](https://www.irs.gov/pub/irs-pdf/fw2.pdf), [1099-MISC](https://www.irs.gov/pub/irs-pdf/f1099msc.pdf), [1099-NEC](https://www.irs.gov/pub/irs-pdf/f1099nec.pdf)
- [1040](https://www.irs.gov/pub/irs-pdf/f1040.pdf)
- [SSA Numident](https://aad.archives.gov/aad/series-description.jsp?s=5057)

@albrja This can serve as the single source of truth for how we want to reorder the columns. Note that I moved the "Event ID" column in the SSA dataset, which doesn't exist yet (it's slated for orange release), so you can ignore that.

- Engineering JIRA ticket: [MIC-4428](https://jira.ihme.washington.edu/browse/MIC-4428)
- Documentation JIRA ticket: [SSCI-1511](https://jira.ihme.washington.edu/browse/SSCI-1511)