### PR TITLE
MNCNH: Create page structure for maternal disorders

### DIFF
--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -24,7 +24,11 @@ Maternal disorders: GBD 2021, MNCNH
 Modeled Subcauses
 -----------------
 
-The following maternal disorders subcauses will be modeled individually:
+The following maternal disorders subcauses will be modeled individually,
+in the indicated model-building wave:
+
+Wave 1
+++++++
 
 .. toctree::
     :maxdepth: 1
@@ -32,6 +36,14 @@ The following maternal disorders subcauses will be modeled individually:
     maternal_hemorrhage
     maternal_sepsis
     obstructed_labor
+
+Wave 2
+++++++
+
+Wave 3
+++++++
+
+* Maternal hypertensive disorders
 
 The remainder of this document describes maternal disorders overall and
 describes the strategy for capturing the burden of the maternal

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -1,0 +1,83 @@
+.. _2021_cause_maternal_disorders_mncnh:
+
+===================================
+Maternal disorders: GBD 2021, MNCNH
+===================================
+
+.. note::
+
+    This page is adapted from the previously developed :ref:`GBD 2021
+    maternal disorders cause model <2021_cause_maternal_disorders>`,
+    which was updated from the :ref:`GBD 2019 maternal disorders cause
+    model <2019_cause_maternal_disorders>`. In contrast to previous
+    versions of the model, in the :ref:`MNCNH Portfolio project
+    <2024_concept_model_vivarium_mncnh_portfolio>`  we are modeling
+    several of the maternal disorders subcauses (see `Modeled
+    Subcauses`_) rather than modeling a single overarching cause. This
+    page documents the strategy for capturing the burden of the
+    remaining maternal disorders subcauses that are not explicitly
+    modeled.
+
+.. contents::
+   :local:
+
+Modeled Subcauses
+-----------------
+
+The following maternal disorders subcauses will be modeled individually:
+
+.. toctree::
+    :maxdepth: 1
+
+    maternal_hemorrhage
+    maternal_sepsis
+    obstructed_labor
+
+The remainder of this document describes maternal disorders overall and
+describes the strategy for capturing the burden of the maternal
+disorders subcauses that are not explicitly modeled above.
+
+Disease Overview
+----------------
+
+GBD 2021 Modeling Strategy
+--------------------------
+
+Cause Hierarchy
++++++++++++++++
+
+Subcause definitions
+""""""""""""""""""""""""""""
+
+Restrictions
+++++++++++++
+
+Vivarium Modeling Strategy
+--------------------------
+
+Scope
++++++
+
+Assumptions and Limitations
++++++++++++++++++++++++++++
+
+Cause Model Diagram
++++++++++++++++++++
+
+Data Tables
+++++++++++++++++++++++++++++++++
+
+Calculating Burden
+++++++++++++++++++
+
+Years of life lost
+"""""""""""""""""""
+
+Years lived with disability
+"""""""""""""""""""""""""""
+
+Validation Criteria
++++++++++++++++++++
+
+References
+----------

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_hemorrhage.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_hemorrhage.rst
@@ -1,0 +1,47 @@
+.. _2021_cause_maternal_hemorrhage_mncnh:
+
+===================
+Maternal hemorrhage
+===================
+
+Disease Overview
+----------------
+
+GBD 2021 Modeling Strategy
+--------------------------
+
+Cause Hierarchy
++++++++++++++++
+
+Restrictions
+++++++++++++
+
+Vivarium Modeling Strategy
+--------------------------
+
+Scope
++++++
+
+Assumptions and Limitations
++++++++++++++++++++++++++++
+
+Cause Model Diagram
++++++++++++++++++++
+
+Data Tables
++++++++++++
+
+Calculating Burden
+++++++++++++++++++
+
+Years of life lost
+"""""""""""""""""""
+
+Years lived with disability
+"""""""""""""""""""""""""""
+
+Validation Criteria
++++++++++++++++++++
+
+References
+----------

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_sepsis.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_sepsis.rst
@@ -3,3 +3,45 @@
 =============================================
 Maternal sepsis and other maternal infections
 =============================================
+
+Disease Overview
+----------------
+
+GBD 2021 Modeling Strategy
+--------------------------
+
+Cause Hierarchy
++++++++++++++++
+
+Restrictions
+++++++++++++
+
+Vivarium Modeling Strategy
+--------------------------
+
+Scope
++++++
+
+Assumptions and Limitations
++++++++++++++++++++++++++++
+
+Cause Model Diagram
++++++++++++++++++++
+
+Data Tables
++++++++++++
+
+Calculating Burden
+++++++++++++++++++
+
+Years of life lost
+"""""""""""""""""""
+
+Years lived with disability
+"""""""""""""""""""""""""""
+
+Validation Criteria
++++++++++++++++++++
+
+References
+----------

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_sepsis.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_sepsis.rst
@@ -1,0 +1,5 @@
+.. _2021_cause_maternal_sepsis_mncnh:
+
+=============================================
+Maternal sepsis and other maternal infections
+=============================================

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -3,3 +3,45 @@
 ====================================
 Obstructed labor and uterine rupture
 ====================================
+
+Disease Overview
+----------------
+
+GBD 2021 Modeling Strategy
+--------------------------
+
+Cause Hierarchy
++++++++++++++++
+
+Restrictions
+++++++++++++
+
+Vivarium Modeling Strategy
+--------------------------
+
+Scope
++++++
+
+Assumptions and Limitations
++++++++++++++++++++++++++++
+
+Cause Model Diagram
++++++++++++++++++++
+
+Data Tables
++++++++++++
+
+Calculating Burden
+++++++++++++++++++
+
+Years of life lost
+"""""""""""""""""""
+
+Years lived with disability
+"""""""""""""""""""""""""""
+
+Validation Criteria
++++++++++++++++++++
+
+References
+----------

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -1,0 +1,5 @@
+.. 2021_cause_obstructed_labor_mncnh:
+
+====================================
+Obstructed labor and uterine rupture
+====================================

--- a/docs/source/models/causes/maternal_disorders/index.rst
+++ b/docs/source/models/causes/maternal_disorders/index.rst
@@ -5,7 +5,8 @@ Maternal disorders
 ===============================
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
+   :titlesonly:
    :glob:
 
    */index*


### PR DESCRIPTION
Adds a page for the new maternal disorders model, and adds stub pages for three subcauses. Also edits the table of contents in the maternal disorders index to display the subpages under the new main page.