### PR TITLE
Alzheimer's Model 5 (use AD proportion of GBD 2023 dementia envelope)

### DIFF
--- a/docs/source/model_design/vivarium_model_components/causes/index.rst
+++ b/docs/source/model_design/vivarium_model_components/causes/index.rst
@@ -671,6 +671,8 @@ Progression Transitions
 Severity Splits
 ^^^^^^^^^^^^^^^
 
+.. _models_cause_mortality_impacts:
+
 Mortality Impacts
 +++++++++++++++++
 

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -313,29 +313,40 @@ been in that state. For simulants in BBBM-AD at time :math:`t=0`, assign
   If we model the entire population including susceptible simulants, the
   state data should be modified as follows.
 
-  Define :math:`p_\textsf{X}` to be the prevalence of cause state X in the
-  total population including susceptible simulants, and define
-  :math:`p_\text{(all AD states)}` to be the sum of :math:`p_\textsf{X}` for
-  the three AD cause states X. Then multiplying the prevalence of each AD state
-  in the :ref:`above state data table
+  Define :math:`p_\textsf{X}` to be the prevalence of cause state X in
+  the total population including susceptible simulants, and define
+  :math:`p_\text{(all AD states)}` to be the sum of :math:`p_\textsf{X}`
+  for the three AD cause states X. Then multiplying the prevalence of
+  each AD state in the :ref:`above state data table
   <2021_cause_alzheimers_presymptomatic_mci_state_data_table>` by
-  :math:`p_\text{(all AD states)}` gives the prevalence of that state in the
-  entire population. Since we know that :math:`p_\text{AD} =
-  \text{prevalence_c543}` (the GBD prevalence of Alzheimer's disease and other
-  dementias), we can solve to obtain
+  :math:`p_\text{(all AD states)}` gives the prevalence of that state in
+  the entire population. Since we know that
+
+  .. math::
+
+    \begin{align*}
+    p_\text{AD}
+    &= \text{prevalence_AD} \\
+    &= \text{prevalence_m24351} \times \text{proportion_AD},
+    \end{align*}
+
+  the prevalence of AD dementia computed from GBD's dementia envelope
+  (see :ref:`data values and sources table below
+  <2021_cause_alzheimers_presymptomatic_mci_data_sources_table>`), we
+  can solve to obtain
 
   .. math::
     :label: prevalence_all_AD_states_eq
 
     p_\text{(all AD states)}
     = \frac{\Delta_\text{(all AD states)}}{\Delta_\text{AD}}
-      \cdot \text{prevalence_c543}
+      \cdot \text{prevalence_AD}
     \quad\text{(for ages 40+)}.
 
   Note that since the GBD prevalence applies to a given demographic
   group, so does the formula for :math:`p_\text{(all AD states)}`. The
   above formula applies to age groups 40+ since this is where
-  prevalence_c543 and :math:`\Delta_\text{AD}` are nonzero. For ages
+  prevalence_AD and :math:`\Delta_\text{AD}` are nonzero. For ages
   30--39, use the value of :math:`p_\text{(all AD states)}` for age
   group 40--44; for ages <30, set :math:`p_\text{(all AD states)} = 0`.
   The following state data table shows the resulting initial prevalences
@@ -375,7 +386,7 @@ been in that state. For simulants in BBBM-AD at time :math:`t=0`, assign
     population model page <other_models_alzheimers_population>`,
     :math:`p_\text{(all AD states)}` refers to the prevalence within the entire
     population of a location, including all age groups and sexes. On the other
-    hand, if we pull prevalence_c543 for a specific demographic subgroup
+    hand, if we compute prevalence_AD for a specific demographic subgroup
     :math:`g` (e.g., a single age group and sex) and year :math:`t`, then
     :math:`p_\text{(all AD states)}` as computed in
     :eq:`prevalence_all_AD_states_eq` corresponds to :math:`p_{g,t}` on the

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -144,30 +144,20 @@ For :ref:`Model 4 <2025_alzheimers_model_runs_table>` of the :ref:`CSU
 Alzheimer's simulation <2025_concept_model_vivarium_alzheimers>`, we
 will add two pre-dementia states to the Alzheimer's disease model. The
 model still functions similar to an SI model, but now there are multiple
-with-condition states, with unidirectional progression between them.
+with-condition states, with unidirectional progression between them. In
+Model 4 we used the incidence and prevalence for GBD's "Alzheimer's disease
+and other dementias" (cause ID 543), so our numbers were inflated by
+the "other dementias" part.
 
