### PR TITLE
Update data limitations based on wave 1 data review

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
@@ -190,9 +190,7 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
 3.0 Assumptions and limitations
 ++++++++++++++++++++++++++++++++
 
-* The timing of ANC visits impacts the ability to accurately estimate gestational age, but we use an average instead. (Note: BMGF sent us data on the error distribution of ultrasound accuracy
-  based on gestational age so we should be able to address this limitation. We also found `a paper <https://obgyn.onlinelibrary.wiley.com/doi/10.1002/uog.15894>`_ that estimated uncertainty of 
-  GA dating by ultrasound was 6–7 days at 14 weeks' gestation, 12–14 days at 26 weeks' gestation and > 14 days in the third trimester.)
+* The timing of ANC visits impacts the ability to accurately estimate gestational age, but we use an average instead. 
 * The current version of the model does not include any false positive rates for pre-term or LBW. Since a false positive is unlikely to cause harm, only inclusion in higher level care, this seems sufficient. 
 * Single cohort of pregnancies does not allow for cyclic effects such as improved ANC visit rates due to ultrasound presence 
 * The data for baseline ultrasound utilization at the ANC is non-ideal for all of the locations. Our data for Ethiopia is most aligned with the value we are trying to find, as it comes from `a paper that
@@ -204,6 +202,23 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
 
   If more suitable baseline coverage data for standard ultrasound utilization at ANCs for Nigeria or Pakistan, we should use that data instead and update 
   this documentation accordingly.
+
+.. note:: 
+  BMGF sent us data on the error distribution of ultrasound accuracy based on gestational age so we should be able to address the first limitation.
+  We also found `a paper <https://obgyn.onlinelibrary.wiley.com/doi/10.1002/uog.15894>`_ that estimated uncertainty of GA dating by ultrasound was 6–7 
+  days at 14 weeks' gestation, 12–14 days at 26 weeks' gestation and > 14 days in the third trimester.
+
+  From Nathaniel: 
+  I think the gestational age in the BMGF data and the gestational age in the paper are actually referring to two different things, and we may want to take both types of variation into account:
+
+  The BMGF microdata compares the gestational age at birth estimated by ultrasound (given at some unknown time during the pregnancy) with gestational age at birth estimated by last menstrual period (LMP).
+  I think the paper compares the gestational age estimated by an ultrasound in late pregnancy at the time of the late ultrasound with the "true" gestational age at the time of the late ultrasound, determined 
+  from a combination of LMP and an ultrasound early in the pregnancy.
+  From the BMGF data, I was interested in seeing whether there was bias (nonzero 1st moment) or skew (nonzero 3rd moment) in the error distribution depending on the gestational age at birth. It looks like there is: 
+  For babies born early, you're more likely to overestimate their gestational age, whereas for babies born late, you're more likely to underestimate their gestational age (that is, when using LMP vs. an ultrasound).
+
+  From the literature, I'm interested in how the size of the variance (2nd moment) of the error changes with the timing of when the ultrasound is administered. We know that the variance is higher when the ultrasound 
+  is given later in pregnancy, and the paper quantifies how much higher.
 
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
@@ -191,9 +191,13 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
 3.0 Assumptions and limitations
 ++++++++++++++++++++++++++++++++
 
-* The timing of ANC visits impacts the ability to accurately estimate gestational age, but we use an average instead. 
+* The timing of ANC visits impacts the ability to accurately estimate gestational age, but we use an average instead. (Note: BMGF sent us data on the error distribution of ultrasound accuracy
+  based on gestational age so we should be able to address this limitation. We also found `a paper <https://obgyn.onlinelibrary.wiley.com/doi/10.1002/uog.15894>`_ that estimated uncertainty of 
+  GA dating by ultrasound was 6–7 days at 14 weeks' gestation, 12–14 days at 26 weeks' gestation and > 14 days in the third trimester.)
 * The current version of the model does not include any false positive rates for pre-term or LBW. Since a false positive is unlikely to cause harm, only inclusion in higher level care, this seems sufficient. 
 * Single cohort of pregnancies does not allow for cyclic effects such as improved ANC visit rates due to ultrasound presence 
+* The data for baseline ultrasound utilization at the ANC is non-ideal for all of the locations. Our data for Ethiopia is most aligned with the value we are trying to find, as it comes from `a paper that
+  estimates ultrasound utilization at ANC <https://pmc.ncbi.nlm.nih.gov/articles/PMC8905208/>`_. For Nigeria, our literature value is less trustworthy, coming from a paper that 
 
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
@@ -165,9 +165,8 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
 
 .. note::
   
