### PR TITLE
Write up documentation for azithromycin intervention

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -230,7 +230,7 @@ defined as a module input in a subsequent row.
     - * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`
       * Antenatal corticosteroid coverage
       * Misoprostol coverage
-    - TODO: create/link intervention model documents
+    - * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>` (TODO: link addition intervention model documents)
   * - :ref:`Maternal disorders <2024_vivarium_mncnh_portfolio_maternal_disorders_module>`
     - * (Pregnancy term duration)
       * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -264,7 +264,7 @@ defined as a module input in a subsequent row.
       - * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`
         * Antenatal corticosteroid coverage
         * Misoprostol coverage
-      - TODO: create/link intervention model documents
+      - * :ref:`Intrapartum azithromycin <azithromycin_intervention>` (TODO: link addition intervention model documents)
       - 
     * - :ref:`Maternal disorders <2024_vivarium_mncnh_portfolio_maternal_disorders_module>`
       - * (Pregnancy term duration)

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -561,7 +561,7 @@ Default stratifications to all observers should include scenario and input draw.
     - * Maternal age group
       * Pregnancy outcome
       * Azithromycin coverage
-      * Misoprostol coverage
+      * Misoprostol coverage (not ready for implementation yet) 
     - Included with maternal age group stratification. Additional stratifiers to be added
   * - 2. Births (this observer includes ALL pregnancy outcomes, including partial term pregnancies that may not typically be considered "births")
     - * Pregnancy outcome
@@ -595,6 +595,7 @@ Default stratifications to all observers should include scenario and input draw.
       * Pregnancy outcome
       * ANC attendance
       * Ultrasound coverage
+      * Azithromycin coverage
     - Included
 
 .. todo::

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -227,13 +227,13 @@ defined as a module input in a subsequent row.
     - * (Pregnancy term duration)
       * Birth facility
       * Believed gestational age
-    - * Intrapartum azithromycin coverage
+    - * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`
       * Antenatal corticosteroid coverage
       * Misoprostol coverage
     - TODO: create/link intervention model documents
   * - :ref:`Maternal disorders <2024_vivarium_mncnh_portfolio_maternal_disorders_module>`
     - * (Pregnancy term duration)
-      * Intrapartum azithromycin coverage
+      * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`
     - * Maternal disorders outcomes (see outcome table)
     - * :ref:`Overall maternal disorders <2021_cause_maternal_disorders_mncnh>`
       * :ref:`Maternal hemorrhage <2021_cause_maternal_hemorrhage_mncnh>`
@@ -261,14 +261,14 @@ defined as a module input in a subsequent row.
       - * (Pregnancy term duration)
         * Birth facility
         * Believed gestational age
-      - * Intrapartum azithromycin coverage
+      - * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`
         * Antenatal corticosteroid coverage
         * Misoprostol coverage
       - TODO: create/link intervention model documents
       - 
     * - :ref:`Maternal disorders <2024_vivarium_mncnh_portfolio_maternal_disorders_module>`
       - * (Pregnancy term duration)
-        * Intrapartum azithromycin coverage
+        * :ref:`Intrapartum azithromycin coverage <azithromycin_intervention>`
         * Hemoglobin at birth
       - * Maternal disorders outcomes (see outcome table)
       - * :ref:`Overall maternal disorders <2021_cause_maternal_disorders_mncnh>`

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/intrapartum_interventions/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/intrapartum_interventions/module_document.rst
@@ -108,14 +108,8 @@ This module in the intrapartum component determines coverage of intrapartum inte
 
 **Intrapartum azithromycin:** 
 
-  * Home birth: 10%
-
-  * Hospital birth: 67.7%
-
-  * Clinic/low-level birth: 18.5%
-
-Source: SARA (Ehtiopia; Table 3.8.2). These are placeholder values (percentage of each facility type that have azithromycin, not the percentage of pregnancies that receive it) and will be updated with further analysis. We want these to be location specific, please code accordingly.
-
+Please see :ref:`the azithromycin intervention documentation page <azithromycin_intervention>` for baseline coverage values for births at 
+home and in BEmONC and CEmONC facilities. 
 
 **Antenatal corticosteroids:** (percentage of believed preterm births)
 
@@ -176,7 +170,7 @@ Source: EmONC (Ethiopia; Table 10.5.4A). These are placeholder values and will b
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++
 
-* Confirm rates of simulants receiving azithromycin and corticosteroid matches inputs
+* See :ref:`the azithromycin intervention documentation page <azithromycin_intervention>` for V&V criteria.
 
 * Confirm no simulants believed to be >37 weeks gestational age at birth recieve corticosteroids
 

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/maternal_disorders_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/maternal_disorders_module/module_document.rst
@@ -68,10 +68,10 @@ There are specific variables that will affect these cause models, summarized in 
     - Instructions
     - Note
   * - Azithromycin coverage
-    - :ref:`Azithromycin intervention page <azithromycin_intervention>`
+    - :ref:`Intrapartum interventions <2024_vivarium_mncnh_portfolio_intrapartum_interventions_module>`
     - Maternal sepsis incidence rate
-    - Relative risk: 0.65 (95% CI: 0.55, 0.77)
-    - `Tita et al 2023 <https://www.ajog.org/article/S0002-9378(22)02210-4/fulltext#undfig1>`_ 
+    - See the :ref:`Azithromycin intervention page <azithromycin_intervention>`
+    - 
   * - Misoprostol coverage
     - :ref:`Intrapartum interventions <2024_vivarium_mncnh_portfolio_intrapartum_interventions_module>`
     - Maternal hemorrhage incidence rate

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/maternal_disorders_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/maternal_disorders_module/module_document.rst
@@ -68,7 +68,7 @@ There are specific variables that will affect these cause models, summarized in 
     - Instructions
     - Note
   * - Azithromycin coverage
-    - :ref:`Intrapartum interventions <2024_vivarium_mncnh_portfolio_intrapartum_interventions_module>`
+    - :ref:`Azithromycin intervention page <azithromycin_intervention>`
     - Maternal sepsis incidence rate
     - Relative risk: 0.65 (95% CI: 0.55, 0.77)
     - `Tita et al 2023 <https://www.ajog.org/article/S0002-9378(22)02210-4/fulltext#undfig1>`_ 
@@ -85,7 +85,7 @@ There are specific variables that will affect these cause models, summarized in 
 
 .. todo::
 
-  Make and link separate intervention module document for azithromycin with more specific instructions on how to implement this to replace information directly in this table (new document to include how to calibrate baseline coverage, potential need for stratifying by birth facility in baseline calibration, specific overview and limitations of intervention)
+  Make and link separate intervention module document for misoprostol with more specific instructions on how to implement this to replace information directly in this table (new document to include how to calibrate baseline coverage, potential need for stratifying by birth facility in baseline calibration, specific overview and limitations of intervention)
 
 .. note::
 
@@ -105,7 +105,7 @@ Incidence, mortality, YLDs, and YLLs due to cause-specific maternal disorders.
 +++++++++++++++++++++++++++++++++++++++++
 
 * Confirm outcomes for each maternal disorder (OL, sepsis, and hemorrhage) matches GBD data 
