### PR TITLE
Alzheimer's model 4.2: Switch to Weibull distribution

### DIFF
--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -511,41 +511,43 @@ are located at the following paths on the cluster:
     - Dwell time in cause state BBBM-AD
     - :math:`T_\text{MCI} - T_\text{BBBM}`
     - Random variable for each simulant, constructed implicitly through
-      simulation dynamics to have approximately a `gamma distribution`_
-      with shape parameter :math:`\alpha` and rate parameter
+      simulation dynamics to have approximately a `Weibull
+      distribution`_ with shape parameter :math:`k` and scale parameter
       :math:`\lambda`
-  * - :math:`\alpha`, :math:`\lambda`
-    - Shape and rate parameters, respectively, of gamma distribution for
+  * - :math:`k`, :math:`\lambda`
+    - Shape and scale parameters, respectively, of Weibull distribution for
       :math:`D_\text{BBBM}`
-    - * :math:`\alpha = 14.0625`
-      * :math:`\lambda = 3.75`
-    - Chosen so that :math:`D_\text{BBBM}` has mean 3.75 and variance 1
-      because client said, "The BBBM+ state lasts about 3.5--4 years
-      before transitioning to MCI." Use the same parameters for all
+    - * :math:`k = 1.22`
+      * :math:`\lambda = 6.76`
+    - Chosen to match clien't specification for :math:`D_\text{BBBM}`:
+      The probability of progression from BBBM-AD to MCI-AD is about 50%
+      at 5 years and 80% at 10 years, corresponding to approximately a
+      15% annual rate of progression. Use the same parameters for all
       years, locations, age groups, and sexes.
-  * - gamma_dist
-    - Python object representing the gamma distribution for
+  * - bbbm_dist
+    - Python object representing the Weibull distribution for
       :math:`D_\text{BBBM}`
-    - scipy.stats.gamma(𝛼, scale=1/λ)
-    - An instance of `SciPy's gamma distribution class`_. Note that
-      SciPy accepts a scale parameter, which is the reciprocal of the
-      rate parameter.
+    - scipy.stats.weibull_min(k, scale=λ)
+    - An instance of `SciPy's Weibull distribution class`_.
   * - :math:`h_\text{MCI}(t)`
     - Hazard function for transitioning into the MCI-AD state from BBBM-AD
-    - * gamma_dist.pdf(t) / gamma_dist.sf(t), or
-      * exp( gamma_dist.logpdf(t) --- gamma_dist.logsf(t) ), an
+    - * bbbm_dist.pdf(t) / bbbm_dist.sf(t), or
+      * exp( bbbm_dist.logpdf(t) --- bbbm_dist.logsf(t) ), an
         equivalent expression that may help avoid underflow
