### PR TITLE
Add instructions to install Graphviz

### DIFF
--- a/docs/source/onboarding_resources/contributing/index.rst
+++ b/docs/source/onboarding_resources/contributing/index.rst
@@ -46,6 +46,23 @@ the commands below.
 At this point, a folder called vivarium_research should be added to your computer and 
 accessible from your file explorer. 
 
+Install Graphviz
+----------------
+
+Our documentation uses the `Sphinx Graphviz extension`_ to embed code
+for Graphviz_ graphs using the DOT_ language, rendering the graphs when
+the docs are built. Graphviz is a separate program that you will need to
+install on your computer in order for the documentation to build without
+errors. The method of installation depends on your platform ( Windows,
+Mac, or Linux), and installation instructions can be found here:
+
+* `Graphviz download page`_
+
+.. _Sphinx Graphviz extension: https://www.sphinx-doc.org/en/master/usage/extensions/graphviz.html
+.. _Graphviz: https://graphviz.org/
+.. _DOT: https://graphviz.org/doc/info/lang.html
+.. _Graphviz download page: https://graphviz.org/download/
+
 Make a new git branch
 ---------------------
 


### PR DESCRIPTION
Add instructions to install [Graphviz](https://graphviz.org/) on the "Contributing New Documentation" page. This PR is a follow-up to https://github.com/ihmeuw/vivarium_research/pull/1544, which, once merged, will require Graphviz to be installed when building the docs.

**Note:** Instead of having everyone install Graphviz on their own in a platform-dependent way as described here, it would probably be better to use `conda` to install it. Then the same method would work across platforms, and we could include an installation script in the repo that could do the installations automatically. Here's the JIRA ticket for creating such a script: https://jira.ihme.washington.edu/browse/SSCI-2000

Until that's accomplished, people should follow the instructions in this PR to manually install Graphviz on their own.