### PR TITLE
Links to age aggregated BMI/hgb data

### DIFF
--- a/docs/source/models/concept_models/vivarium_nutrition_optimization/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_nutrition_optimization/concept_model.rst
@@ -473,23 +473,23 @@ As of 10/16/2023:
 
 - `Prevalence of hemoglobin below 100 g/L among the pregnant population <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/parameter_aggregation/pregnant_proportion_with_hgb_below_100_age_specific.csv>`_
 
-  - Overall (not age specific) values available here for use in the child simulation (to be calculated by research team, unblocked)
+  - `Overall (not age specific) values available here for use in the child simulation <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/parameter_aggregation/pregnant_proportion_with_hgb_below_100_age_aggregated.csv>`_
 
 - `Prevalence of hemoglobin below 70 g/L among the pregnant population <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/parameter_aggregation/pregnant_proportion_with_hgb_below_100_age_specific.csv>`_
-
-  - Overall (not age specific) values available here for use in the child simulation (to be calculated by research team, unblocked)
 
 - Joint BMI/hemoglobin exposure, as calculated by the research team 
 
   - `Prevalence of low BMI given hemoglobin above 10 g/dL <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/misc_investigations/prevalence_of_low_bmi_given_hemoglobin_above_10.csv>`_
 
-    - Overall (not age specific) values available here for use in the child simulation (to be calculated by research team, unblocked)
+  - `Overall (not age specific) values available here for use in the child simulation <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/misc_investigations/prevalence_of_low_bmi_given_hemoglobin_above_10_age_weighted.csv>`_
 
   - `Prevalence of low BMI given hemoglobin below 10 g/dL <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/misc_investigations/prevalence_of_low_bmi_given_hemoglobin_above_10.csv>`_
 
-    - Overall (not age specific) values available here for use in the child simulation (to be calculated by research team, unblocked)
+    - `Overall (not age specific) values available here for use in the child simulation <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/misc_investigations/prevalence_of_low_bmi_given_hemoglobin_below_10_age_weighted.csv>`_
 
 - Child growth failure accessory data (wasting transitions and correlated underweight exposure distributions) calculated by the research team (blocked by 2021 cause data artifact keys)
+
+- Location-specific SQ-LNS effect sizes (blocked by 2021 child growth failure accessory data)
 
 .. _nutritionoptimization5.0:
 


### PR DESCRIPTION
Linked to age aggregated data and also:
- Removed age aggregated line for hemoglobin < 70 because that parameter is actually not used in the child sim
- Added a line to eventually link the 2021 location-specific SQ-LNS effects