### PR TITLE
remove duplicated rst text and alphabetize table of definitions

### DIFF
--- a/docs/source/models/concept_models/vivarium_mace_rct/concept_model.rst
+++ b/docs/source/models/concept_models/vivarium_mace_rct/concept_model.rst
@@ -17,102 +17,30 @@ MACE RCT Simulation
   * - Term or Abbreviation
     - Definition
     - Note
-  * - MACE
-    - Major Adverse Cardiovascular Events
-    - Composite outcome typically including cardiovascular death, myocardial infarction, and stroke
-  * - LDL-C
-    - Low Density Lipoprotein Cholesterol
-    - Risk Factor
-  * - RCT
-    - Randomized Controlled Trial
-    - Study design
-
-Background
-++++++++++
-
-This concept model describes a simulation of a randomized controlled trial
-(RCT) designed to reduce major adverse cardiovascular events (MACE) by
-lowering LDL-C with an experimental new agent.
-
-Modeling Aims and Objectives
-++++++++++++++++++++++++++++
-
-The aim of this simulation is to estimate the effect of the experimental
-LDL-C-lowering agent on MACE incidence under trial conditions.
-
-Concept Model Diagram
-+++++++++++++++++++++
-
-The concept model diagram will represent the trial population, the randomization
-to treatment and control arms, LDL-C exposure, and downstream MACE outcomes.
-
-Vivarium Modeling Components
-++++++++++++++++++++++++++++
-
-The simulation will include cause models for cardiovascular outcomes, a
-risk exposure model for LDL-C, a risk effect linking LDL-C to MACE, and an
-intervention model representing the experimental agent.
-
-Back of the Envelope Calculations
-+++++++++++++++++++++++++++++++++
-
-Back of the envelope calculations to estimate the expected effect size and
-required trial size will be added here.
-
-Limitations
-+++++++++++
-
-Known limitations of the simulation, including assumptions about
-adherence, response heterogeneity, and trial design simplifications, will
-be documented here.
-
-References
-++++++++++
-
-References supporting the model design and parameters will be listed here.
-.. _2026_concept_model_vivarium_mace_rct:
-
-===================
-MACE RCT Simulation
-===================
-
-.. sectnum::
-  :depth: 3
-
-.. contents::
-   :local:
-
-.. list-table:: Definitions of terms and abbreviations
-  :widths: 15 15 15
-  :header-rows: 1
-
-  * - Term or Abbreviation
-    - Definition
-    - Note
-  * - MACE
-    - Major Adverse Cardiovascular Events
-    - Composite outcome typically including cardiovascular death, myocardial infarction, and stroke
-  * - LDL-C
-    - Low Density Lipoprotein Cholesterol
-    - Risk Factor
-  * - RCT
-    - Randomized Controlled Trial
-    - Study design
   * - IHD
     - Ischemic Heart Disease
     - Cause of cardiovascular mortality
-  * - NASH
-    - Non-Alcoholic Steatohepatitis
-    - Also referred to as MASH (metabolic dysfunction-associated steatohepatitis)
-  * - MASLD
-    - Metabolic dysfunction–Associated Steatotic Liver Disease
-    - Spectrum of liver disease ranging from simple steatosis to MASH; a term gradually replacing NAFLD.  
-  * - NAFLD
-    - Non-Alcoholic Fatty Liver Disease
-    - Spectrum of liver disease ranging from simple steatosis to NASH
+  * - LDL-C
+    - Low Density Lipoprotein Cholesterol
+    - Risk Factor
+  * - MACE
+    - Major Adverse Cardiovascular Events
+    - Composite outcome typically including cardiovascular death, myocardial infarction, and stroke
   * - MASH
     - Metabolic Dysfunction-Associated Steatohepatitis
     - Updated nomenclature for NASH
+  * - MASLD
+    - Metabolic dysfunction–Associated Steatotic Liver Disease
+    - Spectrum of liver disease ranging from simple steatosis to MASH; a term gradually replacing NAFLD.
+  * - NAFLD
+    - Non-Alcoholic Fatty Liver Disease
+    - Spectrum of liver disease ranging from simple steatosis to NASH
+  * - NASH
+    - Non-Alcoholic Steatohepatitis
+    - Also referred to as MASH (metabolic dysfunction-associated steatohepatitis)
+  * - RCT
+    - Randomized Controlled Trial
+    - Study design
 
 Background
 ++++++++++


### PR DESCRIPTION
I duplicated a bunch of text with a bad merge, so I deleted the duplicates. But I also alphabetized the table of definitions, so this has a really messy diff.  It is not intended to include any substantive changes!