### PR TITLE
Add reasoning behind default parameter update to concept model (for guardian-based duplication)

### DIFF
--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -3840,6 +3840,13 @@ at a guardian's household with default probability 0.05.
 There should be two user parameters for overriding these probabilities, one
 for each simulant category.
 
+This percentage was estimated from Figure 1 of `"An Analysis of Person Duplication 
+in Census 2000" <http://www.asasrms.org/Proceedings/y2004/files/Jsm2004-000730.pdf>`_ 
+and roughly corroborated by Table 4 of `"Real-Time 2020 Administrative Record 
+Census Simulation" <https://www2.census.gov/programs-surveys/decennial/2020/program-management/evaluate-docs/EAE-2020-admin-records-experiment.pdf>`_ 
+combined with the totals from Table 1.
+
+
 If the user selects a duplication rate that is higher than the calculated
 maximum rate in the sim, a warning should be issued explaining that the selected
 rate is greater than the maximum available, and the actual rate of duplication

--- a/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_census_synthdata/concept_model.rst
@@ -3840,7 +3840,7 @@ at a guardian's household with default probability 0.05.
 There should be two user parameters for overriding these probabilities, one
 for each simulant category.
 
-This percentage was estimated from Figure 1 of `"An Analysis of Person Duplication 
+The 2% duplication rate for simulants under 18 was estimated from Figure 1 of `"An Analysis of Person Duplication 
 in Census 2000" <http://www.asasrms.org/Proceedings/y2004/files/Jsm2004-000730.pdf>`_ 
 and roughly corroborated by Table 4 of `"Real-Time 2020 Administrative Record 
 Census Simulation" <https://www2.census.gov/programs-surveys/decennial/2020/program-management/evaluate-docs/EAE-2020-admin-records-experiment.pdf>`_ 


### PR DESCRIPTION
I missed Zeb's comment suggesting we add this justification of the 2% to the concept model before I merged my last PR - my apologies! 