### PR TITLE
MNCNH: Maternal disorders cause hierarchy & subcause definitions

### DIFF
--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -143,7 +143,7 @@ childbirth, and the postpartum period:
 
    a. Acute event includes failure to progress (no advance of the
       presenting part of the fetus despite strong uterine contractions),
-      cephalopelvic disproportion (fetal size that is too 721 large for
+      cephalopelvic disproportion (fetal size that is too large for
       maternal pelvic dimensions), non-vertex fetal positioning during
       labour (any fetal position besides head down during labour;
       excludes non-vertex positioning during antepartum period), and

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -130,14 +130,14 @@ Subcause case definitions
 Maternal disorders are direct obstetric complications of pregnancy,
 childbirth, and the postpartum period:
 
-1. **Abortion** is defined as elective or medically indicated termination of
-   pregnancy at any gestational age, regardless of symptoms or
-   complications (**abortion**), or spontaneous loss of pregnancy before 24
-   weeks of gestation (**miscarriage**) with complications requiring medical
-   care. Miscarriages that do not require medical care are not included
-   in this cause.
-#. **Ectopic pregnancy** is defined as a pregnancy that implants outside of
-   the uterine cavity, generally presenting with abdominal pain and
+1. **Abortion** is defined as elective or medically indicated
+   termination of pregnancy at any gestational age, regardless of
+   symptoms or complications (**abortion**), or spontaneous loss of
+   pregnancy before 24 weeks of gestation (**miscarriage**) with
+   complications requiring medical care. Miscarriages that do not
+   require medical care are not included in this cause.
+#. **Ectopic pregnancy** is defined as a pregnancy that implants outside
+   of the uterine cavity, generally presenting with abdominal pain and
    vaginal bleeding.
 #. **Obstructed labour and uterine rupture**.
 
@@ -166,8 +166,8 @@ childbirth, and the postpartum period:
    labour), or placental disorders with haemorrhage regardless of blood
    volume lost or timing of bleeding event. Placental disorders without
    haemorrhage are included with other [direct] maternal disorders.
