### PR TITLE
Change "9 months" to "39 weeks"

### DIFF
--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/anemia_component/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/anemia_component/module_document.rst
@@ -221,8 +221,8 @@ Anemia YLDs are estimated according to the following steps:
 
 - We assume uniform distribution across assumed plausible ranges for timing of ANC visits as well as timing of pregnancies that end in ectopic pregnancy/miscarriage/abortion (as detailed on the :ref:`pregnancy model document <other_models_pregnancy_closed_cohort_mncnh>`) rather than informing these parameters with data
 - We assume that interventions affect anemia YLDs at the time of administration at ANC (as according to the timed assumptions in the two prior bullets) with no additional delay 
-- We do not model any deaths in the 9 months after pregnancy, so we assume that all simulants who survive labor also survive 9 months afterward and therefore experience anemia YLDs during this period. This may lead to a slight overestimation of anemia YLDs.
-- We do not model simulants changing age groups during the 9 months after pregnancy, and thereby slightly underestimate the ages
+- We do not model any deaths in the 39 weeks after pregnancy, so we assume that all simulants who survive labor also survive 39 weeks afterward and therefore experience anemia YLDs during this period. This may lead to a slight overestimation of anemia YLDs.
+- We do not model simulants changing age groups during the 39 weeks after pregnancy, and thereby slightly underestimate the ages
   of people in this period.
   The impact of this on anemia YLDs depends on how hemoglobin differs between a simulant's age group and the next:
   if the next age group has higher hemoglobin, and the simulant would have aged into it, then we will underestimate anemia YLDs during this period,

--- a/docs/source/models/concept_models/vivarium_mncnh_portfolio/postpartum_hemoglobin_module/module_document.rst
+++ b/docs/source/models/concept_models/vivarium_mncnh_portfolio/postpartum_hemoglobin_module/module_document.rst
@@ -52,11 +52,11 @@ Follow the steps below to model the postpartum hemoglobin module. Module inputs 
 1. Determine if simulant survived labor and progressed to the postpartum period
 2. Among surviving simulants, assign hemoglobin exposure for the first six weeks after delivery equal to hemoglobin exposure at birth
 3. Shift hemoglobin exposures for incident cases of postpartum hemorrhage according to the :ref:`postpartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>` effect on the first six weeks after the end of pregnancy
-4. Among surviving simulants, assign the hemoglobin exposure between 6 weeks and 9 months postpartum
-   using the non-pregnant hemoglobin distribution (MEID 27596, GBD 2023 version mv_20250804_flash_regal_snake)
+4. Among surviving simulants, assign the hemoglobin exposure between 6 weeks and 39 weeks postpartum
+   using the non-pregnant hemoglobin distribution (the mean can be found at MEID 27596, GBD 2023 version mv_20250804_flash_regal_snake; the standard deviation is the same as the standard deviation of the pregnant hemoglobin distribution)
    and the *same* propensity that was used to assign the simulant their initial hemoglobin exposure.
-5. Shift hemoglobin exposures for incident cases of postpartum hemorrhage according to the :ref:`postpartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>` effect on the period from 6 weeks to 9 months after the end of pregnancy
-6. Shift hemoglobin exposures for incident cases of antepartum hemorrhage according to the :ref:`antepartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>` effect on the period from 6 weeks to 9 months after the end of pregnancy
+5. Shift hemoglobin exposures for incident cases of postpartum hemorrhage according to the :ref:`postpartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>` effect on the period from 6 weeks to 39 weeks after the end of pregnancy
+6. Shift hemoglobin exposures for incident cases of antepartum hemorrhage according to the :ref:`antepartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>` effect on the period from 6 weeks to 39 weeks after the end of pregnancy
 
 .. list-table:: Module required inputs
   :header-rows: 1
@@ -67,15 +67,15 @@ Follow the steps below to model the postpartum hemoglobin module. Module inputs 
     - Note
   * - Hemoglobin at end of pregnancy
     - :ref:`Hemoglobin module <2024_vivarium_mncnh_portfolio_hemoglobin_module>`
-    - Informs hemoglobin exposure between birth and 6 weeks postpartum, and between 6 weeks and 9 months postpartum
+    - Informs hemoglobin exposure between birth and 6 weeks postpartum, and between 6 weeks and 39 weeks postpartum
     - 
   * - Postpartum hemorrhage incidence
     - :ref:`Postpartum disorders module <2024_vivarium_mncnh_portfolio_maternal_disorders_module>`
