### PR TITLE
MNCNH: Update delivery facility strategy and data

### DIFF
--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -110,9 +110,9 @@ parameters.
     - Notes
   * - ANC propensity :math:`u_\text{ANC}`
     - IFD propensity :math:`u_\text{IFD}`
-    - 0.64
-    - 0.47
-    - 0.41
+    - 0.63
+    - 0.46
+    - 0.36
     - Correlation found from causal model optimization after the other
       two correlations were fixed
   * - ANC propensity :math:`u_\text{ANC}`
@@ -326,19 +326,20 @@ choices in the model:
     - Nigeria
     - Pakistan
   * - :math:`\text{Pr}[\text{BEmONC}\mid \text{in-facility}]`
-    -
-    -
-    -
+    - 0.160883
+    - 0.004423
+    - 0.340528
   * - :math:`\text{Pr}[\text{CEmONC}\mid \text{in-facility}]`
-    -
-    -
-    -
+    - 1 - 0.160883
+    - 1 - 0.004423
+    - 1 - 0.340528
 
 .. todo::
 
   Update the above probabilities once we get better data from Annie's
-  team. The current values are based on an imprecise analysis of DHS
-  data and likely underestimate the proportion of BEmONC facilities.
+  team. The current values (except for Pakistan, which is based on
+  microdata from BMGF) are based on an imprecise analysis of DHS data
+  and likely underestimate the proportion of BEmONC facilities.
 
 Challenge of calibrating the model
 ----------------------------------

--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -215,28 +215,62 @@ section.
 
 More explicitly, given the simulant's believed term status (either
 "believed preterm" or "believed full-term") and their IFD propensity,
-:math:`U_\text{IFD}`, the simulant's IFD status is given by the
+:math:`u_\text{IFD}`, the simulant's IFD status is given by the
 following function :math:`f_\text{IFD}`:
 
 .. math::
 
   \begin{align*}
   \text{IFD status}
-  &= f_\text{IFD}(\text{believed term status},\ U_\text{IFD}) \\
+  &= f_\text{IFD}(\text{believed term status},\ u_\text{IFD}) \\
   &=  \begin{cases}
-      \text{at-home}, & \text{if}\quad U_\text{IFD}
+      \text{at-home}, & \text{if}\quad u_\text{IFD}
           < \text{Pr}[\text{at-home} \mid
           \operatorname{do}(\text{believed term status})] \\
       \text{in-facility}, & \text{otherwise}.
       \end{cases}
   \end{align*}
 
-Note that, as described in the previous section, the function
-:math:`f_\text{IFD}` is defined so that smaller values of
-:math:`U_\text{IFD}` correspond with home delivery, while larger values
-of :math:`U_\text{IFD}` correspond with in-facility delivery. This
+Note that, as described in the previous section,  smaller values of
+:math:`u_\text{IFD}` correspond with home delivery, while larger values
+of :math:`u_\text{IFD}` correspond with in-facility delivery. This
 ordering is important for the model to calibrate using the specified