-Since this cause model only includes Alzheimer's disease and its
-precursors, not other types of dementia, we do not want to directly use
-the prevalence and incidence data from
-
-Since the most relevant GBD cause for this model is "Alzheimer's disease
-and other dementias" (cause ID 543), we need a way to separate out
-Alzheimer's disease from other dementias in the data. The dementia team
-has made estimates (unpublished as of September 2025) of the proportion
-of total dementia
-
-The recommendation
-from IHME's dementia team was to not use the published GBD data
-directly, but to start with the "dementia envelope" data from
-DisMod, and multiply by the.
-
-
-Conceptually, this cause model only includes Alzheimer's disease and its
-precursors, not other types of dementia. However, for now we are still
-using the total incidence and prevalence for GBD's "Alzheimer's disease
-and other dementias" (cause ID 543), so our numbers will be inflated by
-the "other dementias" part. In a future model version we will remove the
-"other dementias" portion  to correct this issue.
+In :ref:`Model 5 <2025_alzheimers_model_runs_table>`, we remove the
+"other dementias" from the disease model. To do this, the dementia
+modelers recommended *not* using the published GBD data directly, but to
+start with the GBD 2023 "dementia envelope" data from DisMod, and
+multiply by proportion of the envelope due to Alzheimer's disease. The
+estimates of the proportions of the envelope due to each dementia
+subtype are unpublished as of September 2025, but the modelers shared a
+.csv file we can use as long as we don't expose the raw numbers. See the
+`Data Values and Sources`_ section below for details.
 
 Cause Model Diagram
 -------------------

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -398,18 +398,18 @@ Data Values and Sources
 Unless otherwise noted, all data values depend on year, location, age group,
 and sex, as defined by GBD.
 
-The population (:file:`population_agg.nc`) and mortality rates
-(:file:`_all.nc`) files from the Future Health Scenarios (FHS) team and the
-disability weights file (:file:`all.hdf`) saved by the Simulation Science team
-are located at the following paths on the cluster:
+The following paths on the cluster contain the data files listed in the
+table below:
+
+* :file:`population_agg.nc` and :file:`mortality_all.nc` from FHS team
+* :file:`squeezed_proportions_to_sim_sci.csv` from dementia modelers
+* :file:`all.hdf` disability weight file saved by Simulation Science team
 
 .. code-block:: bash
 
-  # Age-specific population from FHS team:
-  /mnt/share/forecasting/data/9/future/population/20240320_daly_capstone_resubmission_squeeze_soft_round_shifted_hiv_shocks_covid_all_who_reagg/population_agg.nc
-
-  # Deaths rates from FHS team:
-  /snfs1/Project/forecasting/results/7/future/death/20240320_daly_capstone_resubmission_squeeze_soft_round_shifted_hiv_shocks_covid_all_who_reagg/_all.nc
+  # Data folder for Alzheimer's sim, including data from FHS team and
+  # dementia modelers (see README.txt for data provenance)
+  /mnt/team/simulation_science/pub/models/vivarium_csu_alzheimers/data
 
   # Disability weights saved by Simscience team:
   /mnt/team/simulation_science/costeffectiveness/auxiliary_data/GBD_2021/02_processed_data/disability_weight/sequela/all/all.hdf
@@ -449,7 +449,8 @@ are located at the following paths on the cluster:
     -
   * - :math:`p_\textsf{X}`
     - Prevalence of cause state X in total population
-    - defined in :ref:`Attention box above
+    - Defined in the "Initial prevalence" column of the state data table
+      in the :ref:`Attention box above
       <alzheimers_cause_state_data_including_susceptible_note>`
     - By definition, :math:`p_\text{AD} =` prevalence_AD, and
       :math:`p_\text{BBBM}` and :math:`p_\text{MCI}` are derived from
@@ -473,18 +474,19 @@ are located at the following paths on the cluster:
       constant over time in each demographic group.
   * - acmr
     - All-cause mortality rate
-    - loaded from :file:`_all.nc` file provided by FHS Team
-    - Draw-level, age-specific forecasts. See `Abie's population and
-      mortality forecasts notebook`_ for a demonstration of how to load
-      and transform the ``.nc`` file
+    - :file:`mortality_all.nc`
+    - Draw-level, age-specific forecasts from GBD 2021 Forecasting
+      Capstone. See `Abie's population and mortality forecasts
+      notebook`_ for a demonstration of how to load and transform the
+      ``.nc`` file
   * - population_forecast
     - Forecasted average population during specified year
-    - loaded from :file:`population_agg.nc` file provided by FHS Team
-    - Draw-level, age-specific forecasts. Numerically equal to
-      person-years. Used in AD population model to calculate BBBM-AD
-      incidence counts. See `Abie's population and mortality forecasts
-      notebook`_ for a demonstration of how to load and transform the
-      ``.nc`` file.
+    - :file:`population_agg.nc`
+    - Draw-level, age-specific forecasts from GBD 2021 Forecasting
+      Capstone. Numerically equal to person-years. Used in AD population
+      model to calculate BBBM-AD incidence counts. See `Abie's
+      population and mortality forecasts notebook`_ for a demonstration
+      of how to load and transform the ``.nc`` file.
   * - :math:`\text{population}_{2021}`
     - Average population during the year 2021
     - get_population
@@ -512,7 +514,7 @@ are located at the following paths on the cluster:
       constant over time in each demographic group.
   * - emr_X
     - Excess mortality rate in cause state X
-    - values listed in "Excess mortality rate" column of :ref:`state
+    - Values listed in "Excess mortality rate" column of :ref:`state
       data table above
       <2021_cause_alzheimers_presymptomatic_mci_state_data_table>`
     -