-    - Incident postpartum hemorrhage cases decrease hemoglobin exposure between birth and 6 weeks postpartum, and between 6 weeks and 9 months postpartum
+    - Incident postpartum hemorrhage cases decrease hemoglobin exposure between birth and 6 weeks postpartum, and between 6 weeks and 39 weeks postpartum
     - 
   * - Antepartum hemorrhage incidence
     - :ref:`Antepartum hemorrhage module <2024_vivarium_mncnh_portfolio_antepartum_hemorrhage_module>`
-    - Incident antepartum hemorrhage cases decrease hemoglobin exposure between birth and 6 weeks postpartum, and between 6 weeks and 9 months postpartum (in addition to affecting hemoglobin between incidence and birth)
+    - Incident antepartum hemorrhage cases decrease hemoglobin exposure between birth and 6 weeks postpartum, and between 6 weeks and 39 weeks postpartum (in addition to affecting hemoglobin between incidence and birth)
     -
 
 
@@ -88,16 +88,16 @@ Follow the steps below to model the postpartum hemoglobin module. Module inputs 
   * - Hemoglobin concentration during the first six weeks after the end of pregnancy
     - Point value
     - Used for V&V of maternal hemorrhage effect on postpartum hemoglobin, and as an input to the :ref:`Anemia YLDs module <2024_vivarium_mncnh_portfolio_anemia_module>` to calculate anemia YLDs during the first six weeks after the end of pregnancy
-  * - Hemoglobin concentration between 6 weeks and 9 months after the end of pregnancy
+  * - Hemoglobin concentration between 6 weeks and 39 weeks after the end of pregnancy
     - Point value
-    - Used for V&V of maternal hemorrhage effect on postpartum hemoglobin, and as an input to the :ref:`Anemia YLDs module <2024_vivarium_mncnh_portfolio_anemia_module>` to calculate anemia YLDs during the period from 6 weeks to 9 months after the end of pregnancy
+    - Used for V&V of maternal hemorrhage effect on postpartum hemoglobin, and as an input to the :ref:`Anemia YLDs module <2024_vivarium_mncnh_portfolio_anemia_module>` to calculate anemia YLDs during the period from 6 weeks to 39 weeks after the end of pregnancy
 
 
 3.0 Assumptions and limitations
 ++++++++++++++++++++++++++++++++
 
 * We assume the pregnancy-specific hemoglobin thresholds for anemia apply to the first six weeks after the end of pregnancy
-* We apply the effect of maternal hemorrhage on hemoglobin to the first six weeks after the end of pregnancy and the period from 6 weeks to 9 months after the end of pregnancy as discrete timesteps,
+* We apply the effect of maternal hemorrhage on hemoglobin to the first six weeks after the end of pregnancy and the period from 6 weeks to 39 weeks after the end of pregnancy as discrete timesteps,
   which does not capture the continuous nature of hemoglobin changes over time
 * We assume that the impacts of all interventions that have modified hemoglobin during pregnancy
   last only until six weeks after the end of pregnancy
@@ -105,7 +105,7 @@ Follow the steps below to model the postpartum hemoglobin module. Module inputs 
 4.0 Verification and Validation Criteria
 +++++++++++++++++++++++++++++++++++++++++
 
-* Effect of postpartum and antepartum hemorrhage on postpartum hemoglobin (postpartum hemoglobin stratified by postpartum and antepartum hemorrhage incidence) should vary by the size of the relevant hemoglobin shift in the :ref:`postpartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>`, during each postpartum time period (first six weeks after the end of pregnancy and the period from 6 weeks to 9 months after the end of pregnancy)
+* Effect of postpartum and antepartum hemorrhage on postpartum hemoglobin (postpartum hemoglobin stratified by postpartum and antepartum hemorrhage incidence) should vary by the size of the relevant hemoglobin shift in the :ref:`postpartum hemorrhage risk effects document <2023_risk_effect_maternal_hemorrhage>`, during each postpartum time period (first six weeks after the end of pregnancy and the period from 6 weeks to 39 weeks after the end of pregnancy)
 
 5.0 References
 +++++++++++++++

