### PR TITLE
Add instructions to README about building docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,3 +12,13 @@ research projects.
 The hosted documentation can be found at https://vivarium-research.readthedocs.io/en/latest/.
 
 Information on how to contribute to vivarium research docs can be found at https://vivarium-research.readthedocs.io/en/latest/onboarding_resources/contributing/index.html. 
+
+Use the following steps to build the docs locally::
+
+   $> conda create -y --name=vivarium_research python=3.13 graphviz
+   $> conda activate vivarium_research
+   (vivarium_research) $> git clone https://github.com/ihmeuw/vivarium_research.git
+   (vivarium_research) $> cd vivarium_research
+   (vivarium_research) $> pip install -r requirements.txt
+   (vivarium_research) $> cd docs
+   (vivarium_research) $> make html


### PR DESCRIPTION
I decided this would help me and maybe others, instead of having to find the instructions in the `onboarding_resources/contributing/index.html` subfolder.