@@ -522,7 +524,7 @@ are located at the following paths on the cluster:
     -
   * - sequelae_c543
     - Sequelae of Alzheimer's disease and other dementias
-    - set of 3 sequelae: s452, s453, s454
+    - Set of 3 sequelae: s452, s453, s454
     - Obtained from gbd_mapping.
       Sequela names are "Mild," "Moderate," or "Severe Alzheimer's
       disease and other dementias," respectively. Same for all years,
@@ -576,7 +578,7 @@ are located at the following paths on the cluster:
       explanation.
   * - :math:`T_X`
     - The time at which a simulant enters the cause state :math:`X`
-    - determined within the simulation
+    - Determined within the simulation
     - Random variable for each simulant. :math:`T_\text{BBBM}` is used to
       determine how long a simulant has been in the BBBM-AD state, in order to
       compute the hazard rate of transitioning to MCI-AD at a given simulation

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -457,8 +457,8 @@ table below:
       this
   * - :math:`p_\text{(all AD states)}`
     - Prevalence of all stages of AD combined
-    - :math:`p_\text{BBBM} + p_\text{MCI} + p_\text{AD}`
-    -
+    - Defined in :eq:`prevalence_all_AD_states_eq` above
+    - Equals :math:`p_\text{BBBM} + p_\text{MCI} + p_\text{AD}`
   * - incidence_m24351
     - Total-population incidence rate for GBD 2023 dementia envelope
     - get_draws( source="epi", gbd_id_type = "modelable_entity_id",
@@ -468,10 +468,11 @@ table below:
   * - incidence_AD
     - Total-population incidence rate of AD dementia
     - incidence_m24351 :math:`\times` proportion_AD
-    - Used in AD population model to calculate BBBM-AD incidence. We are
-      assuming the prevalence proportions can be applied to
-      incidence. We are assuming the AD-dementia incidence rate is
-      constant over time in each demographic group.
+    - Used in :ref:`AD population model
+      <other_models_alzheimers_population>` to calculate BBBM-AD
+      incidence. We are assuming the prevalence proportions can be
+      applied to incidence. We are assuming the AD-dementia incidence
+      rate is constant over time in each demographic group.
   * - acmr
     - All-cause mortality rate
     - :file:`mortality_all.nc`
@@ -483,10 +484,11 @@ table below:
     - Forecasted average population during specified year
     - :file:`population_agg.nc`
     - Draw-level, age-specific forecasts from GBD 2021 Forecasting
-      Capstone. Numerically equal to person-years. Used in AD population
-      model to calculate BBBM-AD incidence counts. See `Abie's
-      population and mortality forecasts notebook`_ for a demonstration
-      of how to load and transform the ``.nc`` file.
+      Capstone. Numerically equal to person-years. Used in :ref:`AD
+      population model <other_models_alzheimers_population>` to
+      calculate BBBM-AD incidence counts. See `Abie's population and
+      mortality forecasts notebook`_ for a demonstration of how to load
+      and transform the ``.nc`` file.
   * - :math:`\text{population}_{2021}`
     - Average population during the year 2021
     - get_population
@@ -517,11 +519,13 @@ table below:
     - Values listed in "Excess mortality rate" column of :ref:`state
       data table above
       <2021_cause_alzheimers_presymptomatic_mci_state_data_table>`
-    -
+    - * emr_S, emr_BBBM, emr_MCI, emr_AD
   * - m_X
     - Mortality hazard in cause state X
     - acmr --- csmr_c543 + emr_X
-    -
+    - * m_S, m_BBBM, m_MCI, m_AD
+      * See :ref:`Mortality Impacts <models_cause_mortality_impacts>`
+        section of cause model design page
   * - sequelae_c543
     - Sequelae of Alzheimer's disease and other dementias
     - Set of 3 sequelae: s452, s453, s454

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -63,6 +63,10 @@ Disease Overview
 GBD 2021 Modeling Strategy
 ++++++++++++++++++++++++++
 
+The IHME dementia modelers first use DisMod to estimate a "dementia
+envelope" to get the prevalence and incidence of all types of
+dementia.
+
 Restrictions
 ------------
 
@@ -119,6 +123,22 @@ Alzheimer's simulation <2025_concept_model_vivarium_alzheimers>`, we
 will add two pre-dementia states to the Alzheimer's disease model. The
 model still functions similar to an SI model, but now there are multiple
 with-condition states, with unidirectional progression between them.
+
+Since this cause model only includes Alzheimer's disease and its
+precursors, not other types of dementia, we do not want to directly use
+the prevalence and incidence data from
+
+Since the most relevant GBD cause for this model is "Alzheimer's disease
+and other dementias" (cause ID 543), we need a way to separate out
+Alzheimer's disease from other dementias in the data. The dementia team
+has made estimates (unpublished as of September 2025) of the proportion
+of total dementia
+
+The recommendation
+from IHME's dementia team was to not use the published GBD data
+directly, but to start with the "dementia envelope" data from
+DisMod, and multiply by the.
+
 
 Conceptually, this cause model only includes Alzheimer's disease and its
 precursors, not other types of dementia. However, for now we are still

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -63,9 +63,31 @@ Disease Overview
 GBD 2021 Modeling Strategy
 ++++++++++++++++++++++++++
 
-The IHME dementia modelers first use DisMod to estimate a "dementia
-envelope" to get the prevalence and incidence of all types of
-dementia.
+The IHME dementia modelers use DisMod to estimate the prevalence and
+incidence of a "dementia envelope" comprising all types of dementia
+combined, and then they estimate what proportion of the envelope
+corresponds to each subtype of dementia. The proportions of dementia due
+to stroke, Parkinson's disease, Down's syndrome, and traumatic brain
+injury are attributed to those GBD causes, and the remaining dementia in
+the envelope is attributed to the GBD cause "Alzheimer's disease and
+other dementias" (cause ID 543).
+
+For further information, see the methods appendices and HUB page:
+
+* `Alzheimer's disease and other dementias in the GBD 2021 fatal methods
+  appendix <ADOD_2021_fatal_methods_appendix_>`_
+* `Alzheimer's disease and other dementias in the GBD 2021 nonfatal
+  methods appendix <ADOD_2021_nonfatal_methods_appendix_>`_
+* `Alzheimer's/Dementia HUB page <ADOD_HUB_page_>`_
+
+.. _ADOD_2021_fatal_methods_appendix:
+  https://www.healthdata.org/gbd/methods-appendices-2021/alzheimers-disease-and-other-dementias
+
+.. _ADOD_2021_nonfatal_methods_appendix:
+  https://www.healthdata.org/gbd/methods-appendices-2021/alzheimers-disease-and-other-dementias-0
+
+.. _ADOD_HUB_page:
+  https://hub.ihme.washington.edu/spaces/BIRDS/pages/123831566/Alzheimers+Dementia
 
 Restrictions
 ------------

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -422,6 +422,11 @@ are located at the following paths on the cluster:
       area under the population curve). See `Abie's population and mortality
       forecasts notebook`_ for a demonstration of how to load and transform the
       ``.nc`` file.