-#. **Maternal sepsis and other maternal infections** encompasses maternal
-   sepsis during or following labour and delivery (defined as
+#. **Maternal sepsis and other maternal infections** encompasses
+   maternal sepsis during or following labour and delivery (defined as
    temperature <36°C or >38°C and clinical signs of shock [systolic
    blood pressure <90 mmHg and tachycardia >120 bpm]) as well as other
    maternal infections believed to have a close epidemiological
@@ -176,7 +176,8 @@ childbirth, and the postpartum period:
    infections, and breast infections related to childbirth and
    lactation.
 
-#. **Hypertensive disorders of pregnancy** includes several subcategories:
+#. **Hypertensive disorders of pregnancy** includes several
+   subcategories:
 
    a. Gestational hypertension is the new onset of hypertension in a
       pregnant person after 20 weeks’ gestation, as defined by having a

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -68,35 +68,35 @@ Cause Hierarchy
 
         - Maternal hemorrhage (c_367)
 
+          - Maternal hemorrhage with less than 1 liter blood loss (s_180)
+
+          - Maternal hemorrhage with greater than 1 liter blood loss (s_181)
+
           - Mild anemia due to maternal hemorrhage (s_182)
 
           - Moderate anemia due to maternal hemorrhage (s_183)
 
           - Severe anemia due to maternal hemorrhage (s_184)
 
-          - Maternal hemorrhage with less than 1 liter blood loss (s_180)
-
-          - Maternal hemorrhage with greater than 1 liter blood loss (s_181)
-
         - Maternal sepsis and other maternal infections (c_368)
 
           - Infertility due to puerperal sepsis (s_675)
 
-          - Other maternal infections (s_938)
-
           - Puerperal sepsis (s_937)
 
+          - Other maternal infections (s_938)
+
         - Maternal hypertensive disorders (c_369)
-
-          - Long term sequelae of severe pre-eclampsia (s_677)
-
-          - Long term sequelae of eclampsia (s_677)
-
-          - Other hypertensive disorders of pregnancy (s_676)
 
           - Severe pre-eclampsia (s_185)
 
           - Eclampsia (s_186)
+
+          - Long term sequelae of severe pre-eclampsia (s_187)
+
+          - Long term sequelae of eclampsia (s_677)
+
+          - Other hypertensive disorders of pregnancy (s_676)
 
         - Maternal obstructed labor and uterine rupture (c_370)
 
@@ -106,23 +106,23 @@ Cause Hierarchy
 
           - Vesicovaginal fistula (s_190)
 
-        - Abortion and miscarriage (c_995)
-
-          - Maternal abortive outcome (s_191)
-
         - Ectopic pregnancy (c_374)
 
           - Ectopic pregnancy (s_5165)
+
+        - Maternal abortion and miscarriage (c_995)
+
+          - Maternal abortive outcome (s_191)
+
+        - Other direct maternal disorders (c_379)
+
+          - Other maternal disorders (s_192)
 
         - Indirect maternal deaths (c_375)
 
         - Late maternal deaths (c_376)
 
-        - Maternal deaths aggrevated by HIV/AIDs (c_741)
-
-        - Other maternal disorders (c_379)
-
-          - Other maternal disorders (s_192)
+        - Maternal deaths aggravated by HIV/AIDs (c_741)
 
 Subcause case definitions
 """"""""""""""""""""""""""""

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -58,8 +58,77 @@ GBD 2021 Modeling Strategy
 Cause Hierarchy
 +++++++++++++++
 
-Subcause definitions
+- All causes (c_294)
+
+  - Communicable, maternal, neonatal, and nutritional diseases (c_295)
+
+    - Maternal disorders and neonatal disorders (c_962)
+
+      - **Maternal disorders (c_366)**
+
+        - Maternal hemorrhage (c_367)
+
+          - Mild anemia due to maternal hemorrhage (s_182)
+
+          - Moderate anemia due to maternal hemorrhage (s_183)
+
+          - Severe anemia due to maternal hemorrhage (s_184)
+
+          - Maternal hemorrhage with less than 1 liter blood loss (s_180)
+
+          - Maternal hemorrhage with greater than 1 liter blood loss (s_181)
+
+        - Maternal sepsis and other maternal infections (c_368)
+
+          - Infertility due to puerperal sepsis (s_675)
+
+          - Other maternal infections (s_938)
+
+          - Puerperal sepsis (s_937)
+
+        - Maternal hypertensive disorders (c_369)
+
+          - Long term sequelae of severe pre-eclampsia (s_677)
+
+          - Long term sequelae of eclampsia (s_677)
+
+          - Other hypertensive disorders of pregnancy (s_676)
+
+          - Severe pre-eclampsia (s_185)
+
+          - Eclampsia (s_186)
+
+        - Maternal obstructed labor and uterine rupture (c_370)
+
+          - Obstructed labor, acute event (s_188)
+
+          - Rectovaginal fistula (s_189)
+
+          - Vesicovaginal fistula (s_190)
+
+        - Abortion and miscarriage (c_995)
+
+          - Maternal abortive outcome (s_191)
+
+        - Ectopic pregnancy (c_374)
+
+          - Ectopic pregnancy (s_5165)
+
+        - Indirect maternal deaths (c_375)
+
+        - Late maternal deaths (c_376)
+
+        - Maternal deaths aggrevated by HIV/AIDs (c_741)
+
+        - Other maternal disorders (c_379)
+
+          - Other maternal disorders (s_192)
+
+Subcause case definitions
 """"""""""""""""""""""""""""
+
+Maternal disorders are direct obstetric complications of pregnancy,
+childbirth, and the postpartum period:
 
 #. Abortion is defined as elective or medically indicated termination of
    pregnancy at any gestational age, regardless of symptoms or

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -61,6 +61,59 @@ Cause Hierarchy
 Subcause definitions
 """"""""""""""""""""""""""""
 
+1) Abortion is defined as elective or medically indicated termination of pregnancy at any
+gestational age, regardless of symptoms or complications (abortion), or spontaneous loss of
+pregnancy before 24 weeks of gestation (miscarriage) with complications requiring medical care.
+Miscarriages that do not require medical care are not included in this cause.
+2) Ectopic pregnancy is defined as a pregnancy that implants outside of the uterine cavity,
+generally presenting with abdominal pain and vaginal bleeding.
+3) Obstructed labour and uterine rupture.
+a. Acute event includes failure to progress (no advance of the presenting part of the fetus
+despite strong uterine contractions), cephalopelvic disproportion (fetal size that is too
+721
+large for maternal pelvic dimensions), non-vertex fetal positioning during labour (any
+fetal position besides head down during labour; excludes non-vertex positioning during
+antepartum period), and uterine rupture during labour (non-surgical breakdown of
+uterine wall during labour and delivery). Perineal lacerations without any of the above
+conditions are excluded from the case definition. (Estimation of the incidence and short-
+term disability due to these conditions is described in this appendix section.)
+b. Obstetric fistula is defined as an abnormal opening between the vagina and the bladder
+or rectum with involuntary escape of urine, flatus, and/or faeces following childbirth.
+(The non-fatal burden of fistulas is included in the non-fatal burden of obstructed labour
+in reporting, but estimation is described in a separate appendix section on “Fistula –
+impairment.”)
+4) Maternal haemorrhage includes heavier than expected postpartum bleeding (>500 ml following
+vaginal delivery or >1000 ml after cesarean delivery) or antepartum bleeding (vaginal bleeding
+from any cause at or beyond 20 weeks of gestation and prior to onset of labour), or placental
+disorders with haemorrhage regardless of blood volume lost or timing of bleeding event.
+Placental disorders without haemorrhage are included with other [direct] maternal disorders.
+5) Maternal sepsis and other maternal infections encompasses maternal sepsis during or following
+labour and delivery (defined as temperature <36°C or >38°C and clinical signs of shock [systolic
+blood pressure <90 mmHg and tachycardia >120 bpm]) as well as other maternal infections
+believed to have a close epidemiological relationship with pregnancy, including genitourinary
+tract infections (excluding sexually transmitted diseases), obstetrical wound infections, and
+breast infections related to childbirth and lactation.
+6) Hypertensive disorders of pregnancy includes several subcategories:
+a. Gestational hypertension is the new onset of hypertension in a pregnant person after 20
+weeks’ gestation, as defined by having a blood pressure measured >140/90 mmHg on
+more than one occasion.
+b. Preeclampsia is defined by hypertension [>140/90 mmHg] and proteinuria [≥0.3 g/l],
+with or without signs of end-organ damage.
+c. Severe preeclampsia is defined by preeclampsia with severe hypertension [>160/100
+mmHg] or other signs of end organ damage [liver: low platelets, elevated liver enzymes,
+coagulation issues; kidney: elevated creatinine; central nervous system: headaches or
+visual disturbances], syndrome of hypertension, elevated liver enzymes, low platelets
+[HELLP syndrome]).
+d. Eclampsia is defined as hypertension and seizures, with or without proteinuria.
+This definition excludes chronic hypertension in a pregnant person (hypertension present prior
+to 20 weeks’ gestation) unless superimposed preeclampsia develops.
+7) Other [direct] maternal disorders includes a variety of different obstetric complications. The
+most common of these in ICD-10-coded vital registration sources in terms of number of deaths
+include O88 (obstetric embolism), O26 (maternal care for other conditions predominantly
+related to pregnancy), O90 (complications of the puerperium, not elsewhere classified), O75
+(other complications of labour and delivery, not elsewhere classified), C58 (malignant neoplasm
+of placenta), and O36 (maternal care for other fetal problems).
+
 Restrictions
 ++++++++++++
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -130,16 +130,16 @@ Subcause case definitions
 Maternal disorders are direct obstetric complications of pregnancy,
 childbirth, and the postpartum period:
 
-#. Abortion is defined as elective or medically indicated termination of
+1. **Abortion** is defined as elective or medically indicated termination of
    pregnancy at any gestational age, regardless of symptoms or
-   complications (abortion), or spontaneous loss of pregnancy before 24
-   weeks of gestation (miscarriage) with complications requiring medical
+   complications (**abortion**), or spontaneous loss of pregnancy before 24
+   weeks of gestation (**miscarriage**) with complications requiring medical
    care. Miscarriages that do not require medical care are not included
    in this cause.
-#. Ectopic pregnancy is defined as a pregnancy that implants outside of
+#. **Ectopic pregnancy** is defined as a pregnancy that implants outside of
    the uterine cavity, generally presenting with abdominal pain and
    vaginal bleeding.
-#. Obstructed labour and uterine rupture.
+#. **Obstructed labour and uterine rupture**.
 
    a. Acute event includes failure to progress (no advance of the
       presenting part of the fetus despite strong uterine contractions),
@@ -152,21 +152,21 @@ childbirth, and the postpartum period:
       of the above conditions are excluded from the case definition.
       (Estimation of the incidence and short- term disability due to
       these conditions is described in this appendix section.)
-   b. Obstetric fistula is defined as an abnormal opening between the
+   #. Obstetric fistula is defined as an abnormal opening between the
       vagina and the bladder or rectum with involuntary escape of urine,
       flatus, and/or faeces following childbirth. (The non-fatal burden
       of fistulas is included in the non-fatal burden of obstructed
       labour in reporting, but estimation is described in a separate
       appendix section on “Fistula – impairment.”)
 
-#. Maternal haemorrhage includes heavier than expected postpartum
+#. **Maternal haemorrhage** includes heavier than expected postpartum
    bleeding (>500 ml following vaginal delivery or >1000 ml after
    cesarean delivery) or antepartum bleeding (vaginal bleeding from any
    cause at or beyond 20 weeks of gestation and prior to onset of
    labour), or placental disorders with haemorrhage regardless of blood
    volume lost or timing of bleeding event. Placental disorders without
    haemorrhage are included with other [direct] maternal disorders.
-#. Maternal sepsis and other maternal infections encompasses maternal
+#. **Maternal sepsis and other maternal infections** encompasses maternal
    sepsis during or following labour and delivery (defined as
    temperature <36°C or >38°C and clinical signs of shock [systolic
    blood pressure <90 mmHg and tachycardia >120 bpm]) as well as other
@@ -176,24 +176,24 @@ childbirth, and the postpartum period:
    infections, and breast infections related to childbirth and
    lactation.
 
-#. Hypertensive disorders of pregnancy includes several subcategories:
+#. **Hypertensive disorders of pregnancy** includes several subcategories:
 
    a. Gestational hypertension is the new onset of hypertension in a
       pregnant person after 20 weeks’ gestation, as defined by having a
       blood pressure measured >140/90 mmHg on more than one occasion.
-   b. Preeclampsia is defined by hypertension [>140/90 mmHg] and
+   #. Preeclampsia is defined by hypertension [>140/90 mmHg] and
       proteinuria [≥0.3 g/l], with or without signs of end-organ damage.
-   c. Severe preeclampsia is defined by preeclampsia with severe
+   #. Severe preeclampsia is defined by preeclampsia with severe
       hypertension [>160/100 mmHg] or other signs of end organ damage
       [liver: low platelets, elevated liver enzymes, coagulation issues;
       kidney: elevated creatinine; central nervous system: headaches or
       visual disturbances], syndrome of hypertension, elevated liver
       enzymes, low platelets [HELLP syndrome]).
-   d. Eclampsia is defined as hypertension and seizures, with or without
+   #. Eclampsia is defined as hypertension and seizures, with or without
       proteinuria. This definition excludes chronic hypertension in a
       pregnant person (hypertension present prior to 20 weeks’
       gestation) unless superimposed preeclampsia develops.
-#. Other [direct] maternal disorders includes a variety of different
+#. **Other [direct] maternal disorders** includes a variety of different
    obstetric complications. The most common of these in ICD-10-coded
    vital registration sources in terms of number of deaths include O88
    (obstetric embolism), O26 (maternal care for other conditions

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -61,58 +61,78 @@ Cause Hierarchy
 Subcause definitions
 """"""""""""""""""""""""""""
 
-1) Abortion is defined as elective or medically indicated termination of pregnancy at any
-gestational age, regardless of symptoms or complications (abortion), or spontaneous loss of
-pregnancy before 24 weeks of gestation (miscarriage) with complications requiring medical care.
-Miscarriages that do not require medical care are not included in this cause.
-2) Ectopic pregnancy is defined as a pregnancy that implants outside of the uterine cavity,
-generally presenting with abdominal pain and vaginal bleeding.
-3) Obstructed labour and uterine rupture.
-a. Acute event includes failure to progress (no advance of the presenting part of the fetus
-despite strong uterine contractions), cephalopelvic disproportion (fetal size that is too
-721
-large for maternal pelvic dimensions), non-vertex fetal positioning during labour (any
-fetal position besides head down during labour; excludes non-vertex positioning during
-antepartum period), and uterine rupture during labour (non-surgical breakdown of
-uterine wall during labour and delivery). Perineal lacerations without any of the above
-conditions are excluded from the case definition. (Estimation of the incidence and short-
-term disability due to these conditions is described in this appendix section.)
-b. Obstetric fistula is defined as an abnormal opening between the vagina and the bladder
-or rectum with involuntary escape of urine, flatus, and/or faeces following childbirth.
-(The non-fatal burden of fistulas is included in the non-fatal burden of obstructed labour
-in reporting, but estimation is described in a separate appendix section on “Fistula –
-impairment.”)
-4) Maternal haemorrhage includes heavier than expected postpartum bleeding (>500 ml following
-vaginal delivery or >1000 ml after cesarean delivery) or antepartum bleeding (vaginal bleeding
-from any cause at or beyond 20 weeks of gestation and prior to onset of labour), or placental
-disorders with haemorrhage regardless of blood volume lost or timing of bleeding event.
-Placental disorders without haemorrhage are included with other [direct] maternal disorders.
-5) Maternal sepsis and other maternal infections encompasses maternal sepsis during or following
-labour and delivery (defined as temperature <36°C or >38°C and clinical signs of shock [systolic
-blood pressure <90 mmHg and tachycardia >120 bpm]) as well as other maternal infections
-believed to have a close epidemiological relationship with pregnancy, including genitourinary
-tract infections (excluding sexually transmitted diseases), obstetrical wound infections, and
-breast infections related to childbirth and lactation.
-6) Hypertensive disorders of pregnancy includes several subcategories:
-a. Gestational hypertension is the new onset of hypertension in a pregnant person after 20
-weeks’ gestation, as defined by having a blood pressure measured >140/90 mmHg on
-more than one occasion.
-b. Preeclampsia is defined by hypertension [>140/90 mmHg] and proteinuria [≥0.3 g/l],
-with or without signs of end-organ damage.
-c. Severe preeclampsia is defined by preeclampsia with severe hypertension [>160/100
-mmHg] or other signs of end organ damage [liver: low platelets, elevated liver enzymes,
-coagulation issues; kidney: elevated creatinine; central nervous system: headaches or
-visual disturbances], syndrome of hypertension, elevated liver enzymes, low platelets
-[HELLP syndrome]).
-d. Eclampsia is defined as hypertension and seizures, with or without proteinuria.
-This definition excludes chronic hypertension in a pregnant person (hypertension present prior
-to 20 weeks’ gestation) unless superimposed preeclampsia develops.
-7) Other [direct] maternal disorders includes a variety of different obstetric complications. The
-most common of these in ICD-10-coded vital registration sources in terms of number of deaths
-include O88 (obstetric embolism), O26 (maternal care for other conditions predominantly
-related to pregnancy), O90 (complications of the puerperium, not elsewhere classified), O75
-(other complications of labour and delivery, not elsewhere classified), C58 (malignant neoplasm
-of placenta), and O36 (maternal care for other fetal problems).
+#. Abortion is defined as elective or medically indicated termination of
+   pregnancy at any gestational age, regardless of symptoms or
+   complications (abortion), or spontaneous loss of pregnancy before 24
+   weeks of gestation (miscarriage) with complications requiring medical
+   care. Miscarriages that do not require medical care are not included
+   in this cause.
+#. Ectopic pregnancy is defined as a pregnancy that implants outside of
+   the uterine cavity, generally presenting with abdominal pain and
+   vaginal bleeding.
+#. Obstructed labour and uterine rupture.
+
+   a. Acute event includes failure to progress (no advance of the
+      presenting part of the fetus despite strong uterine contractions),
+      cephalopelvic disproportion (fetal size that is too 721 large for
+      maternal pelvic dimensions), non-vertex fetal positioning during
+      labour (any fetal position besides head down during labour;
+      excludes non-vertex positioning during antepartum period), and
+      uterine rupture during labour (non-surgical breakdown of uterine
+      wall during labour and delivery). Perineal lacerations without any
+      of the above conditions are excluded from the case definition.
+      (Estimation of the incidence and short- term disability due to
+      these conditions is described in this appendix section.)
+   b. Obstetric fistula is defined as an abnormal opening between the
+      vagina and the bladder or rectum with involuntary escape of urine,
+      flatus, and/or faeces following childbirth. (The non-fatal burden
+      of fistulas is included in the non-fatal burden of obstructed
+      labour in reporting, but estimation is described in a separate
+      appendix section on “Fistula – impairment.”)
+
+#. Maternal haemorrhage includes heavier than expected postpartum
+   bleeding (>500 ml following vaginal delivery or >1000 ml after
+   cesarean delivery) or antepartum bleeding (vaginal bleeding from any
+   cause at or beyond 20 weeks of gestation and prior to onset of
+   labour), or placental disorders with haemorrhage regardless of blood
+   volume lost or timing of bleeding event. Placental disorders without
+   haemorrhage are included with other [direct] maternal disorders.
+#. Maternal sepsis and other maternal infections encompasses maternal
+   sepsis during or following labour and delivery (defined as
+   temperature <36°C or >38°C and clinical signs of shock [systolic
+   blood pressure <90 mmHg and tachycardia >120 bpm]) as well as other
+   maternal infections believed to have a close epidemiological
+   relationship with pregnancy, including genitourinary tract infections
+   (excluding sexually transmitted diseases), obstetrical wound
+   infections, and breast infections related to childbirth and
+   lactation.
+
+#. Hypertensive disorders of pregnancy includes several subcategories:
+
+   a. Gestational hypertension is the new onset of hypertension in a
+      pregnant person after 20 weeks’ gestation, as defined by having a
+      blood pressure measured >140/90 mmHg on more than one occasion.
+   b. Preeclampsia is defined by hypertension [>140/90 mmHg] and
+      proteinuria [≥0.3 g/l], with or without signs of end-organ damage.
+   c. Severe preeclampsia is defined by preeclampsia with severe
+      hypertension [>160/100 mmHg] or other signs of end organ damage
+      [liver: low platelets, elevated liver enzymes, coagulation issues;
+      kidney: elevated creatinine; central nervous system: headaches or
+      visual disturbances], syndrome of hypertension, elevated liver
+      enzymes, low platelets [HELLP syndrome]).
+   d. Eclampsia is defined as hypertension and seizures, with or without
+      proteinuria. This definition excludes chronic hypertension in a
+      pregnant person (hypertension present prior to 20 weeks’
+      gestation) unless superimposed preeclampsia develops.
+#. Other [direct] maternal disorders includes a variety of different
+   obstetric complications. The most common of these in ICD-10-coded
+   vital registration sources in terms of number of deaths include O88
+   (obstetric embolism), O26 (maternal care for other conditions
+   predominantly related to pregnancy), O90 (complications of the
+   puerperium, not elsewhere classified), O75 (other complications of
+   labour and delivery, not elsewhere classified), C58 (malignant
+   neoplasm of placenta), and O36 (maternal care for other fetal
+   problems).
 
 Restrictions
 ++++++++++++

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -62,7 +62,7 @@ Cause Hierarchy
 
   - Communicable, maternal, neonatal, and nutritional diseases (c_295)
 