-    - Equal to :math:`\frac{t^{\alpha-1}e^{-\lambda t}}{\int_t^\infty
-      u^{\alpha-1} e^{-\lambda u}\, du}`, but can be computed more
-      easily as the ratio of the probability density function to the
-      survival function, using the methods defined in `SciPy's gamma
+    - Equal to :math:`\frac{k}{\lambda}
+      \left(\frac{t}{\lambda}\right)^{k-1}`, but can also be computed as
+      the ratio of the probability density function to the survival
+      function, using the methods defined in `SciPy's Weibull
       distribution class`_
   * - :math:`\Delta_\text{BBBM}`
     - Average duration of BBBM-presymptomatic AD in the absence of
       mortality
-    - :math:`\alpha / \lambda`
-    - Mean of gamma distribution for :math:`D_\text{BBBM}`. Does not vary by
-      year, location, age group, or sex.
+    - :math:`\lambda \Gamma(1 + 1/k)`, where :math:`\Gamma` is the
+      `gamma function`_
+    - Mean of gamma distribution for :math:`D_\text{BBBM}`. The gamma
+      function can be computed using `scipy.special.gamma`_, or the mean
+      can be computed as bbbm_dist.mean(). Does not vary by year,
+      location, age group, or sex.
   * - :math:`\Delta_\text{MCI}`
     - Average duration of MCI due to AD in the absence of mortality
     - 3.85 years
@@ -586,8 +588,16 @@ are located at the following paths on the cluster:
   https://github.com/ihmeuw/vivarium_research_alzheimers/blob/4d5dde0b74eb09ea997af7c2de88b81670ba7d61/2025_08_03a_alz_dw_explore.ipynb
 .. _gamma distribution:
   https://en.wikipedia.org/wiki/Gamma_distribution
+.. _Weibull distribution:
+  https://en.wikipedia.org/wiki/Weibull_distribution
 .. _SciPy's gamma distribution class:
   https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gamma.html
+.. _SciPy's Weibull distribution class:
+  https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.weibull_min.html
+.. _gamma function:
+  https://en.wikipedia.org/wiki/Gamma_function
+.. _scipy.special.gamma:
+  https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.gamma.html
 .. _Potashman et al.:
   https://doi.org/10.1007/s40120-021-00272-1
 

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -101,10 +101,12 @@ restriction on YLDs for the MCI-AD state of the cause model below.
     - * 40 to 44 for AD-dementia cause state
       * No *a priori* age restriction for MCI-AD cause state
     - * Restriction to age_group_id = 13 (40 to 44) for AD-dementia
-        cause state is from GBD
-      * In practice, the age start for MCI-AD will be age_group_id = 11
-        (30 to 34) because we will be adding simulants at most 7 years
-        before AD incidence (so 40 - 7 = 33, in the 30-34 age group)
+        cause state is from GBD. However, due to simulation dynamics, it is
+        possible for simulants to enter this state before age 40.
+      * In practice, the age start for MCI-AD will be age_group_id = 10
+        (25 to 29) because we will be adding simulants at most 10.2
+        years before AD incidence (so 40 -- 10.2 = 29.8, in the 25-29
+        age group)
   * - YLD age group end
     - 95 plus
     - age_group_id = 235

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -542,11 +542,11 @@ are located at the following paths on the cluster:
   * - :math:`\Delta_\text{BBBM}`
     - Average duration of BBBM-presymptomatic AD in the absence of
       mortality
-    - :math:`\lambda \Gamma(1 + 1/k)`, where :math:`\Gamma` is the
-      `gamma function`_
-    - Mean of gamma distribution for :math:`D_\text{BBBM}`. The gamma
-      function can be computed using `scipy.special.gamma`_, or the mean
-      can be computed as bbbm_dist.mean(). Does not vary by year,
+    - bbbm_dist.mean()
+    - Equal to :math:`\lambda \Gamma(1 + 1/k)`, where :math:`\Gamma` is
+      the `gamma function`_.  Can be computed using
+      `scipy.special.gamma`_, but using bbbm_dist.mean() is more general
+      if we update the underlying distribution. Does not vary by year,
       location, age group, or sex.
   * - :math:`\Delta_\text{MCI}`
     - Average duration of MCI due to AD in the absence of mortality

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -519,11 +519,11 @@ are located at the following paths on the cluster:
       :math:`D_\text{BBBM}`
     - * :math:`k = 1.22`
       * :math:`\lambda = 6.76`
-    - Chosen to match clien't specification for :math:`D_\text{BBBM}`:
+    - Chosen to match client's specification for :math:`D_\text{BBBM}`:
       The probability of progression from BBBM-AD to MCI-AD is about 50%
-      at 5 years and 80% at 10 years, corresponding to approximately a
-      15% annual rate of progression. Use the same parameters for all
-      years, locations, age groups, and sexes.
+      at 5 years and 80% at 10 years, corresponding to an average annual
+      rate of progression of approximately 15% . Use the same parameters
+      for all years, locations, age groups, and sexes.
   * - bbbm_dist
     - Python object representing the Weibull distribution for
       :math:`D_\text{BBBM}`

--- a/docs/source/models/concept_models/vivarium_alzheimers/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_alzheimers/concept_model.rst
@@ -229,13 +229,15 @@ The basic plan for the design of the simulation is as follows:
     - Males & Females
     -
   * - Age start (Initialization)
-    - Age at which preclinical AD starts (~30 years or later)
+    - Age at which preclinical AD starts (currently set to 25 years to
+      accommodate the youngest preclinical AD incident cases)
     - Age start is simulant-dependent
   * - Age end (Initialization)
     - 125 years
     - End of oldest age group
   * - Age start (Observation)
-    - Age at which preclinical AD starts (~30 years or later)
+    - Age at which preclinical AD starts (currently set to 25 years to
+      accommodate the youngest preclinical AD incident cases)
     - All simulants are observed since all have AD or its precursors
   * - Age end (Observation)
     - 125 years or death


### PR DESCRIPTION
Changes the hazard function for the BBBM->MCI transition from a Gamma distribution to a Weibull distribution, with a larger mean and variance. Based on input from client.