### PR TITLE
Add Data Tables section to OL docs

### DIFF
--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -142,6 +142,7 @@ in the decision graph. The incidence risk per birth will be computed as
         = \frac{\text{OL cause specific mortality rate}}
             {\text{OL incidence rate}}.
     \end{align*}
+
   The following table shows the data needed from GBD for these
   calculations as well as for the calculation of YLDs in the next section.
 

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -166,14 +166,14 @@ in the decision graph. The incidence risk per birth will be computed as
       - Note
     * - ir
       - obstructed labor and uterine rupture incidence risk per birth
-      - incidence_c368 / birth_rate
+      - incidence_c370 / birth_rate
       - The value of ir is a probabiity in [0,1]. Denominator includes
         live births and stillbirths.
     * - cfr
       - case fatality rate of obstructed labor and uterine rupture
-      - csmr_c368 / incidence_368
+      - csmr_c370 / incidence_368
       - The value of cfr is a probabiity in [0,1]
-    * - incidence_c368
+    * - incidence_c370
       - incidence rate of obstructed labor and uterine rupture
       - como
       - Use the :ref:`total population incidence rate <total population
@@ -181,12 +181,12 @@ in the decision graph. The incidence risk per birth will be computed as
         parameter to susceptible-population incidence rate using
         condition prevalence. Total population person-time is used in
         the denominator in order to cancel out with the person-time in
-        the denominators of birth_rate and csmr_c368.
-    * - csmr_c368
+        the denominators of birth_rate and csmr_c370.
+    * - csmr_c370
       - obstructed labor and uterine rupture cause-specific mortality rate
-      - deaths_c368 / population
+      - deaths_c370 / population
       - Note that deaths / (average population for year) = deaths / person-time
-    * - deaths_c368
+    * - deaths_c370
       - count of deaths due to obstructed labor and uterine rupture
       - codcorrect
       -
@@ -209,13 +209,13 @@ in the decision graph. The incidence risk per birth will be computed as
       - get_covariate_estimates: covariate_id=2267
       - Parameter is not age specific and has no draw-level uncertainty.
         Use mean_value as location-specific point parameter.
-    * - yld_rate_c368
+    * - yld_rate_c370
       - rate of obstructed labor and uterine rupture YLDs per person-year
       - como
       -
-    * - ylds_per_case_c368
+    * - ylds_per_case_c370
       - YLDs per case of obstructed labor and uterine rupture
-      - yld_rate_c368 / incidence_c368
+      - yld_rate_c370 / incidence_c370
       -
 
 Calculating Burden

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -131,6 +131,7 @@ in the decision graph. The incidence risk per birth will be computed as
         = \frac{\text{(OL cases) / person-time}}
             {\text{births / person-time}}
         = \frac{\text{OL incidence rate}}{\text{birth rate}}.
+
   The case fatality rate will be computed as
 
 .. math::

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -104,7 +104,7 @@ well as restrictions on the ages and sexes to which the cause applies.
      - 10 to 14 (ID=7)
      -
    * - YLD age group end
-     - 50 to 54 (ID=15)
+     - 95 plus (ID=235)
      -
 
 Vivarium Modeling Strategy
@@ -121,6 +121,103 @@ Cause Model Diagram
 
 Data Tables
 +++++++++++
+
+
+The obstructed labor and uterine rupture cause model requires two probabilities, the
+incidence risk (ir) per birth and the case fatality rate (cfr), for use
+in the decision graph. The incidence risk per birth will be computed as
+
+.. math::
+    \text{ir} = \frac{\text{OL cases}}{\text{births}}
+        = \frac{\text{(OL cases) / person-time}}
+            {\text{births / person-time}}
+        = \frac{\text{OL incidence rate}}{\text{birth rate}}.
+The case fatality rate will be computed as
+
+.. math::
+    \begin{align*}
+    \text{cfr} &= \frac{\text{OL deaths}}{\text{OL cases}} \\
+        &= \frac{\text{(OL deaths) / person-time}}
+            {\text{(OL cases) / person-time}}
+        = \frac{\text{OL cause specific mortality rate}}
+            {\text{OL incidence rate}}.
+    \end{align*}
+The following table shows the data needed from GBD for these
+calculations as well as for the calculation of YLDs in the next section.
+
+.. note::
+
+  All quantities pulled from GBD in the following table are for a
+  specific year, sex, age group, and location unless otherwise noted
+  (e.g., SBR). Our simulation only includes pregnant women of
+  reproductive age, so the sex will always be female. However, even
+  though all of our simulants will be pregnant, we still pull each
+  quantity for *all* females in a given year, age group, and location,
+  because this is the default behavior of GBD. Since we are using the
+  same total population in all the denominators, the person-time will
+  cancel out in the above calculations to give us the probabilities we
+  want.
+
+.. list-table:: Data values and sources
+    :header-rows: 1
+
+    * - Variable
+      - Definition
+      - Value or source
+      - Note
+    * - ir
+      - obstructed labor and uterine rupture incidence risk per birth
+      - incidence_c368 / birth_rate
+      - The value of ir is a probabiity in [0,1]. Denominator includes
+        live births and stillbirths.
+    * - cfr
+      - case fatality rate of obstructed labor and uterine rupture
+      - csmr_c368 / incidence_368
+      - The value of cfr is a probabiity in [0,1]
+    * - incidence_c368
+      - incidence rate of obstructed labor and uterine rupture
+      - como
+      - Use the :ref:`total population incidence rate <total population
+        incidence rate>` directly from GBD and do not rescale this
+        parameter to susceptible-population incidence rate using
+        condition prevalence. Total population person-time is used in
+        the denominator in order to cancel out with the person-time in
+        the denominators of birth_rate and csmr_c368.
+    * - csmr_c368
+      - obstructed labor and uterine rupture cause-specific mortality rate
+      - deaths_c368 / population
+      - Note that deaths / (average population for year) = deaths / person-time
+    * - deaths_c368
+      - count of deaths due to obstructed labor and uterine rupture
+      - codcorrect
+      -
+    * - population
+      - average population in a given year
+      - get_population
+      - Specific to age/sex/location/year demographic group. Numerically
+        equal to person-time for the year.
+    * - birth_rate
+      - birth rate (live or still)
+      - (1 + SBR) ASFR
+      - Units are total births (live or still) per person-year
+    * - ASFR
+      - Age-specific fertility rate
+      - get_covariate_estimates: coviarate_id=13
+      - Assume lognormal distribution of uncertainty. Units in GBD are
+        live births per person, or equivalently, per person-year.
+    * - SBR
+      - Stillbirth to live birth ratio
+      - get_covariate_estimates: covariate_id=2267
+      - Parameter is not age specific and has no draw-level uncertainty.
+        Use mean_value as location-specific point parameter.
+    * - yld_rate_c368
+      - rate of obstructed labor and uterine rupture YLDs per person-year
+      - como
+      -
+    * - ylds_per_case_c368
+      - YLDs per case of obstructed labor and uterine rupture
+      - yld_rate_c368 / incidence_c368
+      -
 
 Calculating Burden
 ++++++++++++++++++

--- a/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
+++ b/docs/source/models/causes/maternal_disorders/gbd_2021_mncnh/obstructed_labor.rst
@@ -122,7 +122,6 @@ Cause Model Diagram
 Data Tables
 +++++++++++
 
-
 The obstructed labor and uterine rupture cause model requires two probabilities, the
 incidence risk (ir) per birth and the case fatality rate (cfr), for use
 in the decision graph. The incidence risk per birth will be computed as
@@ -132,7 +131,7 @@ in the decision graph. The incidence risk per birth will be computed as
         = \frac{\text{(OL cases) / person-time}}
             {\text{births / person-time}}
         = \frac{\text{OL incidence rate}}{\text{birth rate}}.
-The case fatality rate will be computed as
+  The case fatality rate will be computed as
 
 .. math::
     \begin{align*}
@@ -142,8 +141,8 @@ The case fatality rate will be computed as
         = \frac{\text{OL cause specific mortality rate}}
             {\text{OL incidence rate}}.
     \end{align*}
-The following table shows the data needed from GBD for these
-calculations as well as for the calculation of YLDs in the next section.
+  The following table shows the data needed from GBD for these
+  calculations as well as for the calculation of YLDs in the next section.
 
 .. note::
 


### PR DESCRIPTION
This PR adds data tables to the OL cause model docs, and also updates the Restrictions Table to have YLDs continue accumulating for 95 plus group (instead of 50 to 54 age group).