### PR TITLE
Update IFA documentation based on new Cochrane review

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/concept_model.rst
@@ -1680,6 +1680,8 @@ Default stratifications to all observers should include scenario and input draw.
   
   * We could use the GBD risk effects between hemoglobin and stillbirth to model baseline correlation only and not model updates in stillbirth rates in response to changes in hemoglobin exposure to address this limitation (as these effects are captured in the impact of the hemoglobin-affecting interventions IV Iron and IFA/MMS already). However, this model upgrade is not highest priority. `See this backlog JIRA ticket #2343 <https://jira.ihme.washington.edu/browse/SSCI-2343>`_
 
+* [Finkelstein-et-al-2024]_ primarily includes RCTs from high-income countries, so the effect size for IFA on maternal hemoglobin may be overestimated for Sub-Saharan African countries (including Ethiopia and Nigeria) with typically higher rates of non-iron deficiency anemias.
+
 .. _mncnh_portfolio_7.0:
 
 7.0 References/Other

--- a/docs/source/models/intervention_models/mncnh_pregnancy/oral_iron_antenatal/oral_iron_antenatal.rst
+++ b/docs/source/models/intervention_models/mncnh_pregnancy/oral_iron_antenatal/oral_iron_antenatal.rst
@@ -185,9 +185,9 @@ Notably, the intervention will not affect the hemoglobin level of women of repro
     - Note
     - Source
   * - IFA
-    - +7.8 g/L (4.08, 11.52)
+    - +9.53 g/L (6.99 to 12.06)
     - Relative to no supplementation 
-    - [Oh-et-al-2020]_
+    - [Finkelstein-et-al-2024]_
   * - MMS
     - +0 g/L
     - Relative to IFA
@@ -550,4 +550,4 @@ References
 
   Finkelstein JL, Cuthbert A, Weeks J, Venkatramanan S, Larvie DY, De-Regil LM, Garcia-Casal MN. Daily oral iron supplementation during pregnancy. Cochrane Database of Systematic Reviews 2024, Issue 8. Art. No.: CD004736. DOI: 10.1002/14651858.CD004736.pub6.
 
-The following citations are defined in the :ref:`Antenatal supplementation document <maternal_supplementation_intervention>` from Nutrition Optimization project and should be referenced from there: [Gomes-et-al-2023-antenatal-supplementation], [Keats-et-al-2019-maternal-supplementation], [Li-et-al-2019-antenatal-supplementation], [Oh-et-al-2020]
+The following citations are defined in the :ref:`Antenatal supplementation document <maternal_supplementation_intervention>` from Nutrition Optimization project and should be referenced from there: [Gomes-et-al-2023-antenatal-supplementation], [Keats-et-al-2019-maternal-supplementation], [Li-et-al-2019-antenatal-supplementation]

--- a/docs/source/models/intervention_models/mncnh_pregnancy/oral_iron_antenatal/oral_iron_antenatal.rst
+++ b/docs/source/models/intervention_models/mncnh_pregnancy/oral_iron_antenatal/oral_iron_antenatal.rst
@@ -41,7 +41,7 @@ Maternal supplementation in low and middle income country settings is often acce
 There are various maternal supplementation regimens that provide varying combinations of micro- and macro-nutrients and therefore have varying impacts on both maternal and child health. 
 The two major classes of maternal supplementation regimens that we will be modeling are outlined in the table below.
 
-- **Iron and Folic Acid (IFA):** IFA affects outcomes including maternal anemia (which is a risk factor for maternal mortality) and infant birthweight (a risk factor for infant mortality). Additionally, folic acid deficiency is associated with haematological consequences and congenital malformations, however the effect on congenital malformations is sensitive to timing of administration relative to conception. The latest cochrane review of IFA trials was performed by [Pena-Rosas-et-al-2015]_; notably, as IFA is considered the current standard of care, there are few studies that compare IFA to placebo or no treatment.
+- **Iron and Folic Acid (IFA):** IFA affects outcomes including maternal anemia (which is a risk factor for maternal mortality) and infant birthweight (a risk factor for infant mortality). Additionally, folic acid deficiency is associated with haematological consequences and congenital malformations, however the effect on congenital malformations is sensitive to timing of administration relative to conception. The latest cochrane review of IFA trials was performed by [Finkelstein-et-al-2024]_; notably, as IFA is considered the current standard of care, there are few studies that compare IFA to placebo or no treatment.
 
 - **Multiple Micronutrient Supplementation (MMS):** MMS is a combination of micronutrients that includes iron and folic acid as well as other nutrients such as vitamin A and zinc. The latest cochrane review on MMS (containing IFA) relative to IFA alone was performed by [Keats-et-al-2019-maternal-supplementation]_.
 
@@ -260,7 +260,7 @@ We assume changes in simulant birthweight are independent from changes in their 
   * - IFA supplemented mothers (overall)
     - +57.73 g (7.66 to 107.79)
     - Relative to no supplementation 
-    - [Pena-Rosas-et-al-2015]_
+    - [Finkelstein-et-al-2024]_
   * - MMN supplemented mothers (overall)
     - +45.16 (32.31 to 58.02) 
     - Relative to IFA
@@ -546,4 +546,8 @@ Assumptions and limitations
 References
 ------------
 
-The following citations are defined in the :ref:`Antenatal supplementation document <maternal_supplementation_intervention>` from Nutrition Optimization project and should be referenced from there: [Gomes-et-al-2023-antenatal-supplementation], [Keats-et-al-2019-maternal-supplementation], [Li-et-al-2019-antenatal-supplementation], [Oh-et-al-2020], [Pena-Rosas-et-al-2015]
+.. [Finkelstein-et-al-2024]
+
+  Finkelstein JL, Cuthbert A, Weeks J, Venkatramanan S, Larvie DY, De-Regil LM, Garcia-Casal MN. Daily oral iron supplementation during pregnancy. Cochrane Database of Systematic Reviews 2024, Issue 8. Art. No.: CD004736. DOI: 10.1002/14651858.CD004736.pub6.
+
+The following citations are defined in the :ref:`Antenatal supplementation document <maternal_supplementation_intervention>` from Nutrition Optimization project and should be referenced from there: [Gomes-et-al-2023-antenatal-supplementation], [Keats-et-al-2019-maternal-supplementation], [Li-et-al-2019-antenatal-supplementation], [Oh-et-al-2020]


### PR DESCRIPTION
We found a new Cochrane review for the IFA intervention, so this PR:
- Updates the reference for the IFA effect size on birthweight to be the new Cochrane review (which reported the same value as the previous review)
- Updates the effect size on maternal hemoglobin concentration (Note: both the 2015 and new 2024 Cochrane reviews focus on mainly high-income countries, with no representation of Sub-Saharan Africa, there is an RCT from Pakistan included in both though. I could note the limitation that this might overestimate effect size on Hb given SSA countries have higher rates of non-iron deficiency anemias, but I haven't yet!)