### PR TITLE
MNCNH: Update facility choice documentation with new ANC categories

### DIFF
--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -436,7 +436,15 @@ for each sex.**
   <2019_risk_exposure_lbwsg>`.
 
 **We will also order the ANC and IFD propensities from highest to lowest
-risk: "no ANC" < "some ANC"; and "home birth" < "in-facility birth".**
+risk:**
+
+ANC attendance categories
+  no ANC < ANC in later pregnancy < ANC in 1st trimester <
+  ANC in 1st trimester and later pregnancy
+
+IFD status categories
+  home birth < in-facility birth
+
 These orderings must be used when initializing simulants' ANC status and
 IFD status from the corresponding (correlated) propensities
 :math:`u_\text{ANC}` and :math:`u_\text{IFD}`. See the :ref:`Antenatal

--- a/docs/source/models/other_models/facility_choice/index.rst
+++ b/docs/source/models/other_models/facility_choice/index.rst
@@ -453,6 +453,24 @@ more details on assigning ANC status; see the `Causal conditional
 probabilities for in-facility delivery`_ section below for an explicit
 description of how to assign IFD status.
 
+.. note::
+
+  The facility choice causal optimization model has not yet been updated
+  to make use of all four ANC attendance categories or the corresponding
+  additional detail for ultrasound timing. Accordingly, the
+  :ref:`AI-ultrasound module
+  <2024_vivarium_mncnh_portfolio_ai_ultrasound_module>` currently groups
+  the last three ANC categories together, effectively making ANC
+  attendance a dichotomous variable with categories ordered "no ANC" <
+  "some ANC".
+
+  In a future version of the model, we plan to use the more detailed ANC
+  attendance information to determine whether simulants get a standard
+  ultrasound in the 1st trimester or in later pregnancy, which affects
+  the accuracy of GA estimation. Making these changes will require
+  updating the facility choice causal optimization code and the final
+  outputs used in the Vivarium simulation.
+
 To be more explicit about how the ordered categories and propensities
 work in code: If the categories are ordered from highest risk to lowest
 risk as :math:`c_1, \dotsc, c_n`, divide the unit interval :math:`[0,1]`


### PR DESCRIPTION
Jira ticket: [SSCI-2327](https://jira.ihme.washington.edu/browse/SSCI-2327)

Update the delivery facility choice model page to specify the order for the new 4-category ANC attendance variable, and note that the current version still treats ANC as dichotomous.

Note that the updates on this page refer to the updated AI ultrasound module in https://github.com/ihmeuw/vivarium_research/pull/1700