### PR TITLE
Proprosal for neonatal mortality equation to account for causes unaffected by LBWSG

### DIFF
--- a/docs/source/models/causes/neonatal/index.rst
+++ b/docs/source/models/causes/neonatal/index.rst
@@ -221,12 +221,19 @@ To obtain the ACMR for a specific simulant, we subtract off the *population* CSM
 
 .. math::
     \begin{align*}
-    \text{ACMR}_i &= \text{ACMR}_{\text{BW}_i,\text{GA}_i} - \sum_k \text{CSMR}_{\text{BW}_i,\text{GA}_i}^{k}
+    \text{ACMR}_i &= \text{UUMR}_{\text{baseline BW}_i,\text{baseline GA}_i} + \text{UAMR}_{\text{current BW}_i,\text{current GA}_i} - \text{MUMR}_{\text{baseline BW}_i,\text{baseline GA}_i} - \text{MAMR}_{\text{current BW}_i,\text{current GA}_i}
     + \sum_k \text{CSMR}_{i}^{k},
     \end{align*}
 
-where :math:`\text{BW}_i` and :math:`\text{GA}_i` are the birth weight and gestational age for simulant :math:`i`,
-:math:`\text{CSMR}_{\text{BW}_i,\text{GA}_i}^{k}` is the cause-specific mortality rate for subcause :math:`k` for a population with the same gestational age and birth weight as this simulant, 
+Where:
+
+  - :math:`UUMR` is the "unmodeled unaffected mortality rate," equal to the sum of cause-specific mortality rates for all **unmodeled** causes that are **unaffected** by the LBWSG
+  - :math:`UAMR` is the "unmodeled affected mortalty rate," equal to the sum of cause-specific mortality rates for all **unmodeled** causes that are **affected** by the LBWSG risk factor
+  - :math:`MUMR` is the "modeled unaffected mortalty rate," equal to the sum of cause-specific mortality rates for all **modeled** causes that are **unaffected** by the LBWSG risk factor
+  - :math:`MAMR` is the "modeled affected mortalty rate," equal to the sum of cause-specific mortality rates for all **modeled** causes that are **affected** by the LBWSG risk factor
+
+where :math:`\text{BW}_i` and :math:`\text{GA}_i` are the birth weight and gestational age for simulant :math:`i` (:math:`\text{baseline BW}_i` refers to simulant birthweight in the baseline scenario prior to any changes due to interventions such as antenatal interventions. :math:`\text{current BW}_i` refers to simulant birthweight following any changes due to interventions),
+:math:`\text{CSMR}_{\text{BW}_i,\text{GA}_i}^{k}` is the cause-specific mortality rate for modeled subcause :math:`k` for a population with the same gestational age and birth weight as this simulant, 
 and :math:`\text{CSMR}_{i}^{k}` is the cause-specific mortality rate for subcause :math:`k` for simulant :math:`i` (both detailed in the `Modeled Subcauses`_
 linked from this page).
 


### PR DESCRIPTION
This isn't formatted or detailed in a manner worthy for final documentation, but before I stop working for the week I just wanted to outline what I was thinking could work for this approach that will remain consistent with prior approaches and GBD assumptions around potential LBWSG reverse causality concerns. In case anyone would like to take a look at existing documentation about the difference between affected and unaffected causes, it is discussed on this page: https://vivarium-research.readthedocs.io/en/latest/models/risk_effects/low_birthweight_short_gestation/index.html

Essentially, I want to satisfy the following criteria:
- mortality due to unaffected causes should be higher among LBW/preterm simulants (HIV and malaria can _cause_ LBW/preterm, so there will be an observed association with HIV and malaria mortality), so we apply LBWSG RRs to these unaffected causes at baseline
- improvements in LBWSG due to interventions like MMS should *not* reduce mortality rates from causes unaffected by LBWSG like malaria and HIV (GBD says LBWSG PAF for these causes is zero), so we continue to calculate mortality due to unaffected causes according to unchanged baseline LBWSG exposure (even if there are intervention-associated changes)
- improvements in LBWSG due to interventions like MMS *should* reduce mortality rates from causes affected by LBWSG like LRI, so we use RRs specific intervention-shifted LBWSG exposure to calculate affected mortality rates

(I didn't specify it in the :math:`\sum_k \text{CSMR}_{i}^{k}` term, but we should follow the same baseline versus current LBWSG exposure pattern here too for affected versus unaffected causes).

This approach is still limited by: 
(1) the fact that the RRs are not cause-specific, so we are assuming they are the same for affected and unaffected causes (GBD is subject to this same limitation)
(2) we don't allow for any possibility that despite HIV/malaria _causing_ poor LBWSG exposure that a baby who has HIV/malaria and an _improved_ LBWSG exposure through interventions like MMS may still have a better outlook/lower chance of mortality. Again, GBD is still subject to this same limitation due to data issues and not being able to disentangle reverse causality from the overall association

So this is obviously not the perfect approach, but at least it is (a) consistent with GBD assumptions and (b) more consistent with how we have most recently modeled the impact of interventions that act through LBWSG.