+  * - proportion_AD
+    - The proportion of the dementia envelope that is Alzheimer's
+      disease dementia
+    - :file:`squeezed_proportions_to_sim_sci.csv`
+    -
   * - deaths_c543
     - Deaths from Alzheimer's disease and other dementias
     - codcorrect
@@ -429,22 +434,35 @@ are located at the following paths on the cluster:
   * - prevalence_c543
     - Prevalence of Alzheimer's disease and other dementias
     - como
+    - Used only for calculation of emr_c543 by Vivarium Inputs
+  * - prevalence_m24351
+    - Prevalence of dementia envelope
+    - epi
+    -
+  * - prevalence_AD
+    - Prevalence of AD dementia in total population
+    - prevalence_m24351 :math:`\times` proportion_AD
     -
   * - :math:`p_\textsf{X}`
     - Prevalence of cause state X in total population
     - defined in :ref:`Attention box above
       <alzheimers_cause_state_data_including_susceptible_note>`
-    -
+    - Note that :math:`p_\text{AD} =` prevalence_AD by definition, and
+      :math:`p_\text{BBBM}` and :math:`p_\text{MCI}` are derived from
+      this
   * - :math:`p_\text{(all AD states)}`
     - Prevalence of all stages of AD combined
     - :math:`p_\text{BBBM} + p_\text{MCI} + p_\text{AD}`
     -
-  * - incidence_rate_c543
-    - GBD's "total population incidence rate" for Alzheimer's disease
-      and other dementias
-    - como
-    - Raw GBD value, different from "susceptible incidence rate"
-      automatically calculated by Vivarium Inputs
+  * - incidence_m24351
+    - GBD's "total population incidence rate" for dementia envelope
+    - epi
+    - Raw value from get_draws, different from "susceptible incidence
+      rate" automatically calculated by Vivarium Inputs
+  * - incidence_AD
+    - Total-population incidence rate of AD dementia
+    - incidence_m24351 :math:`\times` proportion_AD
+    -
   * - acmr
     - All-cause mortality rate
     - loaded from :file:`_all.nc` file provided by FHS Team
@@ -589,7 +607,7 @@ are located at the following paths on the cluster:
       chance of dying within a year when starting in the MCI state.
   * - :math:`\Delta_\text{AD}`
     - Average duration of AD-dementia