-    - Maternal disorders and neonatal disorders (c_962)
+    - Maternal and neonatal disorders (c_962)
 
       - **Maternal disorders (c_366)** [level 3]
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/index.rst
@@ -58,13 +58,13 @@ GBD 2021 Modeling Strategy
 Cause Hierarchy
 +++++++++++++++
 
-- All causes (c_294)
+- All causes (c_294) [level 0]
 
   - Communicable, maternal, neonatal, and nutritional diseases (c_295)
 
     - Maternal disorders and neonatal disorders (c_962)
 
-      - **Maternal disorders (c_366)**
+      - **Maternal disorders (c_366)** [level 3]
 
         - Maternal hemorrhage (c_367)
 
@@ -80,11 +80,11 @@ Cause Hierarchy
 
         - Maternal sepsis and other maternal infections (c_368)
 
-          - Infertility due to puerperal sepsis (s_675)
-
           - Puerperal sepsis (s_937)
 
           - Other maternal infections (s_938)
+
+          - Infertility due to puerperal sepsis (s_675)
 
         - Maternal hypertensive disorders (c_369)
 
@@ -92,11 +92,11 @@ Cause Hierarchy
 
           - Eclampsia (s_186)
 
+          - Other hypertensive disorders of pregnancy (s_676)
+
           - Long term sequelae of severe pre-eclampsia (s_187)
 
           - Long term sequelae of eclampsia (s_677)
-
-          - Other hypertensive disorders of pregnancy (s_676)
 
         - Maternal obstructed labor and uterine rupture (c_370)
 


### PR DESCRIPTION
Adds the GBD cause hierarchy for maternal disorders, and the subcause case definitions from the nonfatal methods appendix.