### PR TITLE
Fix antibiotics PAF equation

### DIFF
--- a/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
@@ -222,7 +222,7 @@ Where:
     - 0.78 (95% CI: 0.60 to 1.00), lognormal distribution of uncertainty (implemented as parameter uncertainty)
     - [PSBI-Cochrane-Review]_
   * - mean_rr
-    - :math:`\text{RR}^\text{no antibiotics} * (1 - p_\text{baseline coverage} + p_\text{baseline coverage}`
+    - :math:`\text{RR}^\text{no antibiotics} * (1 - p_\text{baseline coverage}) + p_\text{baseline coverage}`
     - :math:`p_\text{baseline coverage}` is baseline coverage proportion defined in the baseline coverage section above
   * - PAF
     - (mean_rr - 1) / mean_rr

--- a/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
+++ b/docs/source/models/intervention_models/neonatal/antibiotics_intervention.rst
@@ -222,8 +222,8 @@ Where:
     - 0.78 (95% CI: 0.60 to 1.00), lognormal distribution of uncertainty (implemented as parameter uncertainty)
     - [PSBI-Cochrane-Review]_
   * - mean_rr
-    - :math:`\text{RR} * p_\text{covered at baseline} + (1 - p_\text{covered at baseline})`
-    - :math:`p_\text{covered at baseline}` is baseline coverage proportion defined in the baseline coverage section above
+    - :math:`\text{RR}^\text{no antibiotics} * (1 - p_\text{baseline coverage} + p_\text{baseline coverage}`
+    - :math:`p_\text{baseline coverage}` is baseline coverage proportion defined in the baseline coverage section above
   * - PAF
     - (mean_rr - 1) / mean_rr
     - 


### PR DESCRIPTION
Fix error/clarify variables in the PAF equation for neonatal antibiotics intervention. Mistake was due to my confusion over the "no intervention" risk factor format, but "intervention" coverage format which I find very confusing and a reminder that I would love to update this standard procedure on our team :) https://ihme.slack.com/archives/C014RDZA1GE/p1747695754198189