--- a/docs/source/models/risk_effects/maternal_hemorrhage/gbd2023/index.rst
+++ b/docs/source/models/risk_effects/maternal_hemorrhage/gbd2023/index.rst
@@ -74,19 +74,19 @@ Vivarium Modeling Strategy
      - 376
      - Hemoglobin concentration
      - During the first six weeks after the end of pregnancy only
-   * - Hemoglobin concentration between 6 weeks and 9 months after the end of pregnancy
+   * - Hemoglobin concentration between 6 weeks and 39 weeks after the end of pregnancy
      - Modelable entity
      - 27596
      - Hemoglobin concentration
-     - During the period from 6 weeks to 9 months after the end of pregnancy only; this is the "non-pregnant" hemoglobin distribution
+     - During the period from 6 weeks to 39 weeks after the end of pregnancy only; this is the "non-pregnant" hemoglobin distribution
 
 Hemoglobin effects after the end of pregnancy
 +++++++++++++++++++++++++++++++++++++++++++++
 
 For simulants who experience an incident case of postpartum hemorrhage (moderate or severe) as determined in the :ref:`postpartum hemorrhage <2023_cause_postpartum_hemorrhage_mncnh>` page,
-we will decrease the simulant's hemoglobin concentration during two distinct time periods: the first six weeks after the end of pregnancy and the period from 6 weeks to 9 months (which we approximate as 34 weeks) after the end of pregnancy.
-We chose the 9 month cutoff because this is the point at which the GBD 2023 shift curve for postpartum hemorrhage returns to approximately 0, indicating no difference in hemoglobin concentration between those with and without postpartum hemorrhage;
-we do not find the positive shifts after 9 months postpartum to be biologically plausible and therefore do not apply a positive hemoglobin shift after 9 months postpartum.
+we will decrease the simulant's hemoglobin concentration during two distinct time periods: the first six weeks after the end of pregnancy and the period from 6 weeks to 39 weeks after the end of pregnancy.
+We chose the 39 week cutoff because this is the point at which the GBD 2023 shift curve for postpartum hemorrhage returns to approximately 0, indicating no difference in hemoglobin concentration between those with and without postpartum hemorrhage;
+we do not find the positive shifts after 39 weeks postpartum to be biologically plausible and therefore do not apply a positive hemoglobin shift after 39 weeks postpartum.
 The magnitude of the decrease will be determined by the postpartum hemorrhage hemoglobin effect estimated in GBD 2023,
 which is time-dependent by days relative to delivery.
 For each time period, we take an average of the continuous hemoglobin shift curve across that time period to determine the hemoglobin shift value applied during that time period.
@@ -98,14 +98,14 @@ Hemoglobin effects at antepartum hemorrhage
 
 For simulants who experience an incident case of antepartum hemorrhage as determined in the :ref:`antepartum hemorrhage <2023_cause_antepartum_hemorrhage_mncnh>` page,
 we will decrease the simulant's hemoglobin concentration during two distinct time periods: from antepartum hemorrhage incidence
-until six weeks after the end of pregnancy and from 6 weeks after the end of pregnancy until 9 months after the end of pregnancy.
-We chose the 9 month cutoff for consistency with postpartum hemorrhage effects, see section above.
+until six weeks after the end of pregnancy and from 6 weeks after the end of pregnancy until 39 weeks after the end of pregnancy.
+We chose the 39 week cutoff for consistency with postpartum hemorrhage effects, see section above.
 
 As with postpartum hemorrhage, the magnitude of the decrease will be determined by an average of the continuous hemoglobin shift curve from GBD 2023.
 This was calculated for postpartum hemorrhage and used days relative to delivery.
 We will apply the same curve for antepartum hemorrhage, but we will shift the curve to be relative to antepartum hemorrhage incidence rather than delivery.
 Also, to simplify the calculation of shifts, we will assume that all incident antepartum hemorrhage cases occur a week before delivery;
