### PR TITLE
MNCNH: Add pregnancy outcomes to pregnancy page

### DIFF
--- a/docs/source/models/other_models/pregnancy/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/other_models/pregnancy/gbd_2021_mncnh/index.rst
@@ -226,15 +226,19 @@ Pregnancy modeling steps:
 +++++++++++++++++++++++++
 
 First is a summary of the steps for the pregnancy model. 
-Details for each step are provided below.
+Details for each step are provided in the subsections below.
 
 *At initialization:*
 
-#. Assign pregnancy state according to state prevalence values
+#. Assign pregnancy state according to state prevalence values above
 #. Assign partial or full term duration according to table in `Pregnancy term lengths`_ section
-#. Assign sex of infant if pregnancy is full term (stillbirth or live birth)
-#. Assign duration of pregnancy depending on term length and, if applicable, sex of the infant. Note that this is the same value as "gestational age" in other parts of the documentation.
-#. Assign birthweight of simulant child and low birthweight status
+#. Assign `sex of infant`_ if pregnancy is full term (stillbirth or live birth)
+#. Assign duration of pregnancy depending on term length and, if
+   applicable, sex of the infant. Note that this is the same value as
+   "gestational age" in other parts of the documentation (see
+   `Birthweight, Gestational Age, and LBW Status`_ section).
+#. Assign birthweight of simulant child and low birthweight status (see
+   `Birthweight, Gestational Age, and LBW Status`_ section)
 #. Assign propensity values for ANC and ultrasound 
 #. Begin simulation
 

--- a/docs/source/models/other_models/pregnancy/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/other_models/pregnancy/gbd_2021_mncnh/index.rst
@@ -250,7 +250,16 @@ Details for each step are provided below.
 
 *During simulation:*
 
-Run simulants through the pregnancy model as outlined in the :ref:`MNCNH Portfolio project <2024_concept_model_vivarium_mncnh_portfolio>` page. Record all data outlined on the above page. Then move to the intrapartum model. 
+#. Run simulants through the pregnancy model as outlined in the
+   :ref:`MNCNH Portfolio project
+   <2024_concept_model_vivarium_mncnh_portfolio>` page. Record all data
+   outlined on the above page for use in the intrapartum model.
+#. During the intrapartum phase of the model, assign a
+   pregnancy outcome (live birth, stillbirth, or partial term) according
+   to the probabilities in the `Pregnancy outcomes`_ section. Note that
+   some interventions and maternal causes occurring during the
+   intrapartum phase may affect these probabilities.
+
 
 Pregnancy term lengths
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -346,14 +355,14 @@ length is defined in the table below.
   * - Full term
     - Live birth
     - ASFR / (ASFR + ASFR * SBR)
-    - The probability of a livebirth outcome is modified by the
+    - The probability of a livebirth outcome will be modified by the
       :ref:`antenatal supplementation intervention
       <maternal_supplementation_intervention>` and by the obstructed
       labor cause and C-section intervention.
   * - Full term
     - Stillbirth
     - (ASFR * SBR) / (ASFR + ASFR * SBR)
-    - The probability of a stillbirth outcome is modified by the
+    - The probability of a stillbirth outcome will be modified by the
       :ref:`antenatal supplementation intervention
       <maternal_supplementation_intervention>` and by the obstructed
       labor cause and C-section intervention.

--- a/docs/source/models/other_models/pregnancy/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/other_models/pregnancy/gbd_2021_mncnh/index.rst
@@ -315,6 +315,53 @@ Based on the LBWSG category, the simulant will also be categorized as either low
 
   Additionally, the LBWSG exposure distribution may be modified by :ref:`antenatal supplementation intervention coverage <maternal_supplementation_intervention>` in later waves of the project. 
 
+Pregnancy outcomes
+~~~~~~~~~~~~~~~~~~
+
+During the intrapartum phase of the model, the pregnancy outcome must be
+determined for each pregnancy as either 1) live birth, 2) stillbirth, or
+3) partial term (ectopic pregnancy, abortion/miscarriage). The
+probability of each pregnancy outcome conditional on pregnancy term
+length is defined in the table below.
+
+.. list-table:: Pregnancy outcome probabilities conditional on pregnancy term length
+  :header-rows: 1
+
+  * - Pregnancy term length
+    - Outcome
+    - Conditional probability
+    - Note
+  * - Partial term
+    - Live birth
+    - 0
+    -
+  * - Partial term
+    - Stillbirth
+    - 0
+    -
+  * - Partial term
+    - Partial term (abortion, miscarriage, ectopic pregnancy)
+    - 1
+    -
+  * - Full term
+    - Live birth
+    - ASFR / (ASFR + ASFR * SBR)
+    - The probability of a livebirth outcome is modified by the
+      :ref:`antenatal supplementation intervention
+      <maternal_supplementation_intervention>` and by the obstructed
+      labor cause and C-section intervention.
+  * - Full term
+    - Stillbirth
+    - (ASFR * SBR) / (ASFR + ASFR * SBR)
+    - The probability of a stillbirth outcome is modified by the
+      :ref:`antenatal supplementation intervention
+      <maternal_supplementation_intervention>` and by the obstructed
+      labor cause and C-section intervention.
+  * - Full term
+    - Partial term (abortion, miscarriage, ectopic pregnancy)
+    - 0
+    -
+
 .. note::
 
   The current modeling strategy is dependent on our assumption that live births and stillbirths have the same duration. There is ongoing work at IHME to estimate gestational age at birth distributions among stillbirths. 


### PR DESCRIPTION
Specify how to decide pregnancy outcomes (live birth, stillbirth, or partial term) on the pregnancy page, for the intrapartum model.