### PR TITLE
Update intrapartum concept model (part 2)

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -231,7 +231,7 @@ V&V Checks:
     -    
   * - 3
     - % of each facility type have cesarian section capabilities
-    - Public/governmental hospital (62%), private and/or NGO health facility (73%), at home  (0%), country-specific governmental health facility (50%) 
+    - Public/governmental health facility (62%), private for-profit health facility (60%), at home (0%), private not-for-profit health facility (86%), other (10%)
     - EmONC (Ethiopia; filepath saved `on SharePoint <https://uwnetid.sharepoint.com/:w:/r/sites/ihme_simulation_science_team/_layouts/15/Doc.aspx?sourcedoc=%7B63F98143-C6C3-4CF7-BF62-969344726A87%7D&file=ethiopia_data_received_notes.docx&action=default&mobileredirect=true>`_.) 
     - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
   * - 4a

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -221,7 +221,7 @@ V&V Checks:
     - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence.
   * - 1
     - % of simulants to attend each delivery facility type, based on their propensity
-    - At home (68.3%), in public/governmental health facility (26.6%), in private/NGO health facility (3.3%), and other (4.8%) 
+    - At home (68.3%), in public/governmental health facility (26.6%), in private and/or NGO health facility (3.3%), and other (4.8%) 
     - DHS for each location; placeholder values are from `this Ethiopia paper <https://link.springer.com/article/10.1186/s12884-020-03002-x#Tab2>`_.
     - Denominator in DHS is all births (live and stillbirths) to interviewed women in the 2 years preceding the survey. The above values are placeholders until we do a more in-depth analysis. We would like this to be location specific, please code accordingly. 
   * - 2
@@ -230,10 +230,10 @@ V&V Checks:
     - 
     -    
   * - 3
-    - XX% of each facility type have cesarian section capabilities
-    - 
-    - 
-    -  
+    - % of each facility type have cesarian section capabilities
+    - Public/governmental health facility (62%), private and/or NGO health facility (73%), at home  (0%), other (50%) 
+    - EmONC (Ethiopia; saved at J:\Project\simulation_science\optimization_model_data\EmONC 2016_Master Dataset_Final\ETH_EmONC Assessment 2016_Final Report Jan11 2018.pdf) 
+    - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
   * - 4
     - XX relative risk on incidence of hemorrhage and obstructed labor 
     - 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -221,7 +221,7 @@ V&V Checks:
     - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
   * - 1
     - % of simulants to attend each delivery facility type, based on their propensity
-    - At home (68.3%), in public/governmental health facility (26.6%), in private for-profit health facility (2.5%), in private not-for-profit health facility (0.8%), and other (1.8) 
+    - At home (68.3%), in public/governmental health facility (26.6%), in private for-profit health facility (2.5%), in private not-for-profit health facility (0.8%), and other (1.8%) 
     - DHS for each location; placeholder values are from `this Ethiopia paper <https://link.springer.com/article/10.1186/s12884-020-03002-x#Tab2>`_.
     - Denominator in DHS is all births (live and stillbirths) to interviewed women in the 2 years preceding the survey. The above values are placeholders until we do a more in-depth analysis. We would like this to be location specific, please code accordingly. 
   * - 2
@@ -231,7 +231,7 @@ V&V Checks:
     -    
   * - 3
     - % of each facility type have cesarian section capabilities
-    - Public/governmental health facility (62%), private for-profit health facility (60%), at home  (0%), private not-for-profit health facility (86%) 
+    - Public/governmental health facility (62%), private for-profit health facility (60%), at home  (0%), private not-for-profit health facility (86%), other (10%)  
     - EmONC (Ethiopia; saved at J:\Project\simulation_science\optimization_model_data\EmONC 2016_Master Dataset_Final\ETH_EmONC Assessment 2016_Final Report Jan11 2018.pdf) 
     - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
   * - 4