-* Confirm that relative risk of azithromycin on sepsis outcomes matches expectations
+* See :ref:`the azithromycin intervention documentation page <azithromycin_intervention>` for V&V criteria specific to azithromycin intervention model
 
 5.0 References
 +++++++++++++++

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -1,0 +1,227 @@
+.. _intervention_intrapartum_azithromycin:
+
+=============================================
+Antibiotics for treating bacterial infections
+=============================================
+
+.. contents::
+   :local:
+   :depth: 1
+
+.. list-table:: Abbreviations
+  :widths: 15 15 15
+  :header-rows: 1
+
+  * - Abbreviation
+    - Definition
+    - Note
+  * - BEmONC
+    - Basic emergency obstetric and neonatal care
+    - Operationalized as facilities without C-section capabilities
+  * - CEmONC
+    - Comprehensive emergency obstetric and neonatal care
+    - Operationalized as facilities with capabilities to perform  C-section
+  * - PAF
+    - Population Attributable Fraction
+    - 
+
+Intervention Overview
+-----------------------
+
+Antibiotics are used to treat bacterial infections in neonates, reducing the risk mortality.
+
+This section describes how an antibiotic-treatment intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
+
+.. list-table:: Affected Outcomes
+  :widths: 15 15 15 15
+  :header-rows: 1
+
+  * - Outcome
+    - Effect
+    - Modeled?
+    - Note (ex: is this relationship direct or mediated?)
+  * - Neonatal sepsis and other neonatal infections Mortality Probability :math:`\text{CSMR}_i^\text{sepsis}`
+    - Adjust multiplicatively using RR
+    - Yes
+    - For convenience, we will model this like a dichotomous risk factor; more details below
+
+Baseline Coverage Data
+++++++++++++++++++++++++
+
+These placeholder values come from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal antibiotics; the 2016-2018 SARA Report found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal antibiotics.  While we plan a data strategy to fill the gaps we have used a simple average.
+
+.. list-table:: Baseline Coverage of Neonatal Antibiotics (placeholder values)
+  :widths: 15 15 15 15
+  :header-rows: 1
+
+  * - Birth Facility
+    - Coverage Mean (%)
+    - Coverage Distribution (%)
+    - Notes
+  * - Home Birth
+    - 5
+    - :math:`\text{Uniform}(0,10)`
+    - Assumption; need to investigate data sources for care seeking among children born outside of the hospital system 
+  * - BEmONC Facilities
+    - 41.55
+    - :math:`\text{Uniform}(30.2,52.9)`
+    - placeholder value based on two data points 
+  * - CEmONC Facilities
+    - 87.0
+    - :math:`\text{Uniform}(76.8,97.2)`
+    - placeholder value based on two data points 
+
+
+Vivarium Modeling Strategy
+--------------------------
+
+This intervention requires adding an attribute to all simulants to specify if a neonate has access to a facility with access to antibiotics.  Since the neonatal mortality model does not explicitly represent incidence of sepsis, we will not track explicitly if a simulant receives antibiotics.  Instead the model will have different cause-specific mortality rates for sepsis for individuals with and without access to antibiotics (implemented with a slightly confusing application of our ``Risk`` and ``RiskEffect`` components from ``vivarium_public_health``).
+
+The ``Risk`` component adds an attribute to each simulant indicating whether the simulant has access to antibiotics during the neonatal period, which we assume will be closely related to the facility choice during birth, i.e. home births have much lower access than in-facility births, and births in BEmONC facilities have lower access than CEmONC facilities.
+
+To make this work naturally with the ``RiskEffect`` component, it is best to think of the risk as "lack of access to antibiotics".  With this framing, the ``RiskEffect`` component requires data on (1) the relative risk of sepsis mortality for people with lack of access to antibiotics, and (2) the population attributable fraction (PAF) of sepsis due to lack of access to antibiotics.  We will use the decision tree below to find the probability of sepsis mortality with and without access to antibiotics that are logically consistent with the baseline delivery facility rates and baseline antibiotics coverage.
+
+In Vivarium, this risk effect will modify the sepsis mortality pipeline, resulting in 
+
+.. math::
+
+   \text{CSMR}_i^\text{sepsis} = \text{CSMR}^\text{sepsis}_{\text{BW}_i, \text{GA}_i} \cdot (1 - \text{PAF}_\text{no antibiotics}) \cdot \text{RR}_i^\text{no antibiotics}
+
+where :math:`\text{RR}_i^\text{no antibiotics}` is simulant *i*'s individual relative risk for "no antibiotics", meaning :math:`\text{RR}_i^\text{no antibiotics} = \text{RR}_\text{no antibiotics}` if simulant *i* accesses a facility without antibiotics, and :math:`\text{RR}_i^\text{no antibiotics} = 1` if simulant *i* accesses a facility *with* antibiotics.
+
+If there are other interventions also affecting the CSMR of sepsis, the pipeline will combine these effects, and we can write out the math for this risk explicitly as 
+
+.. math::
+
+   \text{CSMR}^\text{sepsis}_{i, \text{updated}} = \text{CSMR}^\text{sepsis}_{i, \text{original}} \cdot (1 - \text{PAF}_\text{no antibiotics}) \cdot \text{RR}_i^\text{no antibiotics}
+
+This reduces to the previous formula if there are no other interventions, and we would have 
+
+.. math::
+
+   \text{CSMR}^\text{sepsis}_{i, \text{original}} = \text{CSMR}^\text{sepsis}_{\text{BW}_i, \text{GA}_i}
+
+While we are searching the literature for an appropriate value for the relative risk, we will use a stand-in value with an origin I have failed to record.
+
+.. list-table:: Risk Effect Parameters for Lack-of-Access-to-Antibiotics
+  :widths: 15 15 15 15
+  :header-rows: 1
+
+  * - Parameter
+    - Mean
+    - Distribution
+    - Notes
+  * - Relative Risk
+    - 1.39
+    - :math:`\text{Normal}(1.39,0.08^2)`
+    - Based on placeholder relative risk of 0.72 (95% CI 0.64-0.80) of sepsis mortality for neonates with access to antibiotics 
+  * - PAF
+    - see below
+    - see below
+    - see `Calibration strategy` section below for details on how to calculate PAF that is consistent with RR, risk exposure, and facility choice model
+
+Calibration Strategy
+--------------------
+
+The following decision tree shows all of the paths from delivery facility choice to antibiotics availability.  Distinct paths in the tree correspond to disjoint events, which we can sum over to find the population probability of sepsis mortality.  The goal here is to use internally consistent conditional probabilities of sepsis mortality for the subpopulations with and without access to antibiotics, so that the baseline scenario can track who has access to antibiotics and still match the baseline sepsis mortality rate.
+
+.. graphviz::
+
+    digraph antibiotics {
+        rankdir = LR;
+        facility [label="Facility type"]
+        home [label="p_sepsis_without_antibiotics"]
+        BEmONC [label="antibiotics?"]
+        CEmONC [label="antibiotics?"]
+        BEmONC_wo [label="p_sepsis_without_antibiotics"] 
+        BEmONC_w [label="p_sepsis_with_antibiotics"]
+        CEmONC_wo [label="p_sepsis_without_antibiotics"] 
+        CEmONC_w [label="p_sepsis_with_antibiotics"]
+
+        facility -> home  [label = "home birth"]
+        facility -> BEmONC  [label = "BEmONC"]
+        facility -> CEmONC  [label = "CEmONC"]
+
+        BEmONC -> BEmONC_w  [label = "available"]
+        BEmONC -> BEmONC_wo  [label = "unavailable"]
+
+        CEmONC -> CEmONC_w  [label = "available"]
+        CEmONC -> CEmONC_wo  [label = "unavailable"]
+    }
+
+.. math::
+    \begin{align*}
+        p(\text{sepsis}) 
+        &= \sum_{\text{paths without antibiotics}} p(\text{path})\cdot p(\text{sepsis}|\text{no antibiotics})\\
+        &+ \sum_{\text{paths with antibiotics}} p(\text{path})\cdot p(\text{sepsis}|\text{antibiotics})\\[.1in]
+        p(\text{sepsis}|\text{no antibiotics}) &= \text{RR}_\text{no antibiotics} \cdot p(\text{sepsis}|\text{antibiotics})
+    \end{align*}
+
+where :math:`p(\text{sepsis})` is the probability of dying from sepsis in the general population, and :math:`p(\text{sepsis}|\text{antibiotics})` and :math:`p(\text{sepsis}|\text{no antibiotics})` are the probability of dying from sepsis in setting with and without access to antibiotics.  For each path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has antibiotics available.
+
+When we fill in the location-specific values for delivery facility rates, antibiotics coverage, relative risk of mortality with antibiotics access, and mortality probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{sepsis}|\text{antibiotics})` and :math:`p(\text{sepsis}|\text{no antibiotics})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
+
+**Alternative PAF Derivation**: An alternative, and possibly simpler derivation of the PAF that will calibrate this model comes from the observation that :math:`\text{PAF} = 1 - \frac{1}{\mathbb{E}(\text{RR})}`.  If we define 
+
+.. math::
+
+   p(\text{no antibiotics}) = \sum_{\text{paths without antibiotics}} p(\text{path}),
+
+then can use this to expand the identity
+
+.. math::
+
+   \text{PAF}_\text{no antibiotics} = 1 - \frac{1}{\mathbb{E}(\text{RR})}.
+
+Since our risk exposure has two categories,
+
+.. math::
+
+   \mathbb{E}(\text{RR}) = p(\text{no antibiotics}) \cdot \text{RR}_\text{no antibiotics} + (1 - p(\text{no antibiotics})) \cdot 1.
+
+
+
+Scenarios
+---------
+
+.. todo::
+
+  Describe our general approach to scenarios, for example set coverage to different levels in different types of health facilities; then the specific values for specific scenarios will be specified in the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
+
+
+Assumptions and Limitations
+---------------------------
+
+- We assume that antibiotics availability captures actual use, and not simply the treatment being in the facility 
+- We assume that the delivery facility is also the facility where a sick neonate will seek care for sepsis
+- We assume that the relative risk of sepsis mortality with antibiotics in practice is a value that we can find in the literature
+- We have excluded the effect of antibiotics on pneumonia mortality, because this cause is currently lumped with 'other causes'
+- Baseline coverage data for antibiotics in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. (These placeholder values come 
+  from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
+  Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal antibiotics; the 2016-2018 SARA Report 
+  found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal antibiotics.  While we plan a data strategy to 
+  fill the gaps we have used a simple average.)
+- We assume that baseline coverage for antibiotics in home births is 5% (this is not data-backed).
+- We are currently using a placeholder value for the relative risk of Lack-of-Access-to-Antibiotics on neonatal sepsis mortality, which is not 
+  backed by literature. Further research is needed to find an appropriate value.
+
+.. todo::
+
+  If more suitable baseline coverage data for antibiotics for neonatal sepsis at all facility types in all 3 locations, we should use that data instead and update 
+  this documentation accordingly. We also need to find a more trustworthy value for the relative risk of antibiotics on neonatal sepsis.
+
+
+Validation and Verification Criteria
+------------------------------------
+
+- Population-level mortality rate should be the same as when this intervention is not included in the model
+- The ratio of sepsis deaths per birth among those without antibiotics access divided by those with antibiotics access should equal the relative risk parameter used in the model
+- The baseline coverage of antibiotics in each facility type should match the values in the artifact
+- Validation: how does the sepsis moratlity rate in a counterfactual scenario with 100% antibiotic access compare to sepsis mortality rates in high-income countries?  They should be close, and the counterfactual should not be lower.
+
+References
+------------
+
+* https://chatgpt.com/share/67c1c7cf-f294-8010-8e65-261f87039e3b
+* https://chatgpt.com/share/67c1c7f9-8230-8010-9ade-30ed07b06bd0
+

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -58,9 +58,9 @@ See the :ref:`Maternal sepsis and other maternal infections cause model <2021_ca
 Baseline Coverage Data
 ++++++++++++++++++++++++
 
-It appears rare for prophylactic azithromycin during labor to be offered in African settings, so for both BEmONC and CEmONC in Nigeria and Ethiopia, we will use baseline coverage of 
-0% as a stand-in value while we search for additional evidence. Pakistan BEmONC settings also have a baseline coverage of 0%, but CEmONC settings should have 
-a baseline coverage of 20.3% according to [Saleem-et-al-2025-intrapartum-antibiotic-use]_.
+It appears rare for prophylactic azithromycin during labor to be offered in African settings, so for both BEmONC and CEmONC in Nigeria and Ethiopia, we will use 
+a baseline coverage of 0% as a stand-in value while we search for additional evidence. Pakistan BEmONC settings also have a baseline coverage of 0%, but CEmONC
+settings in Pakistan should have a baseline coverage of 20.3% according to [Saleem-et-al-2025-intrapartum-antibiotic-use]_.
 
 
 .. list-table:: Baseline Coverage of intrapartum azithromycin
@@ -91,7 +91,7 @@ a baseline coverage of 20.3% according to [Saleem-et-al-2025-intrapartum-antibio
     - CEmONC Facilities
     - 20.3
     - :math:`\text{Uniform}(15.3,25.3)`
-    - 
+    - Value pulled from [Saleem-et-al-2025-intrapartum-antibiotic-use]_
 
 
 Vivarium Modeling Strategy
@@ -229,17 +229,16 @@ Assumptions and Limitations
 - We also do not currently model the impact intrapartum azithromycin has on preventing maternal sepsis in partial term pregnancies. In our 
   :ref:`Maternal sepsis and other maternal infections cause model <2021_cause_maternal_sepsis_mncnh>`, we only model full term pregnancies as 
   at-risk for maternal sepsis.
-- Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These placeholder values come 
-  from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
-  Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
-  found 68.4% of BEmONC facilities and 90.5% of CEmONC facilities have azithromycin; the 2018 SARA Report found 75.9% of BEmONC facilities
-  and 98.0% of CEmONC facilities have azithromycin. While we plan a data strategy to fill the gaps we have used a simple average.
-- We assume that baseline coverage for azithromycin in home births is 5% (this is not data-backed).
+- We assume that [Saleem-et-al-2025-intrapartum-antibiotic-use]_ provides an accurate overview of prophylactic intrampratum antibiotic use in our locations of interest.
+  As such, we assume baseline coverage of intrapartum azithromycin use in African sites is basically zero (despite EmONC 2016, SARA 2016, and SARA 2018 reporting the
+  presence of intrapartum antibiotics in hospitals to be nonzero - we assume these are given to mothers or birthing parents after delivery, which is not the intervention
+  we are modeling here). There was a baseline coverage of 20.3% for Pakistan hospitals though, which we assume is accurate.
+- We assume that baseline coverage for azithromycin in home births is 0% (this is not data-backed).
 
 .. todo::
 
-  - If more suitable baseline coverage data for azithromycin for maternal sepsis at all facility types for Nigeria and Pakistan, we should use that data instead and update 
-    this documentation accordingly. 
+  - If more suitable baseline coverage data for azithromycin for maternal sepsis in CEmONC settings for Nigeria and Ethiopia or BEmONC settings for all locations, 
+    we will update accordingly.
   - We need to decide if/how we would model the effect of intrapartum azithromycin on preterm incidence. 
 
 Validation and Verification Criteria

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -46,7 +46,7 @@ This section describes how an azithromycin intervention can be implemented and c
     - Effect
     - Modeled?
     - Note (ex: is this relationship direct or mediated?)
-  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{CSMR}_i^\text{sepsis}`
+  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{IR}_i^\text{sepsis}`
     - Adjust multiplicatively using RR
     - Yes
     - For convenience, we will model this like a dichotomous risk factor; more details below

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -179,9 +179,9 @@ incidence rate.
     \end{align*}
 
 where :math:`p(\text{maternal_sepsis})` is the probability of contracting maternal sepsis in the general population, and :math:`p(\text{maternal_sepsis}|\text{azithromycin})` and
- :math:`p(\text{maternal_sepsis}|\text{no azithromycin})` are the probability of contracting maternal sepsis in settings with and without receiving prophylactic azithromycin.  For each 
- path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and 
- unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the simulant receives prophylactic azithromycin.
+:math:`p(\text{maternal_sepsis}|\text{no azithromycin})` are the probability of contracting maternal sepsis in settings with and without receiving prophylactic azithromycin.  For each 
+path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and 
+unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the simulant receives prophylactic azithromycin.
 
 When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of maternal sepsis incidence with azithromycin, 
 and maternal sepsis incidence probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{maternal_sepsis}|\text{azithromycin})` 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -24,11 +24,17 @@ Azithromycin for treating maternal sepsis
   * - PAF
     - Population Attributable Fraction
     - 