-    - * prevalence_c543 / incidence_rate_c543 for ages 40+
+    - * prevalence_AD / incidence_AD for ages 40+
       * 0 for ages under 40
     - Follows from the steady-state equation (prevalent cases) = (incident
       cases) x (average duration). Note that the denominator is the **raw

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -413,28 +413,16 @@ are located at the following paths on the cluster:
     - Definition
     - Source or value
     - Notes
-  * - population
-    - Average population during specified year
-    - loaded from :file:`population_agg.nc` file provided by FHS Team
-    - Numerically equal to person-years. Often interpreted as population at
-      year's midpoint (which is approximately equal to person-years if we think
-      the midpoint rule with a single rectangle gives a good estimate of the
-      area under the population curve). See `Abie's population and mortality
-      forecasts notebook`_ for a demonstration of how to load and transform the
-      ``.nc`` file.
   * - proportion_AD
     - The proportion of the dementia envelope that is Alzheimer's
       disease dementia
     - :file:`squeezed_proportions_to_sim_sci.csv`
-    -
-  * - deaths_c543
-    - Deaths from Alzheimer's disease and other dementias
-    - codcorrect
-    -
-  * - prevalence_c543
-    - Prevalence of Alzheimer's disease and other dementias
-    - como
-    - Used only for calculation of emr_c543 by Vivarium Inputs
+    - Point estimate stratified by age group and sex for ages 40+.
+      Filter to type_label == "Alzheimer's disease".
+
+      **Note:** These estimates were provided by the dementia modelers
+      and are not yet published, so they should not be stored directly
+      in the Artifact or any other public location.
   * - prevalence_m24351
     - Prevalence of dementia envelope
     - epi
@@ -447,7 +435,7 @@ are located at the following paths on the cluster:
     - Prevalence of cause state X in total population
     - defined in :ref:`Attention box above
       <alzheimers_cause_state_data_including_susceptible_note>`
-    - Note that :math:`p_\text{AD} =` prevalence_AD by definition, and
+    - By definition, :math:`p_\text{AD} =` prevalence_AD, and
       :math:`p_\text{BBBM}` and :math:`p_\text{MCI}` are derived from
       this
   * - :math:`p_\text{(all AD states)}`
@@ -466,17 +454,42 @@ are located at the following paths on the cluster:
   * - acmr
     - All-cause mortality rate
     - loaded from :file:`_all.nc` file provided by FHS Team
-    - See `Abie's population and mortality forecasts notebook`_ for a
-      demonstration of how to load and transform the ``.nc`` file
+    - Draw-level, age-specific forecasts. See `Abie's population and
+      mortality forecasts notebook`_ for a demonstration of how to load
+      and transform the ``.nc`` file
+  * - population_forecast
+    - Forecasted average population during specified year
+    - loaded from :file:`population_agg.nc` file provided by FHS Team
+    - Draw-level, age-specific forecasts. Numerically equal to
+      person-years. Used to calculate BBBM-AD incidence counts in AD
+      population model. See `Abie's population and mortality forecasts
+      notebook`_ for a demonstration of how to load and transform the
+      ``.nc`` file.
+  * - :math:`\text{population}_{2021}`
+    - Average population during the year 2021
+    - get_population
+    - Point estimate. Used only for the calculation of csmr_c543 by
+      Vivarium Inputs
+  * - :math:`\text{deaths_c543}_{2021}`
+    - Deaths from Alzheimer's disease and other dementias in 2021
+    - codcorrect
+    - Used only for the calculation of csmr_c543 by Vivarium Inputs
   * - csmr_c543
     - Cause-specific mortality rate for Alzheimer's disease and other
       dementias
-    - :math:`\frac{\text{deaths_c543}}{(\text{population}) \cdot (\text{1 year})}`
-    - Calculated automatically by Vivarium Inputs
+    - :math:`\frac{\text{deaths_c543}_{2021}}{(\text{population}_{2021})
+      \cdot (\text{1 year})}`
+    - Calculated automatically by Vivarium Inputs. Assumed to remain
+      constant over time in each demographic group.
+  * - :math:`\text{prevalence_c543}_{2021}`
+    - Prevalence of Alzheimer's disease and other dementias in 2021
+    - como
+    - Used only for calculation of emr_c543 by Vivarium Inputs
   * - emr_c543
     - Excess mortality rate for Alzheimer's disease and other dementias
