### PR TITLE
Add graphviz extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
+          apt install graphviz
       - name: Doc build
         run: |
           make html -C docs/ SPHINXOPTS="-W --keep-going -n"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          apt install graphviz
+          sudo apt-get install graphviz
       - name: Doc build
         run: |
           make html -C docs/ SPHINXOPTS="-W --keep-going -n"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.8"
+  apt_packages:
+    - graphviz
 
 python:
   install:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
+    'sphinx.ext.graphviz',
     'matplotlib.sphinxext.plot_directive',
     'sphinx_rtd_theme',
 ]
@@ -163,6 +164,13 @@ latex_documents = [
      about["__author__"], 'manual'),
 ]
 
+# -- Options for graphviz output ---------------------------------------
+
+# Can be 'png' or 'svg', default is 'png'. If 'svg' is used, in order to
+#  make URL links work properly for graph elements, an appropriate
+#  target attribute must be set, such as "_top" and "_blank".
+#  https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html
+graphviz_output_format = 'svg'
 
 # -- Options for manual page output ---------------------------------------
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_sepsis.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/maternal_sepsis.rst
@@ -56,6 +56,18 @@ Assumptions and Limitations
 Cause Model Diagram
 +++++++++++++++++++
 
+.. graphviz::
+
+    digraph sepsis_decisions {
+        rankdir = LR;
+        pregnant -> "not dead"  [label = "1 - ir"]
+        pregnant -> sepsis [label = "ir"]
+        sepsis -> "not dead" [label = "1 - cfr"]
+        sepsis -> dead [label = "cfr"]
+        "not dead" -> "child born"  [label = "1"]
+        dead -> "child born"  [label = "1"]
+    }
+
 Data Tables
 +++++++++++
 


### PR DESCRIPTION
Add the [Sphinx Graphviz extension](https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html) so we can use a `.. graphviz::` directive to write code to generate Graphviz graphs directly in the docs.

I added a sample graph to the MNCNH maternal sepsis page to verify that the extension works.

If this gets merged, everyone will need to [install Graphviz](https://graphviz.org/download/) on their computer in order to render the docs without warnings/errors.