### PR TITLE
Adding folder for engineering type tasks and to-do pages

### DIFF
--- a/docs/source/model_design/index.rst
+++ b/docs/source/model_design/index.rst
@@ -13,4 +13,5 @@ This section of Vivarium Research Documentation contains information related to 
    vivarium_model_components/index
    designing_vivarium_model/index
    vivarium_features/index
+   programming_vivarium/index
    general_reference_material/index

--- a/docs/source/model_design/programming_vivarium/archiving_models/index.rst
+++ b/docs/source/model_design/programming_vivarium/archiving_models/index.rst
@@ -21,16 +21,17 @@
   https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
   And then add it to the list of decorators above.
 
-.. _vivarium_overview:
+.. _archiving_models_rt:
 
-================================================
-Overview of Vivarium Simulation Models
-================================================
+================
+Archiving Models
+================
 
-The purpose of this page is to document information relevant to the Vivarium framework from a research perspective. 
+.. contents::
+   :local:
+   :depth: 1
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
+.. todo::
 
-   */index
+  Add to this page. Include how-to type information on archiving models, targeted to a research team audience. Include links to the engineering documentation as well and the `Hub page maintained by engineering <https://hub.ihme.washington.edu/pages/viewpage.action?spaceKey=SSE&title=Archiving+a+Simulation+Model+Repository>`_. 
+

--- a/docs/source/model_design/programming_vivarium/artifact_building/index.rst
+++ b/docs/source/model_design/programming_vivarium/artifact_building/index.rst
@@ -21,16 +21,20 @@
   https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
   And then add it to the list of decorators above.
 
-.. _vivarium_overview:
+.. _artifact_building_rt:
 
-================================================
-Overview of Vivarium Simulation Models
-================================================
+=================
+Artifact Building
+=================
 
-The purpose of this page is to document information relevant to the Vivarium framework from a research perspective. 
+.. contents::
+   :local:
+   :depth: 1
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
+.. todo::
 
-   */index
+  Add to this page. Include how-to type information on building the artifact, targeted to a research team audience. Include links to the engineering documentation as well. 
+
+  Review and integrate this `engineering page <https://vivarium.readthedocs.io/en/latest/tutorials/artifact.html>`_. 
+
+

--- a/docs/source/model_design/programming_vivarium/index.rst
+++ b/docs/source/model_design/programming_vivarium/index.rst
@@ -36,8 +36,8 @@ The purpose of this page is to document information relevant to the Vivarium and
    */index
 
 
-General Engineering Documenation for Relevant Packages
-------------------------------------------------------
+General Engineering Documentation for Relevant Packages
+-------------------------------------------------------
 
 Vivarium
 ++++++++

