### PR TITLE
Add explicit configuration to readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ python:
   install:
     - requirements: requirements.txt
 
-# Doc builds will fail if there are any warnings
 sphinx:
+  configuration: docs/source/conf.py
+  # Doc builds will fail if there are any warnings
   fail_on_warning: true


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/