### PR TITLE
Add data tables from sepsis to OL page

### DIFF
--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -161,8 +161,8 @@ while dashed lines indicate pieces of the underlying pregnancy model.
         rankdir = LR;
         ftp [label="full term\npregnancy, post\nintrapartum", style=dashed]
         ftb [label="full term\nbirth", style=dashed]
-        alive [label="parent alive"]
-        dead [label="parent dead"]
+        alive [label="parent did not die of cause"]
+        dead [label="parent died of cause"]
 
         ftp -> alive  [label = "1 - ir"]
         ftp -> OL [label = "ir"]

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -272,7 +272,7 @@ calculations as well as for the calculation of YLDs in the next section.
       - csmr_c368 / incidence_368
       - The value of cfr is a probabiity in [0,1]
     * - incidence_c368
-      - incidence rate of obstructed labor and uterine rupture and other maternal infections
+      - incidence rate of obstructed labor and uterine rupture
       - como
       - Use the :ref:`total population incidence rate <total population
         incidence rate>` directly from GBD and do not rescale this
@@ -285,8 +285,7 @@ calculations as well as for the calculation of YLDs in the next section.
       - deaths_c368 / population
       - Note that deaths / (average population for year) = deaths / person-time
     * - deaths_c368
-      - count of deaths due to obstructed labor and uterine rupture and other maternal
-        infections
+      - count of deaths due to obstructed labor and uterine rupture
       - codcorrect
       -
     * - population

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -113,7 +113,7 @@ Vivarium Modeling Strategy
 Scope
 +++++
 
-The goal of the obstructed labor model is to capture YLLs and YLDs due to
+The goal of the obstructed labor (OL) model is to capture YLLs and YLDs due to
 obstructed labor and uterine rupture among women of
 reproductive age. We only model obstructed labor and uterine rupture among 
 simulants who give (live or still) birth after a full term pregnancy. This 
@@ -215,6 +215,107 @@ while dashed lines indicate pieces of the underlying pregnancy model.
 
 Data Tables
 +++++++++++
+
+The obstructed labor and uterine rupture cause model requires two probabilities, the
+incidence risk (ir) per birth and the case fatality rate (cfr), for use
+in the decision graph. The incidence risk per birth will be computed as
+
+.. math::
+
+    \text{ir} = \frac{\text{OL cases}}{\text{births}}
+        = \frac{\text{(OL cases) / person-time}}
+            {\text{births / person-time}}
+        = \frac{\text{OL incidence rate}}{\text{birth rate}}.
+
+The case fatality rate will be computed as
+
+.. math::
+
+    \begin{align*}
+    \text{cfr} &= \frac{\text{OL deaths}}{\text{OL cases}} \\
+        &= \frac{\text{(OL deaths) / person-time}}
+            {\text{(OL cases) / person-time}}
+        = \frac{\text{OL cause specific mortality rate}}
+            {\text{OL incidence rate}}.
+    \end{align*}
+
+The following table shows the data needed from GBD for these
+calculations as well as for the calculation of YLDs in the next section.
+
+.. note::
+
+  All quantities pulled from GBD in the following table are for a
+  specific year, sex, age group, and location unless otherwise noted
+  (e.g., SBR). Our simulation only includes pregnant women of
+  reproductive age, so the sex will always be female. However, even
+  though all of our simulants will be pregnant, we still pull each
+  quantity for *all* females in a given year, age group, and location,
+  because this is the default behavior of GBD. Since we are using the
+  same total population in all the denominators, the person-time will
+  cancel out in the above calculations to give us the probabilities we
+  want.
+
+.. list-table:: Data values and sources
+    :header-rows: 1
+
+    * - Variable
+      - Definition
+      - Value or source
+      - Note
+    * - ir
+      - obstructed labor and uterine rupture incidence risk per birth
+      - incidence_c368 / birth_rate
+      - The value of ir is a probabiity in [0,1]. Denominator includes
+        live births and stillbirths.
+    * - cfr
+      - case fatality rate of obstructed labor and uterine rupture
+      - csmr_c368 / incidence_368
+      - The value of cfr is a probabiity in [0,1]
+    * - incidence_c368
+      - incidence rate of obstructed labor and uterine rupture and other maternal infections
+      - como
+      - Use the :ref:`total population incidence rate <total population
+        incidence rate>` directly from GBD and do not rescale this
+        parameter to susceptible-population incidence rate using
+        condition prevalence. Total population person-time is used in
+        the denominator in order to cancel out with the person-time in
+        the denominators of birth_rate and csmr_c368.
+    * - csmr_c368
+      - obstructed labor and uterine rupture cause-specific mortality rate
+      - deaths_c368 / population
+      - Note that deaths / (average population for year) = deaths / person-time
+    * - deaths_c368
+      - count of deaths due to obstructed labor and uterine rupture and other maternal
+        infections
+      - codcorrect
+      -
+    * - population
+      - average population in a given year
+      - get_population
+      - Specific to age/sex/location/year demographic group. Numerically
+        equal to person-time for the year.
+    * - birth_rate
+      - birth rate (live or still)
+      - (1 + SBR) ASFR
+      - Units are total births (live or still) per person-year
+    * - ASFR
+      - Age-specific fertility rate
+      - get_covariate_estimates: coviarate_id=13
+      - Assume lognormal distribution of uncertainty. Units in GBD are
+        live births per person, or equivalently, per person-year.
+    * - SBR
+      - Stillbirth to live birth ratio
+      - get_covariate_estimates: covariate_id=2267
+      - Parameter is not age specific and has no draw-level uncertainty.
+        Use mean_value as location-specific point parameter.
+    * - yld_rate_c368
+      - rate of obstructed labor and uterine rupture YLDs per person-year
+      - como
+      -
+    * - ylds_per_case_c368
+      - YLDs per case of obstructed labor and uterine rupture
+      - yld_rate_c368 / incidence_c368
+      -
 
 Calculating Burden
 ++++++++++++++++++


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ed40c0d5-2be2-4623-860d-c3f2445a3ce4)
This PR adds the data tables from sepsis to the OL page, and also updates the wording in our decision graph (lmk if some other wording would be better!) 