### PR TITLE
Upgrade Python and Sphinx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12]
+        python-version: [3.13]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ version: 2
 # Configure the python version and environment construction run before
 # docs are built.
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
   apt_packages:
     - graphviz
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
   apt_packages:
     - graphviz
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -96,8 +96,7 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme_path = ['_theme']
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -111,11 +110,9 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 
 # Custom CSS file to wrap tables automatically
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+html_css_files = [
+    'theme_overrides.css', # override wide tables in RTD theme
+]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/source/onboarding_resources/contributing/index.rst
+++ b/docs/source/onboarding_resources/contributing/index.rst
@@ -37,7 +37,7 @@ the commands below.
 
 ::
 
-   $> conda create -y --name=vivarium_research python graphviz
+   $> conda create -y --name=vivarium_research python=3.13 graphviz
    $> conda activate vivarium_research
    (vivarium_research) $> git clone https://github.com/ihmeuw/vivarium_research.git
    (vivarium_research) $> cd vivarium_research

--- a/docs/source/onboarding_resources/contributing/index.rst
+++ b/docs/source/onboarding_resources/contributing/index.rst
@@ -37,7 +37,7 @@ the commands below.
 
 ::
 
-   $> conda create -y --name=vivarium_research python graphviz pandoc
+   $> conda create -y --name=vivarium_research python graphviz
    $> conda activate vivarium_research
    (vivarium_research) $> git clone https://github.com/ihmeuw/vivarium_research.git
    (vivarium_research) $> cd vivarium_research

--- a/docs/source/onboarding_resources/contributing/index.rst
+++ b/docs/source/onboarding_resources/contributing/index.rst
@@ -37,7 +37,7 @@ the commands below.
 
 ::
 
-   $> conda create -y --name=vivarium_research python=3.8
+   $> conda create -y --name=vivarium_research python graphviz pandoc
    $> conda activate vivarium_research
    (vivarium_research) $> git clone https://github.com/ihmeuw/vivarium_research.git
    (vivarium_research) $> cd vivarium_research
@@ -88,13 +88,14 @@ Use these commands to build your page with edits:
 
    (base) $> cd vivarium_research/docs
    (base) $> conda activate vivarium_research #This line is only needed if vivarium_research has not been activated yet
-   (vivarium_research) $> make html
+   (vivarium_research) $> sphinx-autobuild source build/html
 
 This will create a new ``build`` sub-directory with the new documentation
-rendered in html.  You can open the file `vivarium_research/docs/build/html/index.html` in your
-browser to view your changes. 
+rendered in html, and will open a browser window with the result.
+It should automatically update as you save edits to reStructuredText files, though occasionally
+you may need to manually delete ``build`` and re-run the command.
 
-Note that any warnings in your terminal after the `make html` command will cause the build to 
+Note that any warnings in your terminal will cause the build to 
 fail in GitHub. These include issues like duplicated references. Be sure to check for and correct 
 any warnings you may get before moving on! 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-sphinx==4.0.2
-sphinx_rtd_theme==0.5.2
+sphinx
+sphinx-autobuild
+sphinx_rtd_theme
 matplotlib


### PR DESCRIPTION
Upgrades us to latest stable version of Python and Sphinx. Build is passing and I manually inspected a smattering of pages on the local and RTD build and didn't see anything wacky. Verified that our CSS overrides were still working.