-so the shift for the first time period (from antepartum hemorrhage incidence until six weeks after the end of pregnancy) will be an average of the curve from 0 to 49 days after delivery and the shift for the second time period (from 6 weeks after the end of pregnancy until 9 months after the end of pregnancy) will be an average of the curve from 49 days after delivery to 245 days after delivery.
+so the shift for the first time period (from antepartum hemorrhage incidence until six weeks after the end of pregnancy) will be an average of the curve from 0 to 49 days after delivery and the shift for the second time period (from 6 weeks after the end of pregnancy until 39 weeks after the end of pregnancy) will be an average of the curve from 49 days after delivery to 280 days after delivery.
 This approximation prevents us from having to calculate a unique shift curve for each simulant based on their specific timing of antepartum hemorrhage incidence, which would be computationally intensive.
 
 Validation and Verification Criteria

--- a/docs/source/models/risk_effects/maternal_sepsis/gbd2023/index.rst
+++ b/docs/source/models/risk_effects/maternal_sepsis/gbd2023/index.rst
@@ -77,18 +77,18 @@ Vivarium Modeling Strategy
      - 376
      - Hemoglobin concentration
      - During the first six weeks after the end of pregnancy only
-   * - Hemoglobin concentration between 6 weeks and 38 weeks after the end of pregnancy
+   * - Hemoglobin concentration between 6 weeks and 39 weeks after the end of pregnancy
      - Modelable entity
      - 27596
      - Hemoglobin concentration
-     - During the period from 6 weeks to 38 weeks after the end of pregnancy only; this is the "non-pregnant" hemoglobin distribution
+     - During the period from 6 weeks to 39 weeks after the end of pregnancy only; this is the "non-pregnant" hemoglobin distribution
 
 Hemoglobin effects after the end of pregnancy
 +++++++++++++++++++++++++++++++++++++++++++++
 
 For simulants who experience an incident case of puerperal sepsis as determined in the :ref:`maternal sepsis <2021_cause_maternal_sepsis_mncnh>` page,
-we will decrease the simulant's hemoglobin concentration during two distinct time periods: the first six weeks after the end of pregnancy and the period from 6 weeks to 38 weeks after the end of pregnancy.
-We chose the 38 week cutoff for consistency with :ref:`postpartum hemorrhage effects <2023_risk_effect_maternal_hemorrhage>`.
+we will decrease the simulant's hemoglobin concentration during two distinct time periods: the first six weeks after the end of pregnancy and the period from 6 weeks to 39 weeks after the end of pregnancy.
+We chose the 39 week cutoff for consistency with :ref:`postpartum hemorrhage effects <2023_risk_effect_maternal_hemorrhage>`.
 The magnitude of the decrease will be determined by the maternal sepsis hemoglobin effect estimated in GBD 2023,
 which is time-dependent by days relative to delivery.
 For each time period, we take an average of the continuous hemoglobin shift curve across that time period to determine the hemoglobin shift value applied during that time period.
@@ -104,7 +104,7 @@ Assumptions and Limitations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - This modeling strategy does not consider that the impact of maternal sepsis is already reflected in the pregnancy adjustment factor used for the :ref:`hemoglobin model <2019_hemoglobin_model>` and therefore we may slightly underestimate hemoglobin concentration (and therefore overestimate anemia prevalence) on average during the pregnancy and lactation period by applying an additional negative hemoglobin shift associated with maternal sepsis.
-- This modeling strategy applies an average hemoglobin shift for all incident maternal sepsis cases during the first six weeks after the end of pregnancy and an average hemoglobin shift for all incident maternal sepsis cases during the period from 6 weeks to 38 weeks after the end of pregnancy, which does not capture the continuous nature of hemoglobin changes over time.
+- This modeling strategy applies an average hemoglobin shift for all incident maternal sepsis cases during the first six weeks after the end of pregnancy and an average hemoglobin shift for all incident maternal sepsis cases during the period from 6 weeks to 39 weeks after the end of pregnancy, which does not capture the continuous nature of hemoglobin changes over time.
   The continuous curves could result in simulants moving between several anemia categories over the course of the postpartum period, which is not captured here.
   This also means that the (relatively arbitrary) choices of durations of these periods are impactful.
 - The GBD shift is derived from USA MarketScan data, which may not be generalizable to other locations.


### PR DESCRIPTION
"Months" is not a well-behaved unit of time.

39 weeks was my best approximation (rounded to the nearest week) of when the line here actually crosses 0:

<img width="1877" height="882" alt="image" src="https://github.com/user-attachments/assets/5966bc1d-d60a-4424-912e-ce8b92d96521" />