-    - :math:`\frac{\text{csmr_c543}}{\text{prevalence_c543}}`
-    - Calculated automatically by Vivarium Inputs
+    - :math:`\frac{\text{csmr_c543}}{\text{prevalence_c543}_{2021}}`
+    - Calculated automatically by Vivarium Inputs. Assumed to remain
+      constant over time in each demographic group.
   * - emr_X
     - Excess mortality rate in cause state X
     - values listed in :ref:`state data table above

--- a/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
+++ b/docs/source/models/causes/alzheimers/presymptomatic_and_mci_gbd_2021/index.rst
@@ -418,15 +418,20 @@ are located at the following paths on the cluster:
       disease dementia
     - :file:`squeezed_proportions_to_sim_sci.csv`
     - Point estimate stratified by age group and sex for ages 40+.
-      Filter to type_label == "Alzheimer's disease".
+      Includes proportions for all subtypes of dementia --- filter to
+      type_label == "Alzheimer's disease".
 
       **Note:** These estimates were provided by the dementia modelers
       and are not yet published, so they should not be stored directly
       in the Artifact or any other public location.
   * - prevalence_m24351
-    - Prevalence of dementia envelope
-    - epi
-    -
+    - Prevalence of GBD 2023 dementia envelope
+    - get_draws( source="epi", gbd_id_type = "modelable_entity_id",
+      gbd_id=24351, release_id=16, year_id=2023, measure_id=5 )
+    - The dementia envelope represents the combined prevalence all types
+      of dementia. By contrast, the GBD cause "Alzheimer's disease and
+      other dementias" (c543) does not include certain dementias that
+      result from other modeled GBD causes.
   * - prevalence_AD
     - Prevalence of AD dementia in total population
     - prevalence_m24351 :math:`\times` proportion_AD
@@ -443,14 +448,18 @@ are located at the following paths on the cluster:
     - :math:`p_\text{BBBM} + p_\text{MCI} + p_\text{AD}`
     -
   * - incidence_m24351
-    - GBD's "total population incidence rate" for dementia envelope
-    - epi
-    - Raw value from get_draws, different from "susceptible incidence
-      rate" automatically calculated by Vivarium Inputs
+    - Total-population incidence rate for GBD 2023 dementia envelope
+    - get_draws( source="epi", gbd_id_type = "modelable_entity_id",
+      gbd_id=24351, release_id=16, year_id=2023, measure_id=6 )
+    - Raw value from get_draws, different from susceptible-population
+      incidence rate automatically calculated by Vivarium Inputs
   * - incidence_AD
     - Total-population incidence rate of AD dementia
     - incidence_m24351 :math:`\times` proportion_AD
-    -
+    - Used in AD population model to calculate BBBM-AD incidence. We are
+      assuming the prevalence proportions can be applied to
+      incidence. We are assuming the AD-dementia incidence rate is
+      constant over time in each demographic group.
   * - acmr
     - All-cause mortality rate
     - loaded from :file:`_all.nc` file provided by FHS Team
@@ -461,8 +470,8 @@ are located at the following paths on the cluster:
     - Forecasted average population during specified year
     - loaded from :file:`population_agg.nc` file provided by FHS Team
     - Draw-level, age-specific forecasts. Numerically equal to
-      person-years. Used to calculate BBBM-AD incidence counts in AD
-      population model. See `Abie's population and mortality forecasts
+      person-years. Used in AD population model to calculate BBBM-AD
+      incidence counts. See `Abie's population and mortality forecasts
       notebook`_ for a demonstration of how to load and transform the
       ``.nc`` file.
   * - :math:`\text{population}_{2021}`
@@ -492,7 +501,8 @@ are located at the following paths on the cluster:
       constant over time in each demographic group.
   * - emr_X
     - Excess mortality rate in cause state X