--- a/docs/source/model_design/programming_vivarium/index.rst
+++ b/docs/source/model_design/programming_vivarium/index.rst
@@ -1,35 +1,46 @@
-.. _software:
+..
+  Section title decorators for this document:
+  
+  ==============
+  Document Title
+  ==============
+  Section Level 1
+  ---------------
+  Section Level 2
+  +++++++++++++++
+  Section Level 3
+  ~~~~~~~~~~~~~~~
+  Section Level 4
+  ^^^^^^^^^^^^^^^
+  Section Level 5
+  '''''''''''''''
 
-===============================
-The Vivarium Software Framework
-===============================
+  The depth of each section level is determined by the order in which each
+  decorator is encountered below. If you need an even deeper section level, just
+  choose a new decorator symbol from the list here:
+  https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
+  And then add it to the list of decorators above.
 
-The Vivarium microsimulation framework is separated into numerous
-source-controlled repositories to keep things focused and organized. A list of
-repositories relevant to researchers can be found below, including short
-descriptions and links to the repositories and their documentation. Each
-repository holds installation information in its README.
+.. _programming_vivarium:
 
-Each Vivarium repository contains documentation in the form of API references,
-tutorials, and/or conceptual information. These tutorials are especially useful
-and explain many common tasks but because they are scattered across many
-repositories they can be hard to find. Below is a list of some of the most
-important pieces of documentation to know about.
+==============================================
+Vivarium engineering for research team members
+==============================================
+
+The purpose of this page is to document information relevant to the Vivarium and Vivarium Public Health frameworks from a research perspective. This primarly includes "how-to" pages for different engineering type tasks. A good rule for an engineering type task included here is one that edits or is run from the engineering repository rather than from the research repository.
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   */index
 
 
-- `The model specification <https://vivarium.readthedocs.io/en/latest/concepts/model_specification/index.html>`_
-- `Running a simulation <https://vivarium.readthedocs.io/en/latest/tutorials/running_a_simulation/index.html>`_
-- `Exploring a simulation in an interactive setting <https://vivarium.readthedocs.io/en/latest/tutorials/exploration.html>`_
-- `Creating and altering a data artifact <https://vivarium.readthedocs.io/en/latest/tutorials/artifact.html>`_
-- `Pulling data using Vivarium Inputs <https://vivarium-inputs.readthedocs.io/en/latest/tutorials/pulling_data.html>`_
-- `YAML basics <https://vivarium.readthedocs.io/en/latest/concepts/model_specification/yaml_basics.html#model-specification-yaml-concept>`_
-- `The branches file <https://vivarium-cluster-tools.readthedocs.io/en/latest/branch.html>`_
-
-.. contents:
-   :local:
+General Engineering Documenation for Relevant Packages
+------------------------------------------------------
 
 Vivarium
---------
+++++++++
 
 Vivarium is the core microsimulation framework and command line tools for
 running individual simulations. It contains documentation about how Vivarium
@@ -41,7 +52,7 @@ things.
 - `Documentation <https://vivarium.readthedocs.io/en/latest/>`__
 
 Vivarium Public Health
-----------------------
+++++++++++++++++++++++
 
 Vivarium Public Health is a set of tools for Vivarium simulations that enable
 public health applications like disease and intervention modeling. This is where
@@ -54,7 +65,7 @@ data artifacts.
 
 
 Vivarium Inputs
----------------
++++++++++++++++
 
 Vivarium Inputs contains the tools needed to create data artifacts from GBD
 data. The data artifact is an important notion, you can think of it as all of
@@ -68,7 +79,7 @@ helpful tutorial here for pulling data using these functions, too.
 
 
 Vivarium Cluster Tools
-----------------------
+++++++++++++++++++++++
 
 Vivarium Cluster Tools contains command line tools for running Vivarium
 simulations in parallel using IHME's cluster. It contains documentation
@@ -79,7 +90,7 @@ describing how this is done, as well as how YAML files and branches files work.
 
 
 GBD Mapping
------------
++++++++++++
 
 GBD Mapping is a python package that contains all the things modeled by the GBD
 and their relationships. This means things like causes, risk factors, and

--- a/docs/source/model_design/programming_vivarium/overview_engineering_files/index.rst
+++ b/docs/source/model_design/programming_vivarium/overview_engineering_files/index.rst
@@ -33,7 +33,7 @@ Overview of Engineering Files
 
 .. todo::
 
-  Add to this page. Include explanations for the relevant engineering files (model specs, branches file, loader.py, etc.) the includes when the functions are called, when you might need to look at them, what information is stored where, and any other relavent information for RT based tasks. 
+  Add to this page. Include explanations for the relevant engineering files (model specs, branches file, loader.py, etc.) that includes when the functions are called, when you might need to look at them, what information is stored where, and any other relevant information for RT based tasks. 
 
   Integrate links to: `YAML basics <https://vivarium.readthedocs.io/en/latest/concepts/model_specification/yaml_basics.html#model-specification-yaml-concept>`_, `model specs file <https://vivarium.readthedocs.io/en/latest/concepts/model_specification/index.html>`_, and the `branches file <https://vivarium-cluster-tools.readthedocs.io/en/latest/branch.html>`_. 
 

--- a/docs/source/model_design/programming_vivarium/overview_engineering_files/index.rst
+++ b/docs/source/model_design/programming_vivarium/overview_engineering_files/index.rst
@@ -1,0 +1,40 @@
+..
+  Section title decorators for this document:
+  
+  ==============
+  Document Title
+  ==============
+  Section Level 1
+  ---------------
+  Section Level 2
+  +++++++++++++++
+  Section Level 3
+  ~~~~~~~~~~~~~~~
+  Section Level 4
+  ^^^^^^^^^^^^^^^
+  Section Level 5
+  '''''''''''''''
+
+  The depth of each section level is determined by the order in which each
+  decorator is encountered below. If you need an even deeper section level, just
+  choose a new decorator symbol from the list here:
+  https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
+  And then add it to the list of decorators above.
+
+.. _engineering_files_rt:
+
+=============================
+Overview of Engineering Files
+=============================
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. todo::
+
+  Add to this page. Include explanations for the relevant engineering files (model specs, branches file, loader.py, etc.) the includes when the functions are called, when you might need to look at them, what information is stored where, and any other relavent information for RT based tasks. 
+
+  Integrate links to: `YAML basics <https://vivarium.readthedocs.io/en/latest/concepts/model_specification/yaml_basics.html#model-specification-yaml-concept>`_, `model specs file <https://vivarium.readthedocs.io/en/latest/concepts/model_specification/index.html>`_, and the `branches file <https://vivarium-cluster-tools.readthedocs.io/en/latest/branch.html>`_. 
+
+

--- a/docs/source/model_design/programming_vivarium/running_simulations/index.rst
+++ b/docs/source/model_design/programming_vivarium/running_simulations/index.rst
@@ -21,16 +21,19 @@
   https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#sections
   And then add it to the list of decorators above.
 
-.. _vivarium_overview:
+.. _running_simulations_rt:
 
-================================================
-Overview of Vivarium Simulation Models
-================================================
+===================
+Running Simulations
+===================
 
-The purpose of this page is to document information relevant to the Vivarium framework from a research perspective. 
+.. contents::
+   :local:
+   :depth: 1
 
-.. toctree::
-   :maxdepth: 1
-   :glob:
+.. todo::
 
-   */index
+  Add to this page. Include how-to type information on running the simulation, targeted to a research team audience. Include links to the engineering documentation as well. 
+
+  Review and integrate this `engineering page <https://vivarium.readthedocs.io/en/latest/tutorials/running_a_simulation/index.html>`_. 
+


### PR DESCRIPTION
Hey, couple of notes about this PR: 
1. Adding a new folder and pages for engineering tasks. I think we might well add new pages to this as time goes on, but this is a starting point. 
2. I don't love the name "Vivarium engineering for research team members" if anyone has a better suggestion! 
3. I am also deleting this page: https://vivarium-research.readthedocs.io/en/latest/model_design/vivarium_overview/vivarium_software/index.html (GitHub logged this as renamed and modified rather than deleting and creating a new page). I have added links on the relevant pages in the to-do to integrate, and pasted some of the general paths onto the new, main page. Two pages are getting deleted: Simulations in an interactive setting (I felt like we have a good page for this already) and pulling data using Vivarium Inputs (again, felt we had this covered). 