### PR TITLE
Add link to notebook for pregnancy-specific anemia impairment verification targets

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/anemia_component/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/anemia_component/module_document.rst
@@ -201,7 +201,8 @@ Note that simulants who died during labor should not experience any YLDs due to 
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++
 
-- Baseline simulated anemia YLDs should match corresponding pregnancy-specific GBD values. TODO: define specifically what these are (do they save pregnancy-specific impairment prevalence in GBD 2023 or do we need to calculate our own targets again?)
+- Baseline simulated anemia YLDs should match corresponding pregnancy-specific GBD values (see the 'Pregnancy-specific anemia prevalence and YLD in GBD 2023' section of `this notebook <https://github.com/ihmeuw/vivarium_research_mncnh_portfolio/blob/main/data_prep/gbd_data_pulling.ipynb>` in the research repo for how to pull these data.
+  Note: you need to make sure you have the latest version of db_queries to use the ``population_group_id=16`` argument in the get_outputs() call.)
 
 5.0 References
 +++++++++++++++


### PR DESCRIPTION
I finally managed to pull pregnancy-specific anemia impairment data (YLDs and prevalence) from GBD 2023! So I am adding a link to the V&V criteria on the anemia component page to make note of the call that finally worked for me.