+  * - RR
+    - Relative Risk
+    - 
+  * - SARA
+    - Services Availabiity and Readiness Assessment
+    - 
 
 Intervention Overview
 -----------------------
 
-Azithromycin is used to treat maternal sepsis in the intrapartum period, reducing the risk incidence.
+Azithromycin is used to prevent maternal sepsis in the intrapartum period, reducing the risk incidence.
 
 This section describes how an azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -109,7 +109,7 @@ In Vivarium, this risk effect will modify the maternal sepsis incidence pipeline
    \text{IR}_i^\text{maternal sepsis} = \text{IR}^\text{maternal sepsis}_ \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
 
 where :math:`\text{RR}_i^\text{no azithromycin}` is simulant *i*'s individual relative risk for "no azithromycin", meaning :math:`\text{RR}_i^\text{no azithromycin} = \text{RR}_\text{no azithromycin}` 
-if simulant *i* accesses a facility without azithromycin, and :math:`\text{RR}_i^\text{no azithromycin} = 1` if simulant *i* accesses a facility *with* azithromycin.
+if simulant *i* accesses a facility without azithromycin, and :math:`\text{RR}_i^\text{no azithromycin} = 1` if simulant *i* accesses a facility *with* azithromycin. 
 
 The relative risk value we will use is pulled from `this 2024 systematic review/meta-analysis <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_ 
 that investigated the effect of azithromycin during labor.
@@ -246,10 +246,11 @@ Validation and Verification Criteria
 References
 ------------
 
-* https://chatgpt.com/share/67c1c7cf-f294-8010-8e65-261f87039e3b
-* https://chatgpt.com/share/67c1c7f9-8230-8010-9ade-30ed07b06bd0
-* https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.
-* https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/ 
-* https://link.springer.com/article/10.1007/s40261-022-01203-0
+.. [Ye-et-al-2024-azithromycin-during-labor]
+  Ye, H., Hu, J., Li, B. et al. Can the use of azithromycin during labour reduce the incidence of infection among puerperae and newborns? A systematic review and meta-analysis of randomized controlled trials. BMC Pregnancy Childbirth 24, 200 (2024). `<https://doi.org/10.1186/s12884-024-06390-6>`_
 
+.. [Hume-Nizon-et-al-2021-azithromycin-during-pregnancy]
+  Hume-Nixon M, Quach A, Reyburn R, Nguyen C, Steer A, Russell F. A Systematic Review and meta-analysis of the effect of administration of azithromycin during pregnancy on perinatal and neonatal outcomes. EClinicalMedicine. 2021 Sep 9;40:101123. doi: 10.1016/j.eclinm.2021.101123. PMID: 34541478; PMCID: PMC8436060.
 
+.. [Antonucci-et-al-2022-azithromycin-during-pregnancy]
+  Antonucci, R., Cuzzolin, L., Locci, C. et al. Use of Azithromycin in Pregnancy: More Doubts than Certainties. Clin Drug Investig 42, 921–935 (2022). https://doi.org/10.1007/s40261-022-01203-0

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -40,7 +40,7 @@ This section describes how an azithromycin intervention can be implemented and c
     - Effect
     - Modeled?
     - Note (ex: is this relationship direct or mediated?)
-  * - Neonatal sepsis and other neonatal infections Mortality Probability :math:`\text{CSMR}_i^\text{sepsis}`
+  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{CSMR}_i^\text{sepsis}`
     - Adjust multiplicatively using RR
     - Yes
     - For convenience, we will model this like a dichotomous risk factor; more details below
@@ -48,9 +48,14 @@ This section describes how an azithromycin intervention can be implemented and c
 Baseline Coverage Data
 ++++++++++++++++++++++++
 
-These placeholder values come from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal azithromycin; the 2016-2018 SARA Report found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal azithromycin.  While we plan a data strategy to fill the gaps we have used a simple average.
+Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These 
+placeholder values come from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 
+Ethiopia EmONC Final Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
+found 68.4% of BEmONC facilities and 90.5% of CEmONC facilities have azithromycin; the 2018 SARA Report found 75.9% of BEmONC 
+facilities and 98.0% of CEmONC facilities have azithromycin. While we plan a data strategy to fill the gaps we have used a simple 
+average.
 
-.. list-table:: Baseline Coverage of Neonatal azithromycin (placeholder values)
+.. list-table:: Baseline Coverage of intrapartum azithromycin
   :widths: 15 15 15 15
   :header-rows: 1
 
@@ -61,15 +66,15 @@ These placeholder values come from two data sources, both for Ethiopia, both ide
   * - Home Birth
     - 5
     - :math:`\text{Uniform}(0,10)`
-    - Assumption; need to investigate data sources for care seeking among children born outside of the hospital system 
+    - Assumption; need to investigate data sources for care seeking those giving birth outside of the hospital system 
   * - BEmONC Facilities
-    - 41.55
-    - :math:`\text{Uniform}(30.2,52.9)`
-    - placeholder value based on two data points 
+    - 61.2
+    - :math:`\text{Uniform}(39.2,75.9)`
+    - placeholder value based on three data points 
   * - CEmONC Facilities
-    - 87.0
-    - :math:`\text{Uniform}(76.8,97.2)`
-    - placeholder value based on two data points 
+    - 93.0
+    - :math:`\text{Uniform}(90.4,98.0)`
+    - placeholder value based on three data points 
 
 
 Vivarium Modeling Strategy
@@ -215,6 +220,9 @@ Assumptions and Limitations
 - We assume that the relative risk of sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
   the value we are using is from `this systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
 - We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'
+- We currenty do not model the impact of intrapartum azithromycin on the incidence of preterm births, although there is literature
+  evidence that suggests there may be a significant impact. For reference, this `2021 systematic review <https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/>`_
+  found an RR of 0.79 (95% CI 0.68-0.93) for LBW and an RR of 0.87 (95% CI 0.78-0.98) for premature births.
 - Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These placeholder values come 
   from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
   Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
@@ -225,16 +233,16 @@ Assumptions and Limitations
 .. todo::
 
   If more suitable baseline coverage data for azithromycin for maternal sepsis at all facility types for Nigeria and Pakistan, we should use that data instead and update 
-  this documentation accordingly. We also need to find a more trustworthy value for the relative risk of azithromycin on neonatal sepsis.
-
+  this documentation accordingly. We also need to decide if/how we would model the effect of intrapartum azithromycin on preterm incidence. 
 
 Validation and Verification Criteria
 ------------------------------------
 