@@ -241,7 +241,7 @@ V&V Checks:
     - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type 
   * - 5
     - % of pregnancy receive azithromycin in each delivery facility type
-    - At home (10%), in public/governmental health facility (41%), in private for-profit health facility (10%), and private not-for-profit health facility (10%) 
+    - At home (10%), in public/governmental health facility (41%), in private for-profit health facility (10%), private not-for-profit health facility (10%), other (10%)  
     - SARA (Ethiopia; Table 3.8.2)
     - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly.  
   * - 6
@@ -251,7 +251,7 @@ V&V Checks:
     - Outstanding items: how will we implement this with overlaps in total MD impact of facility type 
   * - 7
     - % of pre-term or known LBW pregnancies will receive antenatal corticosteroids, split by delivery facility type
-    - At home (10%), in public/governmental health facility (2%), in private for-profit health facility (22%), and private not-for-profit health facility (4%) 
+    - At home (10%), in public/governmental health facility (2%), in private for-profit health facility (22%), and private not-for-profit health facility (4%), other (10%)  
     - EmONC (Ethiopia; Table 10.5.4A)
     - Outstanding items: is this for preterm, LBW, or both/combination; believe this only affected neonatal outcomes, confirm with BMGF
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -235,7 +235,7 @@ V&V Checks:
     - EmONC (Ethiopia; saved at J:\Project\simulation_science\optimization_model_data\EmONC 2016_Master Dataset_Final\ETH_EmONC Assessment 2016_Final Report Jan11 2018.pdf) 
     - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
   * - 4
-    - XX relative risk on incidence of hemorrhage and obstructed labor 
+    - XX relative risk of c-section on incidence of hemorrhage and obstructed labor 
     - 
     - 
     - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type 
@@ -245,15 +245,15 @@ V&V Checks:
     - SARA (Ethiopia; Table 3.8.2)
     - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly. The 'at home' and 'other' values are made up. 
   * - 6
-    - XX relative risk of incidence of sepsis and other infections
-    - 
-    - 
-    - Outstanding items: what is the RR, how will we implement this with overlaps in total MD impact of facility type 
+    - Relative risk of azithromycin on incidence of sepsis and other infections
+    - 0.65 (0.55, 0.77)
+    - https://www.ajog.org/article/S0002-9378(22)02210-4/fulltext#undfig1 
+    - Outstanding items: how will we implement this with overlaps in total MD impact of facility type 
   * - 7
-    - XX% of pre-term or known LBW pregnancies will receive, split by delivery facility type
-    - 
-    - 
-    - Outstanding items: data by delivery facility, is this for preterm, LBW, or both/combination; believe this only affected neonatal outcomes, confirm with BMGF
+    - XX% of pre-term or known LBW pregnancies will receive antenatal corticosteroids, split by delivery facility type
+    - At home (10%), in public/governmental health facility (2%), in private and/or NGO health facility (13%), and other (10%) 
+    - EmONC (Ethiopia; Table 10.5.4A)
+    - Outstanding items: is this for preterm, LBW, or both/combination; believe this only affected neonatal outcomes, confirm with BMGF
 
 
 .. list-table:: Inputs to Intrapartum Decision Tree

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -221,7 +221,7 @@ V&V Checks:
     - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence.
   * - 1
     - % of simulants to attend each delivery facility type, based on their propensity
-    - At home (68.3%), in public/governmental health facility (26.6%), in private for-profit health facility (2.5%), in private not-for-profit health facility (0.8%), and other (1.8%) 
+    - At home (68.3%), in public/governmental hospital(26.6%), in private for-profit health facility (2.5%), in private not-for-profit health facility (0.8%), and country-specific governmental health facility (1.8%) 
     - DHS for each location; placeholder values are from `this Ethiopia paper <https://link.springer.com/article/10.1186/s12884-020-03002-x#Tab2>`_.
     - Denominator in DHS is all births (live and stillbirths) to interviewed women in the 2 years preceding the survey. The above values are placeholders until we do a more in-depth analysis. We would like this to be location specific, please code accordingly. 
   * - 2
@@ -231,13 +231,13 @@ V&V Checks:
     -    
   * - 3
     - % of each facility type have cesarian section capabilities
-    - Public/governmental health facility (62%), private and/or NGO health facility (73%), at home  (0%), other (50%) 
+    - Public/governmental hospital (62%), private and/or NGO health facility (73%), at home  (0%), country-specific governmental health facility (50%) 
     - EmONC (Ethiopia; filepath saved `on SharePoint <https://uwnetid.sharepoint.com/:w:/r/sites/ihme_simulation_science_team/_layouts/15/Doc.aspx?sourcedoc=%7B63F98143-C6C3-4CF7-BF62-969344726A87%7D&file=ethiopia_data_received_notes.docx&action=default&mobileredirect=true>`_.) 
     - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
   * - 4a
     - Relative risk of c-section on incidence of hemorrhage
     - 2.05 (1.84-2.29)
-    - https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7887994/
+    - `Pubu et al 2021 <https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7887994/>`_ 
     - This value is a stand-in from this population-based study in Tibet (see 'Source' column), in which the authors reported an odds ratio rather than a relative risk. With further research and analysis we will likely update this value. Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type
   * - 4b
     - Relative risk of c-section on incidence of obstructed labor 
@@ -246,17 +246,17 @@ V&V Checks:
     - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type  
   * - 5
     - % of pregnancy receive azithromycin in each delivery facility type
-    - At home (10%), in public/governmental health facility (41%), in private for-profit health facility (10%), private not-for-profit health facility (10%), other (10%)  
+    - At home (10%), in public/governmental hospital (41%), in private for-profit health facility (10%), private not-for-profit health facility (10%), country-specific governmental health facility (10%)  
     - SARA (Ethiopia; Table 3.8.2)
     - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly.  
   * - 6
     - Relative risk of azithromycin on incidence of sepsis and other infections
     - 0.65 (0.55, 0.77)
-    - https://www.ajog.org/article/S0002-9378(22)02210-4/fulltext#undfig1 
+    - `Tita et al 2023 <https://www.ajog.org/article/S0002-9378(22)02210-4/fulltext#undfig1>`_ 
     - Outstanding items: how will we implement this with overlaps in total MD impact of facility type 
   * - 7
     - % of pre-term or known LBW pregnancies will receive antenatal corticosteroids, split by delivery facility type
-    - At home (10%), in public/governmental health facility (2%), in private for-profit health facility (22%), and private not-for-profit health facility (4%), other (10%)  
+    - At home (10%), in public/governmental hospital (2%), in private for-profit health facility (22%), and private not-for-profit health facility (4%), country-specific governmental health facility (10%)  
     - EmONC (Ethiopia; Table 10.5.4A)
     - Outstanding items: is this for preterm, LBW, or both/combination; believe this only affected neonatal outcomes, confirm with BMGF
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -215,7 +215,7 @@ V&V Checks:
     - Source
     - Notes
   * - 0
-    - Incidence of ectopic pregnancies, abortion or miscarriage among pregnant women
+    - Incidence of ectopic pregnancies, abortion or miscarriage
     - get_draws(gbd_round_id=7, location_id=location_id, gbd_id_type='cause_id', gbd_id=[995,374], source='como', measure_id=6, metric_id=3, age_group_id=24, sex_id=2, year_id=2021, decomp_step='iterative')
     - incidence_c374 + incidence_c995
     - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence.

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -258,7 +258,7 @@ V&V Checks:
     - % of pre-term or known LBW pregnancies will receive antenatal corticosteroids, split by delivery facility type
     - At home (10%), in public/governmental hospital (2%), in private for-profit health facility (22%), and private not-for-profit health facility (4%), country-specific governmental health facility (10%)  
     - EmONC (Ethiopia; Table 10.5.4A)
-    - Outstanding items: is this for preterm, LBW, or both/combination; believe this only affected neonatal outcomes, confirm with BMGF
+    - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly. The denominator for these values is LBW and preterm births. Outstanding items: believe this only affected neonatal outcomes, confirm with BMGF
 
 
 .. list-table:: Inputs to Intrapartum Decision Tree

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -248,7 +248,7 @@ V&V Checks:
     - % of pregnancy receive azithromycin in each delivery facility type
     - At home (10%), in public/governmental hospital (41%), in private for-profit health facility (10%), private not-for-profit health facility (10%), country-specific governmental health facility (10%)  
     - SARA (Ethiopia; Table 3.8.2)
-    - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly.  
+    - These are placeholder values (percentage of each facility type that have azithromycin, not the percentage of pregnancies that receive it) and will be updated with further analysis. We want these to be location specific, please code accordingly.  
   * - 6
     - Relative risk of azithromycin on incidence of sepsis and other infections
     - 0.65 (0.55, 0.77)

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -234,11 +234,16 @@ V&V Checks:
     - Public/governmental health facility (62%), private for-profit health facility (60%), at home  (0%), private not-for-profit health facility (86%), other (10%)  
     - EmONC (Ethiopia; saved at J:\Project\simulation_science\optimization_model_data\EmONC 2016_Master Dataset_Final\ETH_EmONC Assessment 2016_Final Report Jan11 2018.pdf) 
     - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
-  * - 4
-    - XX relative risk of c-section on incidence of hemorrhage and obstructed labor 
+  * - 4a
+    - Relative risk of c-section on incidence of hemorrhage
+    - 2.05 (1.84-2.29)
+    - https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7887994/
+    - This value is a stand-in from this population-based study in Tibet (see 'Source' column), in which the authors reported an odds ratio rather than a relative risk. With further research and analysis we will likely update this value. Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type
+  * - 4b
+    - Relative risk of c-section on incidence of obstructed labor 
     - 
     - 
-    - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type 
+    - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type  
   * - 5
     - % of pregnancy receive azithromycin in each delivery facility type
     - At home (10%), in public/governmental health facility (41%), in private for-profit health facility (10%), private not-for-profit health facility (10%), other (10%)  

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -218,7 +218,7 @@ V&V Checks:
     - Incidence of ectopic pregnancies, abortion or miscarriage
     - get_draws(gbd_round_id=7, location_id=location_id, gbd_id_type='cause_id', gbd_id=[995,374], source='como', measure_id=6, metric_id=3, age_group_id=24, sex_id=2, year_id=2021, decomp_step='iterative')
     - incidence_c374 + incidence_c995
-    - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence.
+    - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
   * - 1
     - % of simulants to attend each delivery facility type, based on their propensity
     - At home (68.3%), in public/governmental health facility (26.6%), in private and/or NGO health facility (3.3%), and other (4.8%) 
@@ -240,10 +240,10 @@ V&V Checks:
     - 
     - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type 
   * - 5
-    - XX% of pregnancy receive in each delivery facility type
-    - 
-    - 
-    - Confirm understanding that all pregnancies can/should receive this
+    - % of pregnancy receive azithromycin in each delivery facility type
+    - At home (10%), in public/governmental health facility (41%), in private and/or NGO health facility (10%), and other (10%) 
+    - SARA (Ethiopia; Table 3.8.2)
+    - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly. The 'at home' and 'other' values are made up. 
   * - 6
     - XX relative risk of incidence of sepsis and other infections
     - 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -221,7 +221,7 @@ V&V Checks:
     - These simulants will NOT continue in the model. Use the `total population incidence <Total Population Incidence Rate>`_ rate directly from GBD and do not rescale this parameter to susceptible-population incidence rate using condition prevalence. 
   * - 1
     - % of simulants to attend each delivery facility type, based on their propensity
-    - At home (68.3%), in public/governmental health facility (26.6%), in private and/or NGO health facility (3.3%), and other (4.8%) 
+    - At home (68.3%), in public/governmental health facility (26.6%), in private for-profit health facility (2.5%), in private not-for-profit health facility (0.8%), and other (1.8) 
     - DHS for each location; placeholder values are from `this Ethiopia paper <https://link.springer.com/article/10.1186/s12884-020-03002-x#Tab2>`_.
     - Denominator in DHS is all births (live and stillbirths) to interviewed women in the 2 years preceding the survey. The above values are placeholders until we do a more in-depth analysis. We would like this to be location specific, please code accordingly. 
   * - 2
@@ -231,7 +231,7 @@ V&V Checks:
     -    
   * - 3
     - % of each facility type have cesarian section capabilities
-    - Public/governmental health facility (62%), private and/or NGO health facility (73%), at home  (0%), other (50%) 
+    - Public/governmental health facility (62%), private for-profit health facility (60%), at home  (0%), private not-for-profit health facility (86%) 
     - EmONC (Ethiopia; saved at J:\Project\simulation_science\optimization_model_data\EmONC 2016_Master Dataset_Final\ETH_EmONC Assessment 2016_Final Report Jan11 2018.pdf) 
     - We want these to be location specific, please code accordingly. These are placeholder values for now (extracted from the EmONC Final Report, link in 'Source' column; the 'other' value is made-up), hopefully we will be able to find similar data available for Pakistan and Nigeria.   
   * - 4
@@ -241,17 +241,17 @@ V&V Checks:
     - Outstanding items: how does c-section need overlap with hemorrhage/OL, what is the RR, how will we implement this with overlaps in total MD impact of facility type 
   * - 5
     - % of pregnancy receive azithromycin in each delivery facility type
-    - At home (10%), in public/governmental health facility (41%), in private and/or NGO health facility (10%), and other (10%) 
+    - At home (10%), in public/governmental health facility (41%), in private for-profit health facility (10%), and private not-for-profit health facility (10%) 
     - SARA (Ethiopia; Table 3.8.2)
-    - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly. The 'at home' and 'other' values are made up. 
+    - These are placeholder values and will be updated with further analysis. We want these to be location specific, please code accordingly.  
   * - 6
     - Relative risk of azithromycin on incidence of sepsis and other infections
     - 0.65 (0.55, 0.77)
     - https://www.ajog.org/article/S0002-9378(22)02210-4/fulltext#undfig1 
     - Outstanding items: how will we implement this with overlaps in total MD impact of facility type 
   * - 7
-    - XX% of pre-term or known LBW pregnancies will receive antenatal corticosteroids, split by delivery facility type
-    - At home (10%), in public/governmental health facility (2%), in private and/or NGO health facility (13%), and other (10%) 
+    - % of pre-term or known LBW pregnancies will receive antenatal corticosteroids, split by delivery facility type
+    - At home (10%), in public/governmental health facility (2%), in private for-profit health facility (22%), and private not-for-profit health facility (4%) 
     - EmONC (Ethiopia; Table 10.5.4A)
     - Outstanding items: is this for preterm, LBW, or both/combination; believe this only affected neonatal outcomes, confirm with BMGF
 


### PR DESCRIPTION
This PR fills in the rest of the intrapartum decision tree inputs with placeholder values. Data points include:
- % of each type of facility with azithromycin (for Ethiopia only; but we do not have data on % of pregnancies receiving azithromycin by facility type) 
- RR of azithromycin on sepsis (from a BMGF-funded RCT) 
- % of pregnancies receiving antenatal corticosteroids by facility type (for Ethiopia only) 
- RR of c-section delivery on PPH

I added a row for the RR of c-sections on obstructed labor, but I'm not sure using an RR here makes sense, if we expect c-sections to completely remove the possibility of OL? Or do we expect some c-sections to still lead to some degree of OL? Also, I'm wondering if we should be grouping OL and uterine rupture together as we currently are. In doing some brief research, it looks like previous c-section surgery is a pretty significant risk factor for uterine rupture.
