### PR TITLE
Add model 12.1 V&V to table

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -1528,8 +1528,9 @@ Default stratifications to all observers should include scenario and input draw.
     - * Confirm neonatal cause-specific mortality risks match expectation for each preterm subcause
       * Confirm LBWSG risk effects are working as expected
       * Check whether neonatal cause-specific mortality risks match expectation for non-preterm causes
-    - 
-    - 
+    - Neonatal cause-specific mortality risks match expectation for both preterm and non-preterm causes *in the early neonatal period*.
+      We appear to be systematically underestimating preterm CSMRisks in the late neonatal period.
+    - `Model 12.1 neonatal checks notebook <https://github.com/ihmeuw/vivarium_research_mncnh_portfolio/blob/c8d568f37906732b6d2f3a630d8ec6be6b591fe7/verification_and_validation/model_12.1_nn_checks.ipynb>`_ 
   * - 13.0
     - * Confirm baseline maternal disorders burden still validates
       * Confirm hemoglobin exposure appropriately modifies maternal disorders incidence ratios (using the interactive sim), but no case fatality rates

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -1637,13 +1637,13 @@ Default stratifications to all observers should include scenario and input draw.
     - This is looking largely resolved in model 8.1, but we will wait to confirm once the LBWSG RR capping strategy is updated
     - Update LBWSG RR caps and PAF calculation strategy for model 12.0
     - For model 12.0
-  * - Neonatal mortality due to preterm birth slightly overestimated and remaining cause-specific mortality is generally underestimated despite this being resolved for all-cause mortality
-    - Unknown -- could be something to do with the neonatal mortality math? Removing the risk effect of LBWSG on NN enceph. did not seem to resolve the issue.
-    - Research team to discuss and consider 
+  * - Late neonatal mortality due to preterm birth slightly underestimated and other-causes mortality may be slightly overestimated (though within 10%)
+    - Possibly a PAF issue?
+    - Re-check when other known PAF issues are addressed
     - None for now
   * - In model 2: Found an error in GBD 2021 for Pakistan fistula modeling - need to come back in a future V&V run after we update the Pakistan OL prevalence values from GBD 2021 to GBD 2023. 
     - 
-    - Revist following GBD 2023 update
+    - Revisit following GBD 2023 update
     - On hold until GBD 2023 update
 
 


### PR DESCRIPTION
This is kind of half-finished, because I haven't yet addressed the V&V criteria of "Confirm LBWSG risk effects are working as expected."

But this was the main point of interest for this model, and 12.1 seems to have improved things substantially!

We think the remaining discrepancy may be an issue in our approach to calculating late neonatal PAFs.