-- Population-level mortality rate should be the same as when this intervention is not included in the model
-- The ratio of sepsis deaths per birth among those without azithromycin access divided by those with azithromycin access should equal the relative risk parameter used in the model
+- Population-level incidence rate should be the same as when this intervention is not included in the model
+- The ratio of maternal sepsis incidence among those without azithromycin access divided by those with azithromycin access 
+  should equal the relative risk parameter used in the model
 - The baseline coverage of azithromycin in each facility type should match the values in the artifact
-- Validation: how does the sepsis moratlity rate in a counterfactual scenario with 100% antibiotic access compare to sepsis mortality rates in high-income countries?  They should be close, and the counterfactual should not be lower.
+- Validation: how does the sepsis incidence rate in a counterfactual scenario with 100% antibiotic access compare to sepsis incidence rates in high-income countries?  They should be close, and the counterfactual should not be lower.
 
 References
 ------------
@@ -242,4 +250,6 @@ References
 * https://chatgpt.com/share/67c1c7cf-f294-8010-8e65-261f87039e3b
 * https://chatgpt.com/share/67c1c7f9-8230-8010-9ade-30ed07b06bd0
 * https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.
+* https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/ 
+
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -34,7 +34,8 @@ Azithromycin for treating maternal sepsis
 Intervention Overview
 -----------------------
 
-Azithromycin is used to prevent maternal sepsis in the intrapartum period, reducing the risk incidence.
+Azithomycin is an oral or intravenous single-dose antibiotic taken before labour for the prevention of maternal sepsis and other maternal infections 
+after vaginal delivery and caesarean section, reducing the risk incidence. 
 
 This section describes how an azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
 See the :ref:`Maternal sepsis and other maternal infections cause model <2021_cause_maternal_sepsis_mncnh>` for relevant details.

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -48,9 +48,9 @@ This section describes how an azithromycin intervention can be implemented and c
 Baseline Coverage Data
 ++++++++++++++++++++++++
 
-These placeholder values come from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal antibiotics; the 2016-2018 SARA Report found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal antibiotics.  While we plan a data strategy to fill the gaps we have used a simple average.
+These placeholder values come from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal azithromycin; the 2016-2018 SARA Report found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal azithromycin.  While we plan a data strategy to fill the gaps we have used a simple average.
 
-.. list-table:: Baseline Coverage of Neonatal Antibiotics (placeholder values)
+.. list-table:: Baseline Coverage of Neonatal azithromycin (placeholder values)
   :widths: 15 15 15 15
   :header-rows: 1
 
@@ -172,30 +172,30 @@ incidence rate.
 where :math:`p(\text{sepsis})` is the probability of contracting sepsis in the general population, and :math:`p(\text{sepsis}|\text{azithromycin})` and
  :math:`p(\text{sepsis}|\text{no azithromycin})` are the probability of contracting sepsis in settings with and without access to azithromycin.  For each 
  path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and 
- unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has antibiotics available.
+ unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has azithromycin available.
 
-When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of mortality with azithromycin access, 
-and mortality probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{sepsis}|\text{antibiotics})` 
-and :math:`p(\text{sepsis}|\text{no antibiotics})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
+When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of sepsis incidence with azithromycin access, 
+and sepsis incidence probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{sepsis}|\text{azithromycin})` 
+and :math:`p(\text{sepsis}|\text{no azithromycin})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
 
 **Alternative PAF Derivation**: An alternative, and possibly simpler derivation of the PAF that will calibrate this model comes from the observation that
 :math:`\text{PAF} = 1 - \frac{1}{\mathbb{E}(\text{RR})}`.  If we define 
 
 .. math::
 
-   p(\text{no antibiotics}) = \sum_{\text{paths without antibiotics}} p(\text{path}),
+   p(\text{no azithromycin}) = \sum_{\text{paths without azithromycin}} p(\text{path}),
 
 then can use this to expand the identity
 
 .. math::
 
-   \text{PAF}_\text{no antibiotics} = 1 - \frac{1}{\mathbb{E}(\text{RR})}.
+   \text{PAF}_\text{no azithromycin} = 1 - \frac{1}{\mathbb{E}(\text{RR})}.
 
 Since our risk exposure has two categories,
 
 .. math::
 
-   \mathbb{E}(\text{RR}) = p(\text{no antibiotics}) \cdot \text{RR}_\text{no antibiotics} + (1 - p(\text{no antibiotics})) \cdot 1.
+   \mathbb{E}(\text{RR}) = p(\text{no azithromycin}) \cdot \text{RR}_\text{no azithromycin} + (1 - p(\text{no azithromycin})) \cdot 1.
 
 
 
@@ -210,31 +210,30 @@ Scenarios
 Assumptions and Limitations
 ---------------------------
 
-- We assume that antibiotics availability captures actual use, and not simply the treatment being in the facility 
-- We assume that the delivery facility is also the facility where a sick neonate will seek care for sepsis
-- We assume that the relative risk of sepsis mortality with antibiotics in practice is a value that we can find in the literature
-- We have excluded the effect of antibiotics on pneumonia mortality, because this cause is currently lumped with 'other causes'
-- Baseline coverage data for antibiotics in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. (These placeholder values come 
-  from two data sources, both for Ethiopia, both identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
-  Report found 30.2% of BEmONC facilities and 76.8% of CEmONC facilities have neonatal antibiotics; the 2016-2018 SARA Report 
-  found 52.9% of BEmONC facilities and 97.2% of CEmONC facilities have neonatal antibiotics.  While we plan a data strategy to 
-  fill the gaps we have used a simple average.)
-- We assume that baseline coverage for antibiotics in home births is 5% (this is not data-backed).
-- We are currently using a placeholder value for the relative risk of Lack-of-Access-to-Antibiotics on neonatal sepsis mortality, which is not 
-  backed by literature. Further research is needed to find an appropriate value.
+- We assume that azithromycin availability captures actual use, and not simply the treatment being in the facility 
+- We assume that the delivery facility is also the facility where a mother or birthing person will seek care for sepsis
+- We assume that the relative risk of sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
+  the value we are using is from `this systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
+- We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'
+- Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These placeholder values come 
+  from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
+  Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
+  found 68.4% of BEmONC facilities and 90.5% of CEmONC facilities have azithromycin; the 2018 SARA Report found 75.9% of BEmONC facilities
+  and 98.0% of CEmONC facilities have azithromycin. While we plan a data strategy to fill the gaps we have used a simple average.
+- We assume that baseline coverage for azithromycin in home births is 5% (this is not data-backed).
 
 .. todo::
 
-  If more suitable baseline coverage data for antibiotics for neonatal sepsis at all facility types in all 3 locations, we should use that data instead and update 
-  this documentation accordingly. We also need to find a more trustworthy value for the relative risk of antibiotics on neonatal sepsis.
+  If more suitable baseline coverage data for azithromycin for maternal sepsis at all facility types for Nigeria and Pakistan, we should use that data instead and update 
+  this documentation accordingly. We also need to find a more trustworthy value for the relative risk of azithromycin on neonatal sepsis.
 
 
 Validation and Verification Criteria
 ------------------------------------
 
 - Population-level mortality rate should be the same as when this intervention is not included in the model
-- The ratio of sepsis deaths per birth among those without antibiotics access divided by those with antibiotics access should equal the relative risk parameter used in the model
-- The baseline coverage of antibiotics in each facility type should match the values in the artifact
+- The ratio of sepsis deaths per birth among those without azithromycin access divided by those with azithromycin access should equal the relative risk parameter used in the model
+- The baseline coverage of azithromycin in each facility type should match the values in the artifact
 - Validation: how does the sepsis moratlity rate in a counterfactual scenario with 100% antibiotic access compare to sepsis mortality rates in high-income countries?  They should be close, and the counterfactual should not be lower.
 
 References
@@ -242,4 +241,5 @@ References
 
 * https://chatgpt.com/share/67c1c7cf-f294-8010-8e65-261f87039e3b
 * https://chatgpt.com/share/67c1c7f9-8230-8010-9ade-30ed07b06bd0
+* https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -46,7 +46,7 @@ This section describes how an azithromycin intervention can be implemented and c
     - Effect
     - Modeled?
     - Note (ex: is this relationship direct or mediated?)
-  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{IcR}_i^\text{sepsis}`
+  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{IcR}_i^\text{maternal sepsis}`
     - Adjust multiplicatively using RR
     - Yes
     - For convenience, we will model this like a dichotomous risk factor; more details below
@@ -87,7 +87,7 @@ Vivarium Modeling Strategy
 --------------------------
 
 This intervention requires adding an attribute to all simulants to specify if a pregnant person has access to a facility with access to azithromycin.  We will track if a simulant has access to azithromycin 
-and the model will have different incidence rates for sepsis for individuals with and without access to azithromycin (implemented with a slightly confusing application of our ``Risk`` and ``RiskEffect`` 
+and the model will have different incidence rates for maternal sepsis for individuals with and without access to azithromycin (implemented with a slightly confusing application of our ``Risk`` and ``RiskEffect`` 
 components from ``vivarium_public_health``).
 
 The ``Risk`` component adds an attribute to each simulant indicating whether the simulant has access to azithromycin during the intrapartum period, which we assume will be closely 
@@ -95,30 +95,30 @@ related to the facility choice during birth, i.e. home births have much lower ac
 facilities.
 
 To make this work naturally with the ``RiskEffect`` component, it is best to think of the risk as "lack of access to azithromycin".  With this framing, the ``RiskEffect`` 
-component requires data on (1) the relative risk of sepsis incidence for people with lack of access to azithromycin, and (2) the population attributable fraction (PAF) of sepsis 
-due to lack of access to azithromycin.  We will use the decision tree below to find the probability of sepsis incidence with and without access to azithromycin that are logically 
+component requires data on (1) the relative risk of maternal sepsis incidence for people with lack of access to azithromycin, and (2) the population attributable fraction (PAF) of maternal sepsis 
+due to lack of access to azithromycin.  We will use the decision tree below to find the probability of maternal sepsis incidence with and without access to azithromycin that are logically 
 consistent with the baseline delivery facility rates and baseline azithromycin coverage.
 
-In Vivarium, this risk effect will modify the sepsis incidence pipeline, resulting in 
+In Vivarium, this risk effect will modify the maternal sepsis incidence pipeline, resulting in 
 
 .. math::
 
-   \text{IR}_i^\text{sepsis} = \text{IR}^\text{sepsis}_ \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
+   \text{IR}_i^\text{maternal sepsis} = \text{IR}^\text{maternal sepsis}_ \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
 
 where :math:`\text{RR}_i^\text{no azithromycin}` is simulant *i*'s individual relative risk for "no azithromycin", meaning :math:`\text{RR}_i^\text{no azithromycin} = \text{RR}_\text{no azithromycin}` 
 if simulant *i* accesses a facility without azithromycin, and :math:`\text{RR}_i^\text{no azithromycin} = 1` if simulant *i* accesses a facility *with* azithromycin.
 
-If there are other interventions also affecting the IR of sepsis, the pipeline will combine these effects, and we can write out the math for this risk explicitly as 
+If there are other interventions also affecting the IR of maternal sepsis, the pipeline will combine these effects, and we can write out the math for this risk explicitly as 
 
 .. math::
 
-   \text{IR}^\text{sepsis}_{i, \text{updated}} = \text{IR}^\text{sepsis}_{i, \text{original}} \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
+   \text{IR}^\text{maternal sepsis}_{i, \text{updated}} = \text{IR}^\text{maternal sepsis}_{i, \text{original}} \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
 
 This reduces to the previous formula if there are no other interventions, and we would have 
 
 .. math::
 
-   \text{IR}^\text{sepsis}_{i, \text{original}} = \text{IR}^\text{sepsis}_
+   \text{IR}^\text{maternal sepsis}_{i, \text{original}} = \text{IR}^\text{maternal sepsis}_
 
 
 The relative risk value we will use is pulled from `this 2024 systematic review/meta-analysis <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_ 