-   Need further clarification on outstanding questions from BMGF, see `PR comments <https://github.com/ihmeuw/vivarium_research/pull/1525>`_. `Standard deviation value for no ultrasound <https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0272718#sec007>`_.
-
-   Values should be confirmed with further research and data anlaysis
+   BMGF sent us data on the error distribution of ultrasound accuracy based on gestational age so we could make this more accurate. 
+   (See first bullet in Limitations list below for more details.)
 
 
 
@@ -197,7 +196,10 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
 * The current version of the model does not include any false positive rates for pre-term or LBW. Since a false positive is unlikely to cause harm, only inclusion in higher level care, this seems sufficient. 
 * Single cohort of pregnancies does not allow for cyclic effects such as improved ANC visit rates due to ultrasound presence 
 * The data for baseline ultrasound utilization at the ANC is non-ideal for all of the locations. Our data for Ethiopia is most aligned with the value we are trying to find, as it comes from `a paper that
-  estimates ultrasound utilization at ANC <https://pmc.ncbi.nlm.nih.gov/articles/PMC8905208/>`_. For Nigeria, our literature value is less trustworthy, coming from a paper that 
+  estimates ultrasound utilization at ANC <https://pmc.ncbi.nlm.nih.gov/articles/PMC8905208/>`_. For Nigeria, our literature value is less trustworthy, coming from a paper that reports the percentage of 
+  study participants who had previously had an obstetric ultrasound. We were unable to find any value for Pakistan, instead using data from the India DHS 2015-2016 to inform our Pakistan ultrasound coverage.
+  India is probably not a great proxy for Pakistan, as use of ultrasound technology in India is heavily regulated (`see here <https://pmc.ncbi.nlm.nih.gov/articles/PMC5441446/#:~:text=In%20an%20attempt%20to%20curb,to%20facilitate%20sex%E2%80%93selective%20abortions>`__.).
+
 
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
@@ -196,7 +196,7 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
 * The current version of the model does not include any false positive rates for pre-term or LBW. Since a false positive is unlikely to cause harm, only inclusion in higher level care, this seems sufficient. 
 * Single cohort of pregnancies does not allow for cyclic effects such as improved ANC visit rates due to ultrasound presence 
 * The data for baseline ultrasound utilization at the ANC is non-ideal for all of the locations. Our data for Ethiopia is most aligned with the value we are trying to find, as it comes from `a paper that
-  estimates ultrasound utilization at ANC <https://pmc.ncbi.nlm.nih.gov/articles/PMC8905208/>`_. For Nigeria, our literature value is less trustworthy, coming from a paper that reports the percentage of 
+  estimates ultrasound utilization at ANC <https://pmc.ncbi.nlm.nih.gov/articles/PMC8905208/>`_, in a specific municipality of Jimma in Ethiopia. For Nigeria, our literature value is less trustworthy, coming from a paper that reports the percentage of 
   study participants who had previously had an obstetric ultrasound. We were unable to find any value for Pakistan, instead using data from the India DHS 2015-2016 to inform our Pakistan ultrasound coverage.
   India is probably not a great proxy for Pakistan, as use of ultrasound technology in India is heavily regulated (`see here <https://pmc.ncbi.nlm.nih.gov/articles/PMC5441446/#:~:text=In%20an%20attempt%20to%20curb,to%20facilitate%20sex%E2%80%93selective%20abortions>`__.).
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/ai_ultrasound_module/module_document.rst
@@ -200,6 +200,10 @@ We assume 100% of ultrasounds are standard (and 0% are AI-assisted) at baseline.
   study participants who had previously had an obstetric ultrasound. We were unable to find any value for Pakistan, instead using data from the India DHS 2015-2016 to inform our Pakistan ultrasound coverage.
   India is probably not a great proxy for Pakistan, as use of ultrasound technology in India is heavily regulated (`see here <https://pmc.ncbi.nlm.nih.gov/articles/PMC5441446/#:~:text=In%20an%20attempt%20to%20curb,to%20facilitate%20sex%E2%80%93selective%20abortions>`__.).
 
+.. todo::
+
+  If more suitable baseline coverage data for standard ultrasound utilization at ANCs for Nigeria or Pakistan, we should use that data instead and update 
+  this documentation accordingly.
 
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -540,6 +540,8 @@ Specific observer outputs and their stratifications may vary by model run as nee
     - 
   * - Ultrasound coverage counts (AI-assisted, standard, none)
     - 
+  * - Birth counts
+    - Delivery facility type, pregnancy outcome, child sex, scenario, and input draw
   * - Pregnancy term counts (full or partial)
     - 
   * - Maternal GBD age group counts

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -540,8 +540,6 @@ Specific observer outputs and their stratifications may vary by model run as nee
     - 
   * - Ultrasound coverage counts (AI-assisted, standard, none)
     - 