-    - values listed in :ref:`state data table above
+    - values listed in "Excess mortality rate" column of :ref:`state
+      data table above
       <2021_cause_alzheimers_presymptomatic_mci_state_data_table>`
     -
   * - m_X

--- a/docs/source/models/concept_models/vivarium_alzheimers/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_alzheimers/concept_model.rst
@@ -204,6 +204,8 @@ The basic plan for the design of the simulation is as follows:
 4.1 Default Parameter Specifications
 ------------------------------------
 
+.. _2025_concept_model_vivarium_alzheimers_sim_parameter_specs:
+
 .. list-table:: Default Simulation Parameter Specifications
   :header-rows: 1
   :widths: 5 7 7

--- a/docs/source/models/other_models/alzheimers_population/index.rst
+++ b/docs/source/models/other_models/alzheimers_population/index.rst
@@ -60,18 +60,14 @@ necessary population size for the :ref:`CSU Alzheiemer's simulation
 <2025_concept_model_vivarium_alzheimers>`. The model document is split
 into two parts: 1) initializing the population, and 2) adding new
 simulants during the simulated timeframe. We will also describe two
-different versions of the population model, corresponding to
-progressive model version of the CSU Alzheiemer's simulation:
+different versions of the population model, corresponding to progressive
+:ref:`model versions <2025_alzheimers_model_runs_table>` of the CSU
+Alzheiemer's simulation:
 
 #. **Models 2 and 3:** Modeling simulants with Alzheimer's disease (AD)
    and other dementias as defined by GBD
 #. **Model 4 and above:** Modeling simulants with presymptomatic AD,
    MCI, or AD dementia
-
-Since this is the model that
-includes details on how to use forecasts of population size, we have also
-included information on how to use forecasts of all-cause mortality rate
-(this is not really part of the Alzheimer's Population Model however).
 
 Initializing the Population
 +++++++++++++++++++++++++++
@@ -707,8 +703,7 @@ terms of these values.
       specifications table in the concept model|
     - Includes all demographic groups
   * - :math:`Y^\text{real}_{g,t}`
-    - Draw-level age-specific total population forecast in demographic
-      group :math:`g` at time :math:`t`
+    - Total population of demographic group :math:`g` at time :math:`t`
     - population_forecast in |AD cause model data sources table|
     - From GBD 2021 Forecasting Capstone. Available for years 2021-2050.
   * - :math:`p_{g,t}`
@@ -757,21 +752,3 @@ terms of these values.
 .. |Attention box on the AD cause model page| replace::
   :ref:`Attention box on the AD cause model page
   <alzheimers_cause_state_data_including_susceptible_note>`
-
-All-cause Mortality Forecasts
-+++++++++++++++++++++++++++++
-
-Since this is the model that
-includes details on how to use forecasts of population size, we have also
-included information on how to use forecasts of all-cause mortality rate.
-This is not really part of the Alzheimer's Population Model, however, and
-perhaps a better place to include this information will emerge as we continue
-to work on this model.
-
-By including draw-level, age-specific mortality rates forecasted for future years,
-the competing mortality from causes other than Alzheimer's Disease will change over time
-as predicted by our IHME colleagues.
-
-The :ref:`all_cause_mortality` docs have more details on how the ACMR forecasts are used
-when they are included in the artifact.
-

--- a/docs/source/models/other_models/alzheimers_population/index.rst
+++ b/docs/source/models/other_models/alzheimers_population/index.rst
@@ -689,8 +689,9 @@ Implementation and data tables
 Data Tables
 -----------
 
-All data values are defined for a specified year, location, age group,
-and sex.
+The following table shows the variables that come directly from our data
+sources. Other quantities needed for the simulation are defined above in
+terms of these values.
 
 .. list-table:: Data Sources
   :widths: 20 30 25 25
@@ -700,26 +701,50 @@ and sex.
     - Definition
     - Source or value
     - Notes
-  * - population
-    - Draw-level age-specific population forecast
-    - GBD 2021 Forecasting Capstone
-    - in `population_agg.nc` file
-  * - all-cause mortality rate
-    - Draw-level age-specific mortality rates saved by cause, for cause==all
-    - GBD 2021 Forecasting Capstone
-    - in `_all.nc` file
+  * - :math:`X_{t_0}`
+    - The initial size of our simulated population
+    - "Initial population size per draw" in the simulation parameter
+      specifications table in the concept model
+    - Includes all demographic groups
   * - :math:`Y^\text{real}_{g,t}`
     - Draw-level age-specific total population forecast in demographic
       group :math:`g` at time :math:`t`
-    - population_forecast in data sources table
+    - population_forecast in AD cause model data sources table
     - From GBD 2021 Forecasting Capstone. Available for years 2021-2050.
+  * - :math:`p_{g,t}`
+    - The combined prevalence of all AD stages in demographic
+      group :math:`g` at time :math:`t`
+    - :math:`p_\text{(All AD states)}` in the Attention box on the AD
+      cause model page
+    - Calculated from the GBD 2023 dementia envelope using the
+      dementia subtype proportions provided by the dementia modelers.
+      We will only need the value for the single year :math:`t_0`.
   * - :math:`i^\text{AD}_{g,t}`
     - Total-population incidence rate of AD dementia in demographic
       group :math:`g` at time :math:`t`
-    - incidence_AD in data sources table
+    - incidence_AD in AD cause model data sources table
     - Calculated from the GBD 2023 dementia envelope using the
       dementia subtype proportions provided by the dementia modelers.
       Assumed to be independent of :math:`t`.
+  * - :math:`m_{g,t}`
+    - Background mortality hazard in demographic group :math:`g` at time
+      :math:`t`
+    - m_BBBM or m_MCI in the AD cause model data sources table
+    - Equal to all-cause mortality rate minus cause-specific mortality
+      rate for AD-dementia. Uses all-cause mortality rate forecasts for
+      2021--2050 from GBD 2021 Forecasting Capstone.
+  * - :math:`\Delta_\text{BBBM}`, :math:`\Delta_\text{MCI}`
+    - Average duration of the BBBM-AD state or MCI-AD state,
+      respectively
+    - :math:`\Delta_\text{BBBM}` and :math:`\Delta_\text{MCI}` in the AD
+      cause model data sources table
+    -
+  * - :math:`w`
+    - The width of a standard GBD age bin
+    - 5 years
+    - We are not modeling the youngest age goups, which have smaller age
+      bins, and we are capping the 95+ age bin at 100, making it a
+      standard 5-year age bin
 
 All-cause Mortality Forecasts
 +++++++++++++++++++++++++++++

--- a/docs/source/models/other_models/alzheimers_population/index.rst
+++ b/docs/source/models/other_models/alzheimers_population/index.rst
@@ -708,6 +708,18 @@ and sex.
     - Draw-level age-specific mortality rates saved by cause, for cause==all
     - GBD 2021 Forecasting Capstone
     - in `_all.nc` file
+  * - :math:`Y^\text{real}_{g,t}`
+    - Draw-level age-specific total population forecast in demographic
+      group :math:`g` at time :math:`t`
+    - population_forecast in data sources table
+    - From GBD 2021 Forecasting Capstone. Available for years 2021-2050.
+  * - :math:`i^\text{AD}_{g,t}`
+    - Total-population incidence rate of AD dementia in demographic
+      group :math:`g` at time :math:`t`
+    - incidence_AD in data sources table
+    - Calculated from the GBD 2023 dementia envelope using the
+      dementia subtype proportions provided by the dementia modelers.
+      Assumed to be independent of :math:`t`.
 
 All-cause Mortality Forecasts
 +++++++++++++++++++++++++++++

--- a/docs/source/models/other_models/alzheimers_population/index.rst
+++ b/docs/source/models/other_models/alzheimers_population/index.rst
@@ -703,41 +703,41 @@ terms of these values.
     - Notes
   * - :math:`X_{t_0}`
     - The initial size of our simulated population
-    - "Initial population size per draw" in the simulation parameter
-      specifications table in the concept model
+    - "Initial population size per draw" in the |simulation parameter
+      specifications table in the concept model|
     - Includes all demographic groups
   * - :math:`Y^\text{real}_{g,t}`
     - Draw-level age-specific total population forecast in demographic
       group :math:`g` at time :math:`t`
-    - population_forecast in AD cause model data sources table
+    - population_forecast in |AD cause model data sources table|
     - From GBD 2021 Forecasting Capstone. Available for years 2021-2050.
   * - :math:`p_{g,t}`
     - The combined prevalence of all AD stages in demographic
       group :math:`g` at time :math:`t`
-    - :math:`p_\text{(All AD states)}` in the Attention box on the AD
-      cause model page
+    - :math:`p_\text{(All AD states)}` in the |Attention box on the AD
+      cause model page|
     - Calculated from the GBD 2023 dementia envelope using the
       dementia subtype proportions provided by the dementia modelers.
       We will only need the value for the single year :math:`t_0`.
   * - :math:`i^\text{AD}_{g,t}`
     - Total-population incidence rate of AD dementia in demographic
       group :math:`g` at time :math:`t`
-    - incidence_AD in AD cause model data sources table
+    - incidence_AD in |AD cause model data sources table|
     - Calculated from the GBD 2023 dementia envelope using the
       dementia subtype proportions provided by the dementia modelers.
       Assumed to be independent of :math:`t`.
   * - :math:`m_{g,t}`
     - Background mortality hazard in demographic group :math:`g` at time
       :math:`t`
-    - m_BBBM or m_MCI in the AD cause model data sources table
+    - m_BBBM or m_MCI in the |AD cause model data sources table|
     - Equal to all-cause mortality rate minus cause-specific mortality
       rate for AD-dementia. Uses all-cause mortality rate forecasts for
       2021--2050 from GBD 2021 Forecasting Capstone.
   * - :math:`\Delta_\text{BBBM}`, :math:`\Delta_\text{MCI}`
     - Average duration of the BBBM-AD state or MCI-AD state,
       respectively
-    - :math:`\Delta_\text{BBBM}` and :math:`\Delta_\text{MCI}` in the AD
-      cause model data sources table
+    - :math:`\Delta_\text{BBBM}` and :math:`\Delta_\text{MCI}` in the |AD
+      cause model data sources table|
     -
   * - :math:`w`
     - The width of a standard GBD age bin
@@ -745,6 +745,18 @@ terms of these values.
     - We are not modeling the youngest age goups, which have smaller age
       bins, and we are capping the 95+ age bin at 100, making it a
       standard 5-year age bin
+
+.. |simulation parameter specifications table in the concept model| replace::
+  :ref:`simulation parameter specifications table in the concept model
+  <2025_concept_model_vivarium_alzheimers_sim_parameter_specs>`
+
+.. |AD cause model data sources table| replace::
+  :ref:`AD cause model data sources table
+  <2021_cause_alzheimers_presymptomatic_mci_data_sources_table>`
+
+.. |Attention box on the AD cause model page| replace::
+  :ref:`Attention box on the AD cause model page
+  <alzheimers_cause_state_data_including_susceptible_note>`
 
 All-cause Mortality Forecasts
 +++++++++++++++++++++++++++++


### PR DESCRIPTION
Describes how to update our data to use the Alzheimer's proportion of the GBD 2023 dementia envelope, rather than using the GBD 2021 "Alzheimer's disease and other dementias" cause.

Also fills in the data sources table on the Alzheimer's population page, and removes the info about ACMR forecasts from that page since it's now included on the cause model page.

Note that we are still getting our CSMR and EMR from the GBD 2021 "Alzheimer's disease and other dementias" cause despite getting prevalence and incidence from DisMod. We should probably revisit this point when we circle back to adding mixed dementias to the model.