@@ -135,7 +135,7 @@ that investigated the effect of azithromycin during labor.
   * - Relative Risk
     - 1.54
     - :math:`\text{Normal}(1.54,0.08^2)`
-    - Based on placeholder relative risk of 0.65 (95% CI 0.55-0.77) on sepsis incidence for pregnant people with access to azithromycin
+    - Based on placeholder relative risk of 0.65 (95% CI 0.55-0.77) on maternal sepsis incidence for pregnant people with access to azithromycin
   * - PAF
     - see below
     - see below
@@ -145,8 +145,8 @@ Calibration Strategy
 --------------------
 
 The following decision tree shows all of the paths from delivery facility choice to azithromycin availability.  Distinct paths in the tree correspond to disjoint events, 
-which we can sum over to find the population probability of sepsis incidence.  The goal here is to use internally consistent conditional probabilities of sepsis incidence
-for the subpopulations with and without access to azithromycin, so that the baseline scenario can track who has access to azithromycin and still match the baseline sepsis 
+which we can sum over to find the population probability of maternal sepsis incidence.  The goal here is to use internally consistent conditional probabilities of maternal sepsis incidence
+for the subpopulations with and without access to azithromycin, so that the baseline scenario can track who has access to azithromycin and still match the baseline maternal sepsis 
 incidence rate.
 
 .. graphviz::
@@ -154,13 +154,13 @@ incidence rate.
     digraph azithromycin {
         rankdir = LR;
         facility [label="Facility type"]
-        home [label="p_sepsis_without_azithromycin"]
+        home [label="p_maternal_sepsis_without_azithromycin"]
         BEmONC [label="azithromycin?"]
         CEmONC [label="azithromycin?"]
-        BEmONC_wo [label="p_sepsis_without_azithromycin"] 
-        BEmONC_w [label="p_sepsis_with_azithromycin"]
-        CEmONC_wo [label="p_sepsis_without_azithromycin"] 
-        CEmONC_w [label="p_sepsis_with_azithromycin"]
+        BEmONC_wo [label="p_maternal_sepsis_without_azithromycin"] 
+        BEmONC_w [label="p_maternal_sepsis_with_azithromycin"]
+        CEmONC_wo [label="p_maternal_sepsis_without_azithromycin"] 
+        CEmONC_w [label="p_maternal_sepsis_with_azithromycin"]
 
         facility -> home  [label = "home birth"]
         facility -> BEmONC  [label = "BEmONC"]
@@ -175,20 +175,20 @@ incidence rate.
 
 .. math::
     \begin{align*}
-        p(\text{sepsis}) 
-        &= \sum_{\text{paths without azithromycin}} p(\text{path})\cdot p(\text{sepsis}|\text{no azithromycin})\\
-        &+ \sum_{\text{paths with azithromycin}} p(\text{path})\cdot p(\text{sepsis}|\text{azithromycin})\\[.1in]
-        p(\text{sepsis}|\text{no azithromycin}) &= \text{RR}_\text{no azithromycin} \cdot p(\text{sepsis}|\text{azithromycin})
+        p(\text{maternal_sepsis}) 
+        &= \sum_{\text{paths without azithromycin}} p(\text{path})\cdot p(\text{maternal_sepsis}|\text{no azithromycin})\\
+        &+ \sum_{\text{paths with azithromycin}} p(\text{path})\cdot p(\text{maternal_sepsis}|\text{azithromycin})\\[.1in]
+        p(\text{maternal_sepsis}|\text{no azithromycin}) &= \text{RR}_\text{no azithromycin} \cdot p(\text{maternal_sepsis}|\text{azithromycin})
     \end{align*}
 
-where :math:`p(\text{sepsis})` is the probability of contracting sepsis in the general population, and :math:`p(\text{sepsis}|\text{azithromycin})` and
- :math:`p(\text{sepsis}|\text{no azithromycin})` are the probability of contracting sepsis in settings with and without access to azithromycin.  For each 
+where :math:`p(\text{maternal_sepsis})` is the probability of contracting maternal sepsis in the general population, and :math:`p(\text{maternal_sepsis}|\text{azithromycin})` and
+ :math:`p(\text{maternal_sepsis}|\text{no azithromycin})` are the probability of contracting maternal sepsis in settings with and without access to azithromycin.  For each 
  path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and 
  unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has azithromycin available.
 
-When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of sepsis incidence with azithromycin access, 
-and sepsis incidence probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{sepsis}|\text{azithromycin})` 
-and :math:`p(\text{sepsis}|\text{no azithromycin})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
+When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of maternal sepsis incidence with azithromycin access, 
+and maternal sepsis incidence probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{maternal_sepsis}|\text{azithromycin})` 
+and :math:`p(\text{maternal_sepsis}|\text{no azithromycin})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
 
 **Alternative PAF Derivation**: An alternative, and possibly simpler derivation of the PAF that will calibrate this model comes from the observation that
 :math:`\text{PAF} = 1 - \frac{1}{\mathbb{E}(\text{RR})}`.  If we define 
@@ -223,8 +223,8 @@ Assumptions and Limitations
 ---------------------------
 
 - We assume that azithromycin availability captures actual use, and not simply the treatment being in the facility. 
-- We assume that the delivery facility is also the facility where a mother or birthing person will seek care for sepsis.
-- We assume that the relative risk of sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
+- We assume that the delivery facility is also the facility where a mother or birthing person will seek care for maternal sepsis.
+- We assume that the relative risk of maternal sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
   the value we are using is from `this 2024 systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
 - We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'.
 - We currenty do not model the impact of intrapartum azithromycin on the incidence of preterm births, despite *some* literature
@@ -252,7 +252,7 @@ Validation and Verification Criteria
 - The ratio of maternal sepsis incidence among those without azithromycin access divided by those with azithromycin access 
   should equal the relative risk parameter used in the model
 - The baseline coverage of azithromycin in each facility type should match the values in the artifact
-- Validation: how does the sepsis incidence rate in a counterfactual scenario with 100% antibiotic access compare to sepsis incidence rates in high-income countries?  They should be close, and the counterfactual should not be lower.
+- Validation: how does the maternal sepsis incidence rate in a counterfactual scenario with 100% antibiotic access compare to maternal sepsis incidence rates in high-income countries?  They should be close, and the counterfactual should not be lower.
 
 References
 ------------

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -108,19 +108,6 @@ In Vivarium, this risk effect will modify the maternal sepsis incidence pipeline
 where :math:`\text{RR}_i^\text{no azithromycin}` is simulant *i*'s individual relative risk for "no azithromycin", meaning :math:`\text{RR}_i^\text{no azithromycin} = \text{RR}_\text{no azithromycin}` 
 if simulant *i* accesses a facility without azithromycin, and :math:`\text{RR}_i^\text{no azithromycin} = 1` if simulant *i* accesses a facility *with* azithromycin.
 
-If there are other interventions also affecting the IR of maternal sepsis, the pipeline will combine these effects, and we can write out the math for this risk explicitly as 
-
-.. math::
-
-   \text{IR}^\text{maternal sepsis}_{i, \text{updated}} = \text{IR}^\text{maternal sepsis}_{i, \text{original}} \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
-
-This reduces to the previous formula if there are no other interventions, and we would have 
-
-.. math::
-
-   \text{IR}^\text{maternal sepsis}_{i, \text{original}} = \text{IR}^\text{maternal sepsis}_
-
-
 The relative risk value we will use is pulled from `this 2024 systematic review/meta-analysis <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_ 
 that investigated the effect of azithromycin during labor.
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -37,6 +37,7 @@ Intervention Overview
 Azithromycin is used to prevent maternal sepsis in the intrapartum period, reducing the risk incidence.
 
 This section describes how an azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
+See the :ref:`MNCNH Portfolio model <2021_cause_maternal_sepsis_mncnh>`.
 
 .. list-table:: Affected Outcomes
   :widths: 15 15 15 15
