### PR TITLE
Unpin Sphinx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# HACK: The <8.2.0 is a workaround for https://github.com/spatialaudio/nbsphinx/issues/825
-# Can be removed when nbsphinx is updated to support Sphinx 8.2.0
-sphinx<8.2.0
+sphinx
 sphinx-autobuild
 sphinx_rtd_theme
 nbsphinx


### PR DESCRIPTION
Note: it's not important to rebuild your environment with this change, as we still aren't building with Sphinx 8.2; rather, the pin has just [been pushed upstream for now](https://github.com/spatialaudio/nbsphinx/pull/828).