### PR TITLE
Update VnV tracker with no-LBWSG and early NN observer bugfix runs 3.2 & 3.3

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -573,6 +573,13 @@ V&V Checks:
     - 10
     - 100,000
     - Locations include Pakistan, Nigeria, and Ethiopia. 10 seeds * 10,000 simulants = 100,000 total population.
+  * - 3.3
+    - Wave I Neonatal disorders V&V with early NN observer bugfix
+    - Complete
+    - N/A
+    - 10
+    - 100,000
+    - Locations include Pakistan, Nigeria, and Ethiopia. 10 seeds * 10,000 simulants = 100,000 total population.
 
 .. note:: 
   
@@ -626,7 +633,10 @@ V&V Checks:
     - Validate all-cause mortality for early and late neonatal age groups with LBWSG component removed 
     - Early neonatal mortality is still being overestimated in the simulation 
     - `Notebook linked here <https://github.com/ihmeuw/vivarium_research_mncnh_portfolio/blob/main/verification_and_validation/2025_2_26_vnv_neonatal_acmr.ipynb>`__
-
+  * - 3.3
+    - Validate all-cause mortality for early neonatal age group with observer bugfix
+    - Early neonatal mortality is validating now! 
+    - `Notebook linked here <https://github.com/ihmeuw/vivarium_research_mncnh_portfolio/blob/main/verification_and_validation/2025_2_27_vnv_neonatal_acmr.ipynb>`__
 
 .. _mncnh_portfolio_6.0:
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -622,7 +622,10 @@ V&V Checks:
     - Validate LBWSG exposure distribution
     - LBWSG distributions in artifact, GBD, and simulation are now matching, but preterm deaths still look too low in the simulation
     - `Notebook linked here <https://github.com/ihmeuw/vivarium_research_mncnh_portfolio/blob/main/verification_and_validation/lbwsg_distribution.ipynb>`__
-
+  * - 3.2
+    - Validate all-cause mortality for early and late neonatal age groups with LBWSG component removed 
+    - Early neonatal mortality is still being overestimated in the simulation 
+    - `Notebook linked here <https://github.com/ihmeuw/vivarium_research_mncnh_portfolio/blob/main/verification_and_validation/2025_2_26_vnv_neonatal_acmr.ipynb>`__
 
 
 .. _mncnh_portfolio_6.0:


### PR DESCRIPTION
With the observer bugfix, early neonatal ACMR is validating now: 
![image](https://github.com/user-attachments/assets/3912b92e-eff5-4c84-8997-b715436fc8e0)

Next step is to look into the CSMRs!