@@ -48,8 +49,10 @@ This section describes how an azithromycin intervention can be implemented and c
     - Note (ex: is this relationship direct or mediated?)
   * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{IcR}_i^\text{maternal sepsis}`
     - Adjust multiplicatively using RR
-    - Yes
-    - For convenience, we will model this like a dichotomous risk factor; more details below
+    - Yes 
+    - 
+      - :ref:`Maternal sepsis cause model <2021_cause_maternal_sepsis_mncnh>` 
+      - For convenience, we will model this like a dichotomous risk factor; more details below
 
 Baseline Coverage Data
 ++++++++++++++++++++++++

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -47,7 +47,7 @@ See the :ref:`Maternal sepsis and other maternal infections cause model <2021_ca
     - Effect
     - Modeled?
     - Note (ex: is this relationship direct or mediated?)
-  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{IcR}_i^\text{maternal sepsis}`
+  * - Maternal sepsis and other maternal infections Incidence Probability :math:`\text{IR}_i^\text{maternal sepsis}`
     - Adjust multiplicatively using RR
     - Yes 
     - 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -201,13 +201,6 @@ Since our risk exposure has two categories,
 
 
 
-Scenarios
----------
-
-.. todo::
-
-  Describe our general approach to scenarios, for example set coverage to different levels in different types of health facilities; then the specific values for specific scenarios will be specified in the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
-
 
 Assumptions and Limitations
 ---------------------------
@@ -217,12 +210,14 @@ Assumptions and Limitations
 - We assume that the relative risk of maternal sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
   the value we are using is from `this 2024 systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
 - We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'.
-- We currenty do not model the impact of intrapartum azithromycin on the incidence of preterm births, despite *some* literature
-  evidence that suggests there may be a significant impact. For reference, this `2021 systematic review <https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/>`_
+- We currenty do not model the impact of azithromycin taken during pregnancy on the incidence of preterm births, despite *some* literature
+  evidence that suggests there may be a significant impact. Currently, we are ony modeling the impact of azithromycin taken during labor, rather
+  than during pregnancy. We may include in a future iteration of this model the use of azithromycin during pregnancy as a treatment for sexually
+  transmitted infections, in which case we may reassess this limitation. For reference, this `2021 systematic review <https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/>`_
   found an RR of 0.79 (95% CI 0.68-0.93) for LBW and an RR of 0.87 (95% CI 0.78-0.98) for premature births. They also reported an 
-  increase in stillbirht incidence. However, more recent publications (the 2024 review referenced above and  `this 2022 paper <https://link.springer.com/article/10.1007/s40261-022-01203-0>`_) 
+  increase in stillbirth incidence. However, more recent publications (the 2024 review referenced above and  `this 2022 paper <https://link.springer.com/article/10.1007/s40261-022-01203-0>`_) 
   have reported that there is no conclusive evidence to support that azithromycin use by pregnant women causes adverse 
-  neonatal outcomes.
+  neonatal outcomes. 
 - Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These placeholder values come 
   from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
   Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -221,14 +221,17 @@ Scenarios
 Assumptions and Limitations
 ---------------------------
 
-- We assume that azithromycin availability captures actual use, and not simply the treatment being in the facility 
-- We assume that the delivery facility is also the facility where a mother or birthing person will seek care for sepsis
+- We assume that azithromycin availability captures actual use, and not simply the treatment being in the facility. 
+- We assume that the delivery facility is also the facility where a mother or birthing person will seek care for sepsis.
 - We assume that the relative risk of sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
-  the value we are using is from `this systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
-- We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'
-- We currenty do not model the impact of intrapartum azithromycin on the incidence of preterm births, although there is literature
+  the value we are using is from `this 2024 systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
+- We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'.
+- We currenty do not model the impact of intrapartum azithromycin on the incidence of preterm births, despite *some* literature
   evidence that suggests there may be a significant impact. For reference, this `2021 systematic review <https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/>`_
-  found an RR of 0.79 (95% CI 0.68-0.93) for LBW and an RR of 0.87 (95% CI 0.78-0.98) for premature births.
+  found an RR of 0.79 (95% CI 0.68-0.93) for LBW and an RR of 0.87 (95% CI 0.78-0.98) for premature births. They also reported an 
+  increase in stillbirht incidence. However, more recent publications (the 2024 review referenced above and  `this 2022 paper <https://link.springer.com/article/10.1007/s40261-022-01203-0>`_) 
+  have reported that there is no conclusive evidence to support that azithromycin use by pregnant women causes adverse 
+  neonatal outcomes.
 - Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These placeholder values come 
   from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
   Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
@@ -257,5 +260,6 @@ References
 * https://chatgpt.com/share/67c1c7f9-8230-8010-9ade-30ed07b06bd0
 * https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.
 * https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/ 
+* https://link.springer.com/article/10.1007/s40261-022-01203-0
 
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -37,7 +37,7 @@ Intervention Overview
 Azithromycin is used to prevent maternal sepsis in the intrapartum period, reducing the risk incidence.
 
 This section describes how an azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
-See the :ref:`MNCNH Portfolio model <2021_cause_maternal_sepsis_mncnh>`.
+See the :ref:`Maternal sepsis and other maternal infections cause model <2021_cause_maternal_sepsis_mncnh>` for relevant details.
 
 .. list-table:: Affected Outcomes
   :widths: 15 15 15 15
@@ -218,6 +218,9 @@ Assumptions and Limitations
   increase in stillbirth incidence. However, more recent publications (the 2024 review referenced above and  `this 2022 paper <https://link.springer.com/article/10.1007/s40261-022-01203-0>`_) 
   have reported that there is no conclusive evidence to support that azithromycin use by pregnant women causes adverse 
   neonatal outcomes. 
+- We also do not currently model the impact intrapartum azithromycin has on preventing maternal sepsis in partial term pregnancies. In our 
+  :ref:`Maternal sepsis and other maternal infections cause model <2021_cause_maternal_sepsis_mncnh>`, we only model full term pregnancies as 
+  at-risk for maternal sepsis.
 - Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These placeholder values come 
   from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 Ethiopia EmONC Final 
   Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
@@ -227,8 +230,9 @@ Assumptions and Limitations
 
 .. todo::
 
