### PR TITLE
Update links to IFA/MMS GA shifts

### DIFF
--- a/docs/source/models/intervention_models/mncnh_pregnancy/oral_iron_antenatal/oral_iron_antenatal.rst
+++ b/docs/source/models/intervention_models/mncnh_pregnancy/oral_iron_antenatal/oral_iron_antenatal.rst
@@ -387,7 +387,7 @@ Additionally, our methods differ from GBD's in that we estimated two separate GA
 
 2. Find and apply a second shift that replicates the preterm birth dichotomous effect when applied only to the portion of the distribution with baseline gestational age exposures that are *greater* than 32 (the very preterm birth threshold) *minus* this second shift. Note that the second shift will be negative in direction.
 
-`The estimation of the antenatal supplementation gestational age shifts as described was performed in this notebook <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/antenatal_interventions/Gestational%20age%20shifts.ipynb>`_
+`The estimation of the antenatal supplementation gestational age shifts as described was performed in this notebook <https://github.com/ihmeuw/vivarium_gates_mncnh/src/vivarium_gates_mncnh/data/ifa_mms_gestation_shifts/ifa_gestational_age_shifts.ipynb>`_
 
 Assumptions and limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -465,17 +465,12 @@ Where,
   * - Parameter
     - Value
   * - IFA_SHIFT
-    - `Location-specific .csv files of IFA_SHIFT values can be found here <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/tree/data_prep/data_prep/antenatal_interventions/ifa_gestational_age_shifts>`_
+    - `Location-specific .csv files of IFA_SHIFT values can be found here <https://github.com/ihmeuw/vivarium_gates_mncnh/src/vivarium_gates_mncnh/data/ifa_mms_gestation_shifts/ifa_gestational_age_shifts.csv>`_
   * - MMS_SHIFT_1
-    - `Location-specific .csv files of MMS_SHIFT_1 values can be found here <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/antenatal_interventions/updated_mms_shifts.csv>`_
+    - `Location-specific .csv files of MMS_SHIFT_1 values can be found here <https://github.com/ihmeuw/vivarium_gates_mncnh/src/vivarium_gates_mncnh/data/updated_mms_shifts.csv>`_
   * - MMS_SHIFT_2
-    - `Location-specific .csv files of MMS_SHIFT_2 values can be found here <https://github.com/ihmeuw/vivarium_research_nutrition_optimization/blob/data_prep/data_prep/antenatal_interventions/updated_mms_shifts.csv>`_
+    - `Location-specific .csv files of MMS_SHIFT_2 values can be found here <https://github.com/ihmeuw/vivarium_gates_mncnh/src/vivarium_gates_mncnh/data/updated_mms_shifts.csv>`_
 
-.. todo::
-
-  These notebooks are outdated from the Nutrition Optimization project, so we need to update the above notebook links once we update to new GBD rounds
-  and to the locations of interest for the :ref:`MNCNH Portfolio <2024_concept_model_vivarium_mncnh_portfolio>` simulation. 
-  Here is the relevant `JIRA ticket <https://jira.ihme.washington.edu/browse/SSCI-2209>`_.
 
 Verification and validation criteria
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR updates the links on the IFA/MMS intervention pages to the new IFA/MMS GA shift calculations (from [this PR](https://github.com/ihmeuw/vivarium_gates_mncnh/pull/107)). 