### PR TITLE
Update to model 11.1 V&V summary

### DIFF
--- a/docs/source/models/concept_models/vivarium_nutrition_optimization/kids/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_nutrition_optimization/kids/concept_model.rst
@@ -1281,7 +1281,7 @@ Wave II
   * - 11.1
     - Check on issues from run 11.1
     - * `Total MAM exposure now looks good at initialization (bug resolved) <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/child_model/model_11.1_risk_exposure.ipynb>`_. Note that MAM and SAM is underestimated in 6-59 month ages, but this issue is present in model 10 and therefore not a model 11 bug.
-      * `MAM treatment targets do not appear to be functioning correctly (bug remains -- no change from model 11.0) <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/child_model/model_11.1_MAM_targets.ipynb>`_
+      * `Targete MAM treatment targeted to better rather than worse MAM state <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/child_model/model_11.1_MAM_targets.ipynb>`_
       * `Inaccurate MAM/SAM recovery rates among 6-59 month age group (new bugs) <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/verification_and_validation/child_model/model_11.1_wasting_transitions.ipynb>`_, including:
 
         * Underestimated treated SAM->mild transition rate
@@ -1308,19 +1308,15 @@ Wave II
     - Bug in generation of wasting transition rate version #4 that erroneously set c_mam and c_sam parameters to zero
     - `Update wasting transition rates to version 5 (in accordance with this PR) <https://github.com/ihmeuw/vivarium_research/pull/1403>`_
     - Model 11.2
-  * - 2: Targeted MAM intervention not targeted to those 6-24 months (should be 100% coverage for this group)
-    - Unknown -- we thought a fix for this bug was included in model 11.1, but no change from 11.0
-    - Engineers to investigate
+  * - 2: Targeted MAM intervention not targeted to better MAM state instead of worse MAM state
+    - Bug
+    - Hussain implemented fix but it has not yet been run
     - Model 11.2
-  * - 3: Targeted MAM intervention not targeted to worse MAM state
-    - Unknown -- we thought a fix for this bug was included in model 11.1, but no change from 11.0
-    - Engineers to investigate
-    - Model 11.2
-  * - 4: Issue with MAM and SAM recovery rates among 6-59 month age group
+  * - 3: Issue with MAM and SAM recovery rates among 6-59 month age group
     - Unknown, but suspected to be an issue with how wasting treatment component is interacting with the better/worse MAM substates, as issue is only present in the age groups that receive treatment (not the 1-5 month age group) and only among the transitions that are affected by treatment. NOTE: this issue was NOT present in model 12.0 -- checking versioning between these models could be helpful in diagnosing issue.
     - Ali to pair with engineers to review how treatment component is interacting with better/worse MAM substates
     - Model 11.2
-  * - 5: Underestimation of diarrheal diseases and LRI excess mortality rates in 1-5 and 6-11 month age groups
+  * - 4: Underestimation of diarrheal diseases and LRI excess mortality rates in 1-5 and 6-11 month age groups
     - Suspected to be a timestep issue. Application of CGF EMR RRs can cause very high EMR rates for high-risk individuals in these age groups and our timesteps may not be short enough to accurately capture them. (Note that they are no faster than the diarrheal diseases and LRI remission rates, but we have adjusted the remission rates to account for the relatively long timestep in a way that we have not done for these EMRs. Also note that this same pattern is not present for ages/causes with lower EMRs, indicating it is likely not an issue with implementation of CGF risk effects on EMR)
     - Test validation in variable timestep test runs when ready. No code changes for now.
     - N/A


### PR DESCRIPTION
My initial V&V check on this was not scenario-specific which led to the wrong conclusion -- updated now : )