-  If more suitable baseline coverage data for azithromycin for maternal sepsis at all facility types for Nigeria and Pakistan, we should use that data instead and update 
-  this documentation accordingly. We also need to decide if/how we would model the effect of intrapartum azithromycin on preterm incidence. 
+  - If more suitable baseline coverage data for azithromycin for maternal sepsis at all facility types for Nigeria and Pakistan, we should use that data instead and update 
+    this documentation accordingly. 
+  - We need to decide if/how we would model the effect of intrapartum azithromycin on preterm incidence. 
 
 Validation and Verification Criteria
 ------------------------------------

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -58,33 +58,40 @@ See the :ref:`Maternal sepsis and other maternal infections cause model <2021_ca
 Baseline Coverage Data
 ++++++++++++++++++++++++
 
-Baseline coverage data for azithromycin in CEmONC and BEmONC is only reflective of Ethiopian health systems in 2015-2018. These 
-placeholder values come from three data sources, all for Ethiopia, all identified by the Health Systems team at IHME: the 2016 
-Ethiopia EmONC Final Report found 39.2% of BEmONC facilities and 90.4% of CEmONC facilities have azithromycin; the 2016 SARA Report 
-found 68.4% of BEmONC facilities and 90.5% of CEmONC facilities have azithromycin; the 2018 SARA Report found 75.9% of BEmONC 
-facilities and 98.0% of CEmONC facilities have azithromycin. While we plan a data strategy to fill the gaps we have used a simple 
-average.
+It appears rare for prophylactic azithromycin during labor to be offered in African settings, so for both BEmONC and CEmONC in Nigeria and Ethiopia, we will use baseline coverage of 
+0% as a stand-in value while we search for additional evidence. Pakistan BEmONC settings also have a baseline coverage of 0%, but CEmONC settings should have 
+a baseline coverage of 20.3% according to [Saleem-et-al-2025-intrapartum-antibiotic-use]_.
+
 
 .. list-table:: Baseline Coverage of intrapartum azithromycin
-  :widths: 15 15 15 15
+  :widths: 15 15 15 15 15
   :header-rows: 1
 
-  * - Birth Facility
+  * - Location
+    - Birth Facility
     - Coverage Mean (%)
     - Coverage Distribution (%)
     - Notes
-  * - Home Birth
-    - 5
-    - :math:`\text{Uniform}(0,10)`
+  * - All (Ethiopia, Nigeria, Pakistan)
+    - Home Birth
+    - 0
+    - N/A
     - Assumption; need to investigate data sources for care seeking those giving birth outside of the hospital system 
-  * - BEmONC Facilities
-    - 61.2
-    - :math:`\text{Uniform}(39.2,75.9)`
-    - placeholder value based on three data points 
-  * - CEmONC Facilities
-    - 93.0
-    - :math:`\text{Uniform}(90.4,98.0)`
-    - placeholder value based on three data points 
+  * - All (Ethiopia, Nigeria, Pakistan)
+    - BEmONC Facilities
+    - 0
+    - N/A
+    - 
+  * - Ethiopia and Nigeria
+    - CEmONC Facilities
+    - 0
+    - N/A
+    - 
+  * - Pakistan
+    - CEmONC Facilities
+    - 20.3
+    - :math:`\text{Uniform}(15.3,25.3)`
+    - 
 
 
 Vivarium Modeling Strategy
@@ -255,3 +262,6 @@ References
 
 .. [Antonucci-et-al-2022-azithromycin-during-pregnancy]
   Antonucci, R., Cuzzolin, L., Locci, C. et al. Use of Azithromycin in Pregnancy: More Doubts than Certainties. Clin Drug Investig 42, 921–935 (2022). https://doi.org/10.1007/s40261-022-01203-0
+
+.. [Saleem-et-al-2025-intrapartum-antibiotic-use]
+  Saleem S, Yasmin H, Moore JL, Rahim A, Shakeel I, Lokangaka A, et al. Intrapartum and postpartum antibiotic use in seven low- and middle-income countries: Findings from the A-PLUS trial. BJOG. 2025; 132(1): 72–80. https://doi-org.offcampus.lib.washington.edu/10.1111/1471-0528.17930

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -1,8 +1,8 @@
-.. _intervention_intrapartum_azithromycin:
+.. _azithromycin_intervention:
 
-=============================================
-Antibiotics for treating bacterial infections
-=============================================
+=========================================
+Azithromycin for treating maternal sepsis
+=========================================
 
 .. contents::
    :local:
@@ -28,9 +28,9 @@ Antibiotics for treating bacterial infections
 Intervention Overview
 -----------------------
 
-Antibiotics are used to treat bacterial infections in neonates, reducing the risk mortality.
+Azithromycin is used to treat maternal sepsis in the intrapartum period, reducing the risk incidence.
 
-This section describes how an antibiotic-treatment intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
+This section describes how an azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
 
 .. list-table:: Affected Outcomes
   :widths: 15 15 15 15
@@ -75,33 +75,42 @@ These placeholder values come from two data sources, both for Ethiopia, both ide
 Vivarium Modeling Strategy
 --------------------------
 
-This intervention requires adding an attribute to all simulants to specify if a neonate has access to a facility with access to antibiotics.  Since the neonatal mortality model does not explicitly represent incidence of sepsis, we will not track explicitly if a simulant receives antibiotics.  Instead the model will have different cause-specific mortality rates for sepsis for individuals with and without access to antibiotics (implemented with a slightly confusing application of our ``Risk`` and ``RiskEffect`` components from ``vivarium_public_health``).
+This intervention requires adding an attribute to all simulants to specify if a pregnant person has access to a facility with access to azithromycin.  We will track if a simulant has access to azithromycin 
+and the model will have different incidence rates for sepsis for individuals with and without access to azithromycin (implemented with a slightly confusing application of our ``Risk`` and ``RiskEffect`` 
+components from ``vivarium_public_health``).
 
-The ``Risk`` component adds an attribute to each simulant indicating whether the simulant has access to antibiotics during the neonatal period, which we assume will be closely related to the facility choice during birth, i.e. home births have much lower access than in-facility births, and births in BEmONC facilities have lower access than CEmONC facilities.
+The ``Risk`` component adds an attribute to each simulant indicating whether the simulant has access to azithromycin during the intrapartum period, which we assume will be closely 
+related to the facility choice during birth, i.e. home births have much lower access than in-facility births, and births in BEmONC facilities have lower access than CEmONC 
+facilities.
 
-To make this work naturally with the ``RiskEffect`` component, it is best to think of the risk as "lack of access to antibiotics".  With this framing, the ``RiskEffect`` component requires data on (1) the relative risk of sepsis mortality for people with lack of access to antibiotics, and (2) the population attributable fraction (PAF) of sepsis due to lack of access to antibiotics.  We will use the decision tree below to find the probability of sepsis mortality with and without access to antibiotics that are logically consistent with the baseline delivery facility rates and baseline antibiotics coverage.
+To make this work naturally with the ``RiskEffect`` component, it is best to think of the risk as "lack of access to azithromycin".  With this framing, the ``RiskEffect`` 
+component requires data on (1) the relative risk of sepsis incidence for people with lack of access to azithromycin, and (2) the population attributable fraction (PAF) of sepsis 
+due to lack of access to azithromycin.  We will use the decision tree below to find the probability of sepsis incidence with and without access to azithromycin that are logically 
+consistent with the baseline delivery facility rates and baseline azithromycin coverage.
 
-In Vivarium, this risk effect will modify the sepsis mortality pipeline, resulting in 
+In Vivarium, this risk effect will modify the sepsis incidence pipeline, resulting in 
 
 .. math::
 
-   \text{CSMR}_i^\text{sepsis} = \text{CSMR}^\text{sepsis}_{\text{BW}_i, \text{GA}_i} \cdot (1 - \text{PAF}_\text{no antibiotics}) \cdot \text{RR}_i^\text{no antibiotics}
+   \text{IR}_i^\text{sepsis} = \text{IR}^\text{sepsis}_{\text{BW}_i, \text{GA}_i} \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
 
-where :math:`\text{RR}_i^\text{no antibiotics}` is simulant *i*'s individual relative risk for "no antibiotics", meaning :math:`\text{RR}_i^\text{no antibiotics} = \text{RR}_\text{no antibiotics}` if simulant *i* accesses a facility without antibiotics, and :math:`\text{RR}_i^\text{no antibiotics} = 1` if simulant *i* accesses a facility *with* antibiotics.
+where :math:`\text{RR}_i^\text{no azithromycin}` is simulant *i*'s individual relative risk for "no azithromycin", meaning :math:`\text{RR}_i^\text{no azithromycin} = \text{RR}_\text{no azithromycin}` 
+if simulant *i* accesses a facility without azithromycin, and :math:`\text{RR}_i^\text{no azithromycin} = 1` if simulant *i* accesses a facility *with* azithromycin.
 
-If there are other interventions also affecting the CSMR of sepsis, the pipeline will combine these effects, and we can write out the math for this risk explicitly as 
+If there are other interventions also affecting the IR of sepsis, the pipeline will combine these effects, and we can write out the math for this risk explicitly as 
 
 .. math::
 
-   \text{CSMR}^\text{sepsis}_{i, \text{updated}} = \text{CSMR}^\text{sepsis}_{i, \text{original}} \cdot (1 - \text{PAF}_\text{no antibiotics}) \cdot \text{RR}_i^\text{no antibiotics}
+   \text{IR}^\text{sepsis}_{i, \text{updated}} = \text{IR}^\text{sepsis}_{i, \text{original}} \cdot (1 - \text{PAF}_\text{no azithromycin}) \cdot \text{RR}_i^\text{no azithromycin}
 
 This reduces to the previous formula if there are no other interventions, and we would have 
 
 .. math::
 
-   \text{CSMR}^\text{sepsis}_{i, \text{original}} = \text{CSMR}^\text{sepsis}_{\text{BW}_i, \text{GA}_i}
+   \text{IR}^\text{sepsis}_{i, \text{original}} = \text{IR}^\text{sepsis}_{\text{BW}_i, \text{GA}_i}
 
-While we are searching the literature for an appropriate value for the relative risk, we will use a stand-in value with an origin I have failed to record.
+The relative risk value we will use is pulled from `this 2024 systematic review/meta-analysis <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_ 
+that investigated the effect of azithromycin during labor.
 
 .. list-table:: Risk Effect Parameters for Lack-of-Access-to-Antibiotics
   :widths: 15 15 15 15
@@ -112,9 +121,9 @@ While we are searching the literature for an appropriate value for the relative 
     - Distribution
     - Notes
   * - Relative Risk
-    - 1.39
+    - 1.54
     - :math:`\text{Normal}(1.39,0.08^2)`
-    - Based on placeholder relative risk of 0.72 (95% CI 0.64-0.80) of sepsis mortality for neonates with access to antibiotics 
+    - Based on placeholder relative risk of 0.65 (95% CI 0.55-0.77) on sepsis incidence for pregnant people with access to azithromycin
   * - PAF
     - see below
     - see below
@@ -123,7 +132,10 @@ While we are searching the literature for an appropriate value for the relative 
 Calibration Strategy
 --------------------
 
-The following decision tree shows all of the paths from delivery facility choice to antibiotics availability.  Distinct paths in the tree correspond to disjoint events, which we can sum over to find the population probability of sepsis mortality.  The goal here is to use internally consistent conditional probabilities of sepsis mortality for the subpopulations with and without access to antibiotics, so that the baseline scenario can track who has access to antibiotics and still match the baseline sepsis mortality rate.
+The following decision tree shows all of the paths from delivery facility choice to antibiotics availability.  Distinct paths in the tree correspond to disjoint events, 
+which we can sum over to find the population probability of sepsis mortality.  The goal here is to use internally consistent conditional probabilities of sepsis mortality 
+for the subpopulations with and without access to antibiotics, so that the baseline scenario can track who has access to antibiotics and still match the baseline sepsis 
+mortality rate.
 
 .. graphviz::
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -112,7 +112,7 @@ This reduces to the previous formula if there are no other interventions, and we
 The relative risk value we will use is pulled from `this 2024 systematic review/meta-analysis <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_ 
 that investigated the effect of azithromycin during labor.
 
-.. list-table:: Risk Effect Parameters for Lack-of-Access-to-Antibiotics
+.. list-table:: Risk Effect Parameters for Lack-of-Access-to-Azithromycin
   :widths: 15 15 15 15
   :header-rows: 1
 
@@ -122,7 +122,7 @@ that investigated the effect of azithromycin during labor.
     - Notes
   * - Relative Risk
     - 1.54
-    - :math:`\text{Normal}(1.39,0.08^2)`
+    - :math:`\text{Normal}(1.54,0.08^2)`
     - Based on placeholder relative risk of 0.65 (95% CI 0.55-0.77) on sepsis incidence for pregnant people with access to azithromycin
   * - PAF
     - see below
@@ -132,23 +132,23 @@ that investigated the effect of azithromycin during labor.
 Calibration Strategy
 --------------------
 
-The following decision tree shows all of the paths from delivery facility choice to antibiotics availability.  Distinct paths in the tree correspond to disjoint events, 
-which we can sum over to find the population probability of sepsis mortality.  The goal here is to use internally consistent conditional probabilities of sepsis mortality 
-for the subpopulations with and without access to antibiotics, so that the baseline scenario can track who has access to antibiotics and still match the baseline sepsis 
-mortality rate.
+The following decision tree shows all of the paths from delivery facility choice to azithromycin availability.  Distinct paths in the tree correspond to disjoint events, 
+which we can sum over to find the population probability of sepsis incidence.  The goal here is to use internally consistent conditional probabilities of sepsis incidence
+for the subpopulations with and without access to azithromycin, so that the baseline scenario can track who has access to azithromycin and still match the baseline sepsis 
+incidence rate.
 
 .. graphviz::
 
-    digraph antibiotics {
+    digraph azithromycin {
         rankdir = LR;
         facility [label="Facility type"]
-        home [label="p_sepsis_without_antibiotics"]
-        BEmONC [label="antibiotics?"]
-        CEmONC [label="antibiotics?"]
-        BEmONC_wo [label="p_sepsis_without_antibiotics"] 
-        BEmONC_w [label="p_sepsis_with_antibiotics"]
-        CEmONC_wo [label="p_sepsis_without_antibiotics"] 
-        CEmONC_w [label="p_sepsis_with_antibiotics"]
+        home [label="p_sepsis_without_azithromycin"]
+        BEmONC [label="azithromycin?"]
+        CEmONC [label="azithromycin?"]
+        BEmONC_wo [label="p_sepsis_without_azithromycin"] 
+        BEmONC_w [label="p_sepsis_with_azithromycin"]
+        CEmONC_wo [label="p_sepsis_without_azithromycin"] 
+        CEmONC_w [label="p_sepsis_with_azithromycin"]
 
         facility -> home  [label = "home birth"]
         facility -> BEmONC  [label = "BEmONC"]
@@ -164,16 +164,22 @@ mortality rate.
 .. math::
     \begin{align*}
         p(\text{sepsis}) 
-        &= \sum_{\text{paths without antibiotics}} p(\text{path})\cdot p(\text{sepsis}|\text{no antibiotics})\\
-        &+ \sum_{\text{paths with antibiotics}} p(\text{path})\cdot p(\text{sepsis}|\text{antibiotics})\\[.1in]
-        p(\text{sepsis}|\text{no antibiotics}) &= \text{RR}_\text{no antibiotics} \cdot p(\text{sepsis}|\text{antibiotics})
+        &= \sum_{\text{paths without azithromycin}} p(\text{path})\cdot p(\text{sepsis}|\text{no azithromycin})\\
+        &+ \sum_{\text{paths with azithromycin}} p(\text{path})\cdot p(\text{sepsis}|\text{azithromycin})\\[.1in]
+        p(\text{sepsis}|\text{no azithromycin}) &= \text{RR}_\text{no azithromycin} \cdot p(\text{sepsis}|\text{azithromycin})
     \end{align*}
 
-where :math:`p(\text{sepsis})` is the probability of dying from sepsis in the general population, and :math:`p(\text{sepsis}|\text{antibiotics})` and :math:`p(\text{sepsis}|\text{no antibiotics})` are the probability of dying from sepsis in setting with and without access to antibiotics.  For each path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has antibiotics available.
+where :math:`p(\text{sepsis})` is the probability of contracting sepsis in the general population, and :math:`p(\text{sepsis}|\text{azithromycin})` and
+ :math:`p(\text{sepsis}|\text{no azithromycin})` are the probability of contracting sepsis in settings with and without access to azithromycin.  For each 
+ path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and 
+ unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has antibiotics available.
 
-When we fill in the location-specific values for delivery facility rates, antibiotics coverage, relative risk of mortality with antibiotics access, and mortality probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{sepsis}|\text{antibiotics})` and :math:`p(\text{sepsis}|\text{no antibiotics})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
+When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of mortality with azithromycin access, 
+and mortality probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{sepsis}|\text{antibiotics})` 
+and :math:`p(\text{sepsis}|\text{no antibiotics})`), which we can solve analytically using the same approach as in the :ref:`cpap calibration <cpap_calibration>`.
 
-**Alternative PAF Derivation**: An alternative, and possibly simpler derivation of the PAF that will calibrate this model comes from the observation that :math:`\text{PAF} = 1 - \frac{1}{\mathbb{E}(\text{RR})}`.  If we define 
+**Alternative PAF Derivation**: An alternative, and possibly simpler derivation of the PAF that will calibrate this model comes from the observation that
+:math:`\text{PAF} = 1 - \frac{1}{\mathbb{E}(\text{RR})}`.  If we define 
 
 .. math::
 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -34,10 +34,9 @@ Azithromycin for treating maternal sepsis
 Intervention Overview
 -----------------------
 
-Azithomycin is an oral or intravenous single-dose antibiotic taken before labour for the prevention of maternal sepsis and other maternal infections 
-after vaginal delivery and caesarean section, reducing the risk incidence. 
+Azithomycin is an oral or intravenous single-dose antibiotic that can be taken before or during labour to prevent or reduce incidence of maternal sepsis and other maternal infections. 
 
-This section describes how an azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
+This section describes how a prophylactic azithromycin intervention can be implemented and calibrated for the :ref:`MNCNH Portfolio model <2024_concept_model_vivarium_mncnh_portfolio>`.
 See the :ref:`Maternal sepsis and other maternal infections cause model <2021_cause_maternal_sepsis_mncnh>` for relevant details.
 
 .. list-table:: Affected Outcomes
@@ -182,7 +181,7 @@ incidence rate.
 where :math:`p(\text{maternal_sepsis})` is the probability of contracting maternal sepsis in the general population, and :math:`p(\text{maternal_sepsis}|\text{azithromycin})` and
  :math:`p(\text{maternal_sepsis}|\text{no azithromycin})` are the probability of contracting maternal sepsis in settings with and without receiving prophylactic azithromycin.  For each 
  path through the decision tree, :math:`p(\text{path})` is the probability of that path; for example the path that includes the edges labeled BEmONC and 
- unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the facility has azithromycin available.
+ unavailable occurs with probability that the birth is in a BEmONC facility times the probability that the simulant receives prophylactic azithromycin.
 
 When we fill in the location-specific values for delivery facility rates, azithromycin coverage, relative risk of maternal sepsis incidence with azithromycin, 
 and maternal sepsis incidence probability (which is also age-specific), this becomes a system of two linear equations with two unknowns (:math:`p(\text{maternal_sepsis}|\text{azithromycin})` 

--- a/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
+++ b/docs/source/models/intervention_models/intrapartum/azithromycin_intervention.rst
@@ -111,8 +111,8 @@ In Vivarium, this risk effect will modify the maternal sepsis incidence pipeline
 where :math:`\text{RR}_i^\text{no azithromycin}` is simulant *i*'s individual relative risk for "no azithromycin", meaning :math:`\text{RR}_i^\text{no azithromycin} = \text{RR}_\text{no azithromycin}` 
 if simulant *i* accesses a facility without azithromycin, and :math:`\text{RR}_i^\text{no azithromycin} = 1` if simulant *i* accesses a facility *with* azithromycin. 
 
-The relative risk value we will use is pulled from `this 2024 systematic review/meta-analysis <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_ 
-that investigated the effect of azithromycin during labor.
+The relative risk value we will use is pulled from [Ye-et-al-2024-azithromycin-during-labor]_, a 2024 systematic review that investigated the effect of 
+azithromycin during labor.
 
 .. list-table:: Risk Effect Parameters for Lack-of-Access-to-Azithromycin
   :widths: 15 15 15 15
@@ -208,14 +208,14 @@ Assumptions and Limitations
 - We assume that azithromycin availability captures actual use, and not simply the treatment being in the facility. 
 - We assume that the delivery facility is also the facility where a mother or birthing person will seek care for maternal sepsis.
 - We assume that the relative risk of maternal sepsis incidence with azithromycin in practice is a value that we can find in the literature (Note: 
-  the value we are using is from `this 2024 systematic review <https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.>`_)
+  the value we are using is from [Ye-et-al-2024-azithromycin-during-labor]_.)
 - We have excluded the effect of azithromycin on pneumonia incidence/mortality, because this cause is currently lumped with 'other causes'.
 - We currenty do not model the impact of azithromycin taken during pregnancy on the incidence of preterm births, despite *some* literature
   evidence that suggests there may be a significant impact. Currently, we are ony modeling the impact of azithromycin taken during labor, rather
   than during pregnancy. We may include in a future iteration of this model the use of azithromycin during pregnancy as a treatment for sexually
-  transmitted infections, in which case we may reassess this limitation. For reference, this `2021 systematic review <https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/>`_
+  transmitted infections, in which case we may reassess this limitation. For reference, [Hume-Nizon-et-al-2021-azithromycin-during-pregnancy]_
   found an RR of 0.79 (95% CI 0.68-0.93) for LBW and an RR of 0.87 (95% CI 0.78-0.98) for premature births. They also reported an 
-  increase in stillbirth incidence. However, more recent publications (the 2024 review referenced above and  `this 2022 paper <https://link.springer.com/article/10.1007/s40261-022-01203-0>`_) 
+  increase in stillbirth incidence. However, more recent publications (the 2024 review referenced above and [Antonucci-et-al-2022-azithromycin-during-pregnancy]_) 
   have reported that there is no conclusive evidence to support that azithromycin use by pregnant women causes adverse 
   neonatal outcomes. 
 - We also do not currently model the impact intrapartum azithromycin has on preventing maternal sepsis in partial term pregnancies. In our 

--- a/docs/source/models/intervention_models/intrapartum/index.rst
+++ b/docs/source/models/intervention_models/intrapartum/index.rst
@@ -1,0 +1,12 @@
+.. _intrapartum_intervention_models:
+
+=========================
+Intrapartum Interventions
+=========================
+
+.. toctree::
+    :maxdepth: 1
+
+    azithromycin_intervention
+
+


### PR DESCRIPTION
This PR adds a page for how we will model azithromycin in the intrpartum model.

Currently we only include the impact of azithromycin on maternal sepsis (as is supported by the most recent systematic review I found on the topic), but I did find a [2021 systematic review](https://pmc.ncbi.nlm.nih.gov/articles/PMC8436060/) that found a significant impact of intrapartum azithromycin on the incidence of preterm births and stillbirths (a decrease in preterm and an increase in stillbirths). The [2024 systematic review](https://bmcpregnancychildbirth.biomedcentral.com/articles/10.1186/s12884-024-06390-6#:~:text=Primary%20outcomes,-Among%20the%20six&text=The%20incidence%20of%20maternal%20sepsis%20was%20significantly%20lower%20in%20the,was%20analysed%20in%20three%20studies.) found no significant impact of azithromycin on neonatal sepsis and other causes of mortality, but doesn't report anything about preterm incidence. Overall it seems like evidence is pretty inconclusive/conflicting about the impact of azithromycin on neonates (see also [this 2022 paper](https://link.springer.com/article/10.1007/s40261-022-01203-0#:~:text=and%20Neonatal%20Outcomes-,Fetal%20and%20neonatal%20outcomes%20following%20prenatal%20azithromycin%20exposure%20have%20been%20investigated,%5D%2C%20but%20not%20in%20others%20%5B23%2C%2073%2C%2075%5D.,-Table%202%20Selected)), so just wanted to flag that here. 