-  * - Birth counts
-    - Delivery facility type, pregnancy outcome, child sex, scenario, and input draw
   * - Pregnancy term counts (full or partial)
     - 
   * - Maternal GBD age group counts

--- a/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
@@ -205,6 +205,11 @@ Assumptions and Limitations
 - We are currently using a placeholder value for the relative risk of Lack-of-Access-to-Antibiotics on neonatal sepsis mortality, which is not 
   backed by literature. Further research is needed to find an appropriate value.
 
+  .. todo::
+
+  If more suitable baseline coverage data for antibiotics for neonatal sepsis at all facility types in all 3 locations, we should use that data instead and update 
+  this documentation accordingly. We also need to find a more trustworthy value for the relative risk of antibiotics on neonatal sepsis.
+
 Validation and Verification Criteria
 ------------------------------------
 

--- a/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
@@ -205,10 +205,11 @@ Assumptions and Limitations
 - We are currently using a placeholder value for the relative risk of Lack-of-Access-to-Antibiotics on neonatal sepsis mortality, which is not 
   backed by literature. Further research is needed to find an appropriate value.
 
-  .. todo::
+.. todo::
 
   If more suitable baseline coverage data for antibiotics for neonatal sepsis at all facility types in all 3 locations, we should use that data instead and update 
   this documentation accordingly. We also need to find a more trustworthy value for the relative risk of antibiotics on neonatal sepsis.
+
 
 Validation and Verification Criteria
 ------------------------------------

--- a/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
@@ -196,6 +196,12 @@ Assumptions and Limitations
 - We assume that the delivery facility is also the facility where a sick neonate will seek care for sepsis
 - We assume that the relative risk of sepsis mortality with antibiotics in practice is a value that we can find in the literature
 - We have excluded the effect of antibiotics on pneumonia mortality, because this cause is currently lumped with 'other causes'
+- Baseline coverage data for antibiotics in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. (These placeholder values come 
+  from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
+  Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal antibiotics; the 2016-2018 SARA Report 
+  found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal antibiotics.  While we plan a data strategy to 
+  fill the gaps we have used a simple average.)
+- We assume that baseline coverage for antibiotics in home births is 5% (this is not data-backed).
 
 Validation and Verification Criteria
 ------------------------------------

--- a/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
@@ -202,6 +202,8 @@ Assumptions and Limitations
   found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal antibiotics.  While we plan a data strategy to 
   fill the gaps we have used a simple average.)
 - We assume that baseline coverage for antibiotics in home births is 5% (this is not data-backed).
+- We are currently using a placeholder value for the relative risk of Lack-of-Access-to-Antibiotics on neonatal sepsis mortality, which is not 
+  backed by literature. Further research is needed to find an appropriate value.
 
 Validation and Verification Criteria
 ------------------------------------

--- a/docs/source/models/intervention_models/neonatal/cpap_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/cpap_intervention.rst
@@ -197,6 +197,8 @@ Assumptions and Limitations
 - We assume that CPAP availability captures actual use, and not simply the machine being in the facility 
 - We assume that the delivery facility is the final facility in the care continum for deliveries that are transferred due to complications
 - We assume that the relative risk of RDS mortality with CPAP in practice is similar to that found in the Cochrane Review meta-analysis
+- Baseline coverage data for CPAP in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2016 based on the EmONC Final Report. 
+  We assume that Nigeria and Pakistan health systems have the same CPAP availability.
 
 Validation and Verification Criteria
 ------------------------------------

--- a/docs/source/models/intervention_models/neonatal/cpap_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/cpap_intervention.rst
@@ -200,6 +200,11 @@ Assumptions and Limitations
 - Baseline coverage data for CPAP in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2016 based on the EmONC Final Report. 
   We assume that Nigeria and Pakistan health systems have the same CPAP availability.
 
+.. todo::
+
+  If more suitable baseline coverage data for CPAP availability at BEmONC and CEmONC for Nigeria or Pakistan, we should use that data instead and update 
+  this documentation accordingly.
+
 Validation and Verification Criteria
 ------------------------------------
 


### PR DESCRIPTION
Our key data gaps are: 
- RR of neonatal antibiotics on sepsis mortality*
- CPAP and neonatal antibiotics baseline coverage by delivery facility type (OK data for Ethiopia, no data for Nigeria or Pakistan)
- Standard ultrasound baseline coverage at ANC (OK literature value for Ethiopia, questionable lit value for Nigeria, none for Pakistan)
- Delivery facility choice by preterm status (Good data for Pakistan, questionable data for Ethiopia, no data for Nigeria)

*I'm currently trying to track down where Abie got the placeholder value for neonatal antibiotics RR on sepsis. The value I found in wave 1 data seeking is actually for prenatal/parental antibiotics effect on neonatal sepsis, which is not what we're looking for. 
