### PR TITLE
Add table of contents and audience intro to BLISS page

### DIFF
--- a/docs/source/model_design/general_reference_material/bliss/index.rst
+++ b/docs/source/model_design/general_reference_material/bliss/index.rst
@@ -37,6 +37,12 @@ Building Language Inclusivity into Simulation Science (BLISS) is an important pa
 our team's work! Here you will find our ongoing style guide for incorporating inclusive 
 language into our day-to-day work.
 
+For those on the simulation science team or not - if you are setting out to do some research 
+that somehow touches on sex and gender and  you aren’t sure how to proceed with methods and 
+results, this should be exactly what you need!
+
+.. contents::
+  :local:
 
 1.0 Overview 
 ++++++++++++


### PR DESCRIPTION
This PR address the following two tickets:
- Introduce target audience of document: https://jira.ihme.washington.edu/browse/SSCI-1594
- And add a table of contents https://jira.ihme.washington.edu/browse/SSCI-1593

There were a couple of points in the description of the second ticket that I am not sure I have met, but figured I would add in the general default table of contents to start! Specifically, there was a link to this resource that I am not necessarily sure how to incorporate and maybe others have ideas to follow-up with (https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Retaining_existing_styles). Further, RST automatically links back to the TOC if you click on an individual header in the body of the document, so I don't think we need to make separate links!

Thanks and let me know if anyone has thoughts/concerns!