-correlations.
+propensity correlations. The function :math:`f_\text{IFD}` is one of the
+`structural equations`_ defining the causal model drawn above.
+
+.. _structural equations: https://en.wikipedia.org/wiki/Structural_equation_modeling
+
+.. note::
+
+  The above probabilities represent the *causal* effect of a simulant's
+  believed term status on their choice of home delivery or in-facility
+  delivery. These will be different from the population's *observed*
+  conditional probabilities of IFD status given the believed term
+  status, because of the correlations of :math:`u_\text{IFD}` with
+  :math:`u_\text{ANC}` and :math:`u_\text{cat}`.
+
+For reference when validating the model, the in-facility delivery
+proportions from GBD 2021 (covariate ID 51, "In-Facility Delivery
+(proportion)") are listed below. The observed overall IFD proportions in
+the simulation should match these values, but these probabilities will
+not be used directly in the simulation.
+
+.. list-table:: Proportion of at-home vs. in-facility deliveries
+  :header-rows: 1
+  :widths: 20 10 10 10
+
+  * - IFD status
+    - Ethiopia
+    - Nigeria
+    - Pakistan
+  * - at-home
+    - 0.507432
+    - 0.479903
+    - 0.228234
+  * - in-facility
+    - 0.492568
+    - 0.520097
+    - 0.771766
 
 Choosing BEmONC vs. CEmONC
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -244,6 +278,29 @@ Choosing BEmONC vs. CEmONC
 Among simulants whose IFD status is "in-facility," choose BEmONC vs.
 CEmONC according to the following probabilities, independently of other
 choices in the model:
+
+.. list-table:: Conditional probabilities of BEmONC and CEmONC given in-facility delivery
+  :header-rows: 1
+  :widths: 20 10 10 10
+
+  * - Conditional probability
+    - Ethiopia
+    - Nigeria
+    - Pakistan
+  * - :math:`\text{Pr}[\text{BEmONC}\mid \text{in-facility}]`
+    -
+    -
+    -
+  * - :math:`\text{Pr}[\text{CEmONC}\mid \text{in-facility}]`
+    -
+    -
+    -
+
+.. todo::
+
+  Update the above probabilities once we get better data from Annie's
+  team. The current values are based on an imprecise analysis of DHS
+  data and likely underestimate the proportion of BEmONC facilities.
 
 Challenge of calibrating the model
 ----------------------------------

--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -142,7 +142,7 @@ parameters.
 
   One way to do this would be to specify the two fixed correlations in
   ``model_spec.yaml`` and use a branches file to run parallel sims with
-  different values, but this would require Vivarium to call the
+  different values, but this would require the simulation to call the
   optimization code, which takes 10-15 minutes to run. Alternatively, we
   could precompute several sets of consistent parameters, and then
   different scenarios would only have to specify which set of values to
@@ -172,8 +172,8 @@ for each sex.**
 
 .. important::
 
-  * All preterm categories (:math:`< 37` weeks) are ordered **before** all full-term
-    categories (:math:`\ge 37` weeks)
+  * All preterm categories (< 37 weeks) are ordered **before** all
+    full-term categories (37+ weeks)
   * The ordering is **sex-specific** (the ordering is different for
     males and females)
   * Within each term status (preterm or full-term), LBWSG categories are

--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -183,8 +183,9 @@ for each sex.**
     group since we're interested in the risk right after birth
 
   This ordering must be used when initializing the LBWSG category from
-  its (correlated) propensity :math:`u_\text{cat}` as described on the
-  :ref:`LBWSG risk exposure page <2019_risk_exposure_lbwsg>`.
+  its (correlated) propensity :math:`u_\text{cat}`, following the
+  strategy described on the :ref:`LBWSG risk exposure page
+  <2019_risk_exposure_lbwsg>`.
 
 **We will also order the ANC and IFD propensities from highest to lowest
 risk: "no ANC" < "some ANC"; and "home birth" < "in-facility birth".**
@@ -201,8 +202,8 @@ work in code, if the categories are ordered from highest risk to lowest
 risk as :math:`c_1, \dotsc, c_n`, divide the unit interval :math:`[0,1]`
 into :math:`n` subintervals :math:`I_1, \dotsc, I_n` ordered from left
 to right, such that the length of :math:`I_j` is :math:`P(c_j)`. Then a
-uniform propensity :math:`p \in [0,1]` corresponds to category
-:math:`c_j` precisely when :math:`p \in I_j`. This correspondence
+uniform propensity :math:`u \in [0,1]` corresponds to category
+:math:`c_j` precisely when :math:`u \in I_j`. This correspondence
 specifies how each ordinal variable should be initialized from its
 corresponding propensity. [[A picture would probably help, should we add
 one here?]]
@@ -218,12 +219,11 @@ about preterm status.  Although deriving consistent values for these
 probabilities is complex, and described in the final section of this
 page, *using* the causal conditional probabilities is simple: Simply
 select in-facility delivery with probability
-:math:`\text{Pr}[\text{in-facility}\mid
-\operatorname{do}(\text{believed preterm})]`
-or :math:`\text{Pr}[\text{in-facility}\mid
-\operatorname{do}(\text{believed full-term})]` for the corresponding
-cases, using the correlated IFD propensity defined in the previous
-section.
+:math:`\text{Pr}[\text{in-facility}\mid \operatorname{do}(\text{believed preterm})]`
+or
+:math:`\text{Pr}[\text{in-facility}\mid \operatorname{do}(\text{believed full-term})]`
+for the corresponding cases, using the correlated IFD propensity and
+category ordering defined in the previous section.
 
 .. list-table:: Causal conditional probabilities of in-facility delivery for mean draw
    :header-rows: 1

--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -58,13 +58,24 @@ Similarly, it is likely that there are social exclusion factors causing both exp
 In a simulation model where we have not included scenarios that change these common-cause factors, we do not have to model their effects explicitly.
 For our purposes, it is sufficient to capture the correlations between ANC, in-facility birth, and LBWSG risk exposure.
 
-In Vivarium, we use values selected uniformly at random from the interval [0,1], which we call propensities, to keep attributes like LBWSG and ANC calibrated at the population level while reducing variance between scenarios at the simulant level.  This makes it straightforward to represent the correlation in our factors by generating correlated propensities. The :code:`statsmodels.distributions.copula.api.GaussianCopula` implementation can make them::
+In Vivarium, we use values selected uniformly at random from the interval [0,1], which we call propensities, to keep attributes like LBWSG and ANC calibrated at the population level while reducing variance between scenarios at the simulant level.  This makes it straightforward to represent the correlation in our factors by generating correlated propensities. The :code:`statsmodels.distributions.copula.api.GaussianCopula` implementation can make them:
 
-    from statsmodels.distributions.copula.api import GaussianCopula
-    copula = GaussianCopula([[1.,   .643, .2],
-                             [.643, 1.,   .2],
-                             [.2,   .2,   1.]])
-    copula.rvs(10)
+.. code-block:: pycon
+
+    >>> from statsmodels.distributions.copula.api import GaussianCopula
+    >>> # Input is a correlation matrix
+    >>> copula = GaussianCopula([[1.,   .64, .2],
+    ...                          [.64, 1.,   .2],
+    ...                          [.2,  .2,   1.]])
+    >>> # Each row contains 3 correlated propensities
+    >>> copula.rvs(10_000)
+    array([[0.29591901, 0.46609153, 0.43592752],
+          [0.99152512, 0.94530017, 0.85288664],
+          [0.46295916, 0.02359119, 0.49424445],
+          ...,
+          [0.01641805, 0.05247892, 0.02022793],
+          [0.16978166, 0.27245795, 0.10548769],
+          [0.67100234, 0.83628491, 0.83330358]])
 
 The argument of the ``GaussianCopula`` constructor is a `correlation
 matrix`_, whose :math:`(i,j)^\text{th}` entry specifies the correlation


### PR DESCRIPTION
Jira ticket: [SSCI-1966](https://jira.ihme.washington.edu/browse/SSCI-1966)

Makes the following updates to the delivery facility page that Abie wrote:

- Switch to only choosing home delivery vs. in-facility delivery (IFD) based on believed term status, instead of directly choosing from home/BEmONC/CEmONC
- Update data tables with actual values from the causal model optimization, to be used for a "mean draw" run with no parameter uncertainty
- Update the specified ordering of the LBWSG categories
- Give an explicit equation for how to assign the IFD status
- Add links to related modules
- Switch some notation to match my causal model diagram (to come in a future PR)
- Additional edits for clarity, etc.

More PRs will be forthcoming to implement the following additional changes:

- Add the causal model diagram to this page
- Edit the related module pages and concept model page to match the new strategy, terminology, and notation
- Record some assumptions and limitations, and V&V criteria
- Add a new requested model run to the concept model page

**One question I have:** I haven't thought too carefully about the implications of the first change listed above (choosing at-home vs.in-facility instead of directly choosing from  home/BEmONC/CEmONC), so if anyone has thoughts on how well this might reflect reality or whether it could be problematic, that would be helpful. (We mainly made this change because (1) the optimization was not converging as well in the 3-choice version, and (2) the data to inform the 3-choice version is more limited.)