### PR TITLE
Update targeted BEP/IFA scenario cov

### DIFF
--- a/docs/source/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_nutrition_optimization/pregnancies/concept_model.rst
@@ -292,8 +292,8 @@ Documents that contain information specific to the overall model and the child s
     - 1
     - 0
     - 0
-  * - 3: Targeted BEP/none
-    - Baseline for adequate BMI pregnancies
+  * - 3: Targeted BEP/IFA
+    - 1 for adequate BMI pregnancies
     - 0
     - 1 for low BMI pregnancies
   * - 4: Targeted BEP/MMS


### PR DESCRIPTION
@hussain-jafari I think we had a miscommunication in what scenarios we wanted for the pregnancy production runs. I am only seeing scenarios baseline, 0, 1, 2 in the results you sent. We want to keep the targeted BEP scenarios #3 and #4 for wave II, though (we just removed what used to be the "universal" BEP scenario). However, it worked out because I would like to make a change to scenario #3 before we run anyway. Let me know if you have any questions.