### PR TITLE
Use `build.os` for RTD

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,8 +4,12 @@ version: 2
 
 # Configure the python version and environment construction run before
 # docs are built.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
-  version: 3.8
   install:
     - requirements: requirements.txt
 


### PR DESCRIPTION
Deprecation: https://blog.readthedocs.com/use-build-os-config/

Docs: https://docs.readthedocs.io/en/stable/config-file/v2.html