### PR TITLE
MNCNH V&V draw and seed count

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -489,27 +489,33 @@ Limitations:
     - Population size per draw
     - Note
   * - 1
-    - Wave I Pakistan maternal
+    - Wave I Pakistan maternal V&V
     - Incomplete
     - N/A
-    - 25
-    - 600,000
+    - 20
+    - 20,000
     - 
   * - 2
-    - Wave I Nigeria maternal
+    - Wave I Nigeria maternal V&V
     - Incomplete
     - N/A
-    - 25
-    - 600,000
+    - 20
+    - 20,000
     - 
   * - 3
-    - Wave I Ethiopia maternal
+    - Wave I Ethiopia maternal V&V
     - Incomplete
     - N/A
-    - 25
-    - 600,000
+    - 20
+    - 20,000
     - 
 
+.. note:: 
+  
+  These numbers are based on calculations from the `Nutrition Optimization project <https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/kids/concept_model.html#production-run-specifications>`_)
+  that found the appropriate seed and draw count for production runs. I'm not sure 
+  if these numbers are correct for V&V runs. This table also doesn't include seed count,
+  but based on the page I linked, NO runs used 10 random seeds. -Alix 
 
 .. _mncnh_portfolio_6.0:
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -489,33 +489,17 @@ Limitations:
     - Population size per draw
     - Note
   * - 1
-    - Wave I Pakistan maternal V&V
+    - Wave I Pregnancy V&V
     - Incomplete
     - N/A
-    - 20
-    - 20,000
-    - 
-  * - 2
-    - Wave I Nigeria maternal V&V
-    - Incomplete
-    - N/A
-    - 20
-    - 20,000
-    - 
-  * - 3
-    - Wave I Ethiopia maternal V&V
-    - Incomplete
-    - N/A
-    - 20
-    - 20,000
-    - 
+    - 10
+    - 100,000
+    - Locations include Pakistan, Nigeria, and Ethiopia. 10 seeds * 10,000 simulants = 100,000 total population.
 
 .. note:: 
   
   These numbers are based on calculations from the `Nutrition Optimization project <https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/kids/concept_model.html#production-run-specifications>`_)
-  that found the appropriate seed and draw count for production runs. I'm not sure 
-  if these numbers are correct for V&V runs. This table also doesn't include seed count,
-  but based on the page I linked, NO runs used 10 random seeds. -Alix 
+  that found the appropriate seed and draw count for production runs, then divided in half for V&V runs. 
 
 .. _mncnh_portfolio_6.0:
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -478,9 +478,37 @@ Limitations:
 5.0 Model run requests
 ++++++++++++++++++++++
 
-.. todo::
+.. list-table:: Model run plan as of October 4, 2024
+  :header-rows: 1
 
-  Fill in this section as we continue to work
+  * - Number
+    - Run
+    - Status
+    - Priority
+    - Number of draws
+    - Population size per draw
+    - Note
+  * - 1
+    - Wave I Pakistan maternal
+    - Incomplete
+    - N/A
+    - 25
+    - 600,000
+    - 
+  * - 2
+    - Wave I Nigeria maternal
+    - Incomplete
+    - N/A
+    - 25
+    - 600,000
+    - 
+  * - 3
+    - Wave I Ethiopia maternal
+    - Incomplete
+    - N/A
+    - 25
+    - 600,000
+    - 
 
 
 .. _mncnh_portfolio_6.0:


### PR DESCRIPTION
In this PR I'm adding information on model run plans based on what I could find in [Nutrition Optimization docs](https://vivarium-research.readthedocs.io/en/latest/models/concept_models/vivarium_nutrition_optimization/kids/concept_model.html#production-run-specifications), but I am not confident these are the right numbers for V&V runs. 

Syl, I've tagged you in this PR in case you have some insight as to what I should be doing for MNCNH V&V runs (vs. production runs?). And maybe this isn't the format for how we usually save draw and seed count for V&V in the docs? Maybe we can discuss